### PR TITLE
feat(i18n): localize home page

### DIFF
--- a/packages/web-app/src/i18n/locales/en.json
+++ b/packages/web-app/src/i18n/locales/en.json
@@ -10,6 +10,32 @@
     "not_available": "-",
     "unknown": "Unknown"
   },
+  "home": {
+    "state": {
+      "active": "Ongoing",
+      "upcoming": "Upcoming",
+      "ended": "Ended"
+    },
+    "empty": {
+      "text": "No tournaments available to display.",
+      "action": {
+        "open_filter": "Open filters"
+      }
+    },
+    "remaining_days": "{{days}} days left",
+    "progress": {
+      "summary": "Registered {{submitted}} / {{total}}",
+      "percent": "({{percent}}%)",
+      "badge": {
+        "send_waiting": "Waiting to send {{count}}",
+        "pending": "Unsubmitted entries",
+        "completed": "All submitted"
+      }
+    },
+    "action": {
+      "view_detail": "View details"
+    }
+  },
   "settings": {
     "title": "Settings",
     "language": {

--- a/packages/web-app/src/i18n/locales/ja.json
+++ b/packages/web-app/src/i18n/locales/ja.json
@@ -10,6 +10,32 @@
     "not_available": "-",
     "unknown": "不明"
   },
+  "home": {
+    "state": {
+      "active": "開催中",
+      "upcoming": "開催前",
+      "ended": "終了"
+    },
+    "empty": {
+      "text": "表示できる大会がありません。",
+      "action": {
+        "open_filter": "フィルタを開く"
+      }
+    },
+    "remaining_days": "残{{days}}日",
+    "progress": {
+      "summary": "登録 {{submitted}} / {{total}}",
+      "percent": "({{percent}}%)",
+      "badge": {
+        "send_waiting": "送信待ち {{count}}件",
+        "pending": "未登録あり",
+        "completed": "全て登録済"
+      }
+    },
+    "action": {
+      "view_detail": "詳細を見る"
+    }
+  },
   "settings": {
     "title": "設定",
     "language": {

--- a/packages/web-app/src/i18n/locales/ko.json
+++ b/packages/web-app/src/i18n/locales/ko.json
@@ -10,6 +10,32 @@
     "not_available": "-",
     "unknown": "알 수 없음"
   },
+  "home": {
+    "state": {
+      "active": "진행 중",
+      "upcoming": "시작 전",
+      "ended": "종료"
+    },
+    "empty": {
+      "text": "표시할 수 있는 대회가 없습니다.",
+      "action": {
+        "open_filter": "필터 열기"
+      }
+    },
+    "remaining_days": "{{days}}일 남음",
+    "progress": {
+      "summary": "등록 {{submitted}} / {{total}}",
+      "percent": "({{percent}}%)",
+      "badge": {
+        "send_waiting": "전송 대기 {{count}}건",
+        "pending": "미등록 있음",
+        "completed": "모두 등록됨"
+      }
+    },
+    "action": {
+      "view_detail": "상세 보기"
+    }
+  },
   "settings": {
     "title": "설정",
     "language": {


### PR DESCRIPTION
## 目的
Home（大会一覧）画面の直書き文字列を i18n 化し、`home.*` 名前空間を追加する。

## BASE_SHA
`5bacbbbe985847a0e2b40c4c2c0e26626b438cff`

## 作業環境
git worktree で物理分離して作業:
`c:\work\score_attack_manager\iidx_score_attack_manager-pr3-home-i18n`

## 変更点
- `packages/web-app/src/pages/HomePage.tsx` の表示文字列を `t('home.*')` 化
- `packages/web-app/src/i18n/locales/{ja,en,ko}.json` に `home` セクション追加
- `packages/web-app/src/pages/HomePage.test.tsx` の文言依存を安定要素ベースに変更（必要最小限）

## 非変更点
- Home画面の挙動・レイアウト・デザイン・状態管理は変更なし
- 変更範囲は Home画面の文字列置換 + 辞書追加 + 必要なテスト調整のみ
- `shared/**` `services/**` `utils/**` への波及なし

## 影響範囲
- Home（大会一覧）画面の表示文言
- i18n 辞書（`ja/en/ko`）

## テスト内容
- `pnpm --filter @iidx/web-app lint`
- `pnpm --filter @iidx/web-app test`
- `pnpm --filter @iidx/web-app build`

## 回帰確認項目
- Home画面で `ja/en/ko` 切替時に表示崩れがないこと
- Home画面の空状態・カード表示・進捗表示の動作が従来どおりであること