### PR TITLE
chore(repo): add monorepo version sync script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "dev": "pnpm --filter @iidx/web-app dev",
     "build": "pnpm -r build",
     "test": "pnpm -r test",
-    "lint": "pnpm -r lint"
+    "lint": "pnpm -r lint",
+    "sync:versions": "node scripts/sync-versions.mjs",
+    "sync:versions:check": "node scripts/sync-versions.mjs --check"
   },
   "devDependencies": {
     "@types/node": "^22.12.0",

--- a/scripts/sync-versions.mjs
+++ b/scripts/sync-versions.mjs
@@ -1,0 +1,241 @@
+import { readdir, readFile, stat, writeFile } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+
+const SEMVER_PATTERN = /^\d+\.\d+\.\d+$/;
+
+function toDisplayPath(filePath) {
+  return path.relative(process.cwd(), filePath) || ".";
+}
+
+function parseArgs(argv) {
+  let version;
+  let check = false;
+
+  for (const arg of argv) {
+    if (arg === "--check") {
+      check = true;
+      continue;
+    }
+
+    if (version !== undefined) {
+      throw new Error(`Unexpected argument: ${arg}`);
+    }
+
+    version = arg;
+  }
+
+  if (version !== undefined && !SEMVER_PATTERN.test(version)) {
+    throw new Error(`Invalid version format: "${version}". Expected x.y.z`);
+  }
+
+  if (!check && version === undefined) {
+    throw new Error("Version argument is required unless --check is specified.");
+  }
+
+  return { check, version };
+}
+
+async function ensureFileExists(filePath, label) {
+  let fileStat;
+  try {
+    fileStat = await stat(filePath);
+  } catch (error) {
+    if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") {
+      throw new Error(`${label} not found: ${toDisplayPath(filePath)}`);
+    }
+    throw error;
+  }
+
+  if (!fileStat.isFile()) {
+    throw new Error(`${label} is not a file: ${toDisplayPath(filePath)}`);
+  }
+}
+
+async function ensureDirectoryExists(dirPath, label) {
+  let dirStat;
+  try {
+    dirStat = await stat(dirPath);
+  } catch (error) {
+    if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") {
+      throw new Error(`${label} not found: ${toDisplayPath(dirPath)}`);
+    }
+    throw error;
+  }
+
+  if (!dirStat.isDirectory()) {
+    throw new Error(`${label} is not a directory: ${toDisplayPath(dirPath)}`);
+  }
+}
+
+async function readJsonFile(filePath) {
+  const raw = await readFile(filePath, "utf8");
+  const withoutBom = raw.charCodeAt(0) === 0xfeff ? raw.slice(1) : raw;
+
+  let data;
+  try {
+    data = JSON.parse(withoutBom);
+  } catch {
+    throw new Error(`Failed to parse JSON: ${toDisplayPath(filePath)}`);
+  }
+
+  return {
+    data,
+    lineEnding: withoutBom.includes("\r\n") ? "\r\n" : "\n",
+    sourceText: withoutBom,
+    trailingNewline: withoutBom.endsWith("\n"),
+  };
+}
+
+function serializeJson(value, lineEnding, trailingNewline) {
+  let text = JSON.stringify(value, null, 2);
+  if (lineEnding === "\r\n") {
+    text = text.replace(/\n/g, "\r\n");
+  }
+
+  if (trailingNewline) {
+    text += lineEnding;
+  }
+
+  return text;
+}
+
+async function writeJsonIfChanged(filePath, value, current) {
+  const nextText = serializeJson(value, current.lineEnding, current.trailingNewline);
+  if (nextText === current.sourceText) {
+    return false;
+  }
+
+  await writeFile(filePath, nextText, "utf8");
+  return true;
+}
+
+function versionString(value) {
+  if (typeof value === "string") {
+    return value;
+  }
+  return "";
+}
+
+async function listPackageJsonFiles(packagesDir) {
+  const entries = await readdir(packagesDir, { withFileTypes: true });
+  const packageFiles = [];
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+    if (entry.name === "node_modules") {
+      continue;
+    }
+
+    const packageJsonPath = path.join(packagesDir, entry.name, "package.json");
+    try {
+      const packageStat = await stat(packageJsonPath);
+      if (packageStat.isFile()) {
+        packageFiles.push(packageJsonPath);
+      }
+    } catch (error) {
+      if (!(error && typeof error === "object" && "code" in error && error.code === "ENOENT")) {
+        throw error;
+      }
+    }
+  }
+
+  packageFiles.sort();
+  return packageFiles;
+}
+
+async function runCheckMode(rootPackagePath, packagePaths, rootPackage, expectedVersionArg) {
+  const rootVersion = versionString(rootPackage.data.version);
+  const mismatches = [];
+
+  if (!SEMVER_PATTERN.test(rootVersion)) {
+    mismatches.push({
+      actual: rootVersion || "(missing)",
+      expected: expectedVersionArg ?? "x.y.z",
+      path: toDisplayPath(rootPackagePath),
+    });
+  } else if (expectedVersionArg !== undefined && rootVersion !== expectedVersionArg) {
+    mismatches.push({
+      actual: rootVersion,
+      expected: expectedVersionArg,
+      path: toDisplayPath(rootPackagePath),
+    });
+  }
+
+  for (const packagePath of packagePaths) {
+    const pkg = await readJsonFile(packagePath);
+    const packageVersion = versionString(pkg.data.version);
+    if (packageVersion !== rootVersion) {
+      mismatches.push({
+        actual: packageVersion || "(missing)",
+        expected: rootVersion || "(missing)",
+        path: toDisplayPath(packagePath),
+      });
+    }
+  }
+
+  if (mismatches.length > 0) {
+    console.error("Version mismatches found:");
+    for (const mismatch of mismatches) {
+      console.error(`- ${mismatch.path}: expected ${mismatch.expected}, actual ${mismatch.actual}`);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log("All versions are synchronized.");
+}
+
+async function runSyncMode(rootPackagePath, packagePaths, rootPackage, targetVersion) {
+  const changedFiles = [];
+
+  rootPackage.data.version = targetVersion;
+  if (await writeJsonIfChanged(rootPackagePath, rootPackage.data, rootPackage)) {
+    changedFiles.push(toDisplayPath(rootPackagePath));
+  }
+
+  for (const packagePath of packagePaths) {
+    const pkg = await readJsonFile(packagePath);
+    pkg.data.version = targetVersion;
+    if (await writeJsonIfChanged(packagePath, pkg.data, pkg)) {
+      changedFiles.push(toDisplayPath(packagePath));
+    }
+  }
+
+  if (changedFiles.length === 0) {
+    console.log("No version changes were necessary.");
+    return;
+  }
+
+  console.log("Updated files:");
+  for (const file of changedFiles) {
+    console.log(`- ${file}`);
+  }
+}
+
+async function main() {
+  const { check, version } = parseArgs(process.argv.slice(2));
+
+  const rootPackagePath = path.resolve("package.json");
+  const packagesDir = path.resolve("packages");
+
+  await ensureFileExists(rootPackagePath, "root package.json");
+  await ensureDirectoryExists(packagesDir, "packages directory");
+
+  const rootPackage = await readJsonFile(rootPackagePath);
+  const packagePaths = await listPackageJsonFiles(packagesDir);
+
+  if (check) {
+    await runCheckMode(rootPackagePath, packagePaths, rootPackage, version);
+    return;
+  }
+
+  await runSyncMode(rootPackagePath, packagePaths, rootPackage, version);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/tasks/chore-sync-versions.md
+++ b/tasks/chore-sync-versions.md
@@ -1,0 +1,6 @@
+# chore/sync-versions plan
+
+- [x] scripts/sync-versions.mjs を作成して、root SSOT で packages/* の version 同期を実装する。
+- [x] root package.json に sync:versions / sync:versions:check を追加する。
+- [x] sync:versions:check と build を実行して受け入れ条件を検証する。
+- [x] 変更差分が宣言スコープ内のみであることを確認する。


### PR DESCRIPTION
## 目的
- monorepo の version を root package.json を SSOT として同期できるようにする。
- 手動運用と CI のチェック運用（--check）を分離する。

## 変更点
- scripts/sync-versions.mjs を追加。
  - `node scripts/sync-versions.mjs <x.y.z>` で root + packages/* の version 同期
  - `node scripts/sync-versions.mjs --check` で不一致検出のみ（不一致時 exit 1）
  - `node scripts/sync-versions.mjs <x.y.z> --check` で指定versionと root の整合も検証
  - SemVer は `^\d+\.\d+\.\d+$` のみ許可
  - 差分が無い場合は書き込みを行わない
- root package.json に以下 scripts を追加
  - `sync:versions`
  - `sync:versions:check`
- tasks/chore-sync-versions.md に実施計画を追加

## 非変更点
- タグ作成、git タグ運用、リリースフローは変更なし
- `packages/*/package.json` 以外の各パッケージ設定は変更なし
- Web Locks / BroadcastChannel / storage event の単一タブ不変条件に関わる実装変更なし

## 影響範囲
- ルートスクリプト運用（version 同期手順）
- root package.json scripts

## テスト内容
- `pnpm sync:versions:check`（同期済みで exit 0）
- `pnpm sync:versions 0.1.3`（差分なしで no-op）
- `node scripts/sync-versions.mjs 0.1.3 --check`（exit 0）
- `node scripts/sync-versions.mjs 9.9.9 --check`（不一致検出で exit 1）
- `node scripts/sync-versions.mjs`（引数不足で exit 1）
- `node scripts/sync-versions.mjs 1.2`（SemVer 不正で exit 1）
- `pnpm lint`
- `pnpm test`
- `pnpm build`

## 回帰確認項目
- 既存のビルド・lint・テストが成功すること
- version 同期が差分最小で動作し、変更不要時にファイルを書き換えないこと