### PR TITLE
feat(i18n): localize import flow

### DIFF
--- a/packages/web-app/src/i18n/locales/en.json
+++ b/packages/web-app/src/i18n/locales/en.json
@@ -10,6 +10,70 @@
     "not_available": "-",
     "unknown": "Unknown"
   },
+  "import": {
+    "title": "Import tournament",
+    "description": "You can import from a URL or image/text files.",
+    "warning": {
+      "song_master_unavailable": "Tournament import is unavailable because song master data is missing.",
+      "song_master_action": "Check updates in the \"Song data\" section on the settings screen."
+    },
+    "input": {
+      "url_placeholder": "Paste URL"
+    },
+    "action": {
+      "import_text": "Import text",
+      "import_file": "Import file",
+      "open_settings": "Open settings",
+      "import": "Import",
+      "importing": "Importing..."
+    },
+    "state": {
+      "loading": "Validating import data..."
+    },
+    "error": {
+      "none": "Could not recognize the URL import link.",
+      "invalid_param": "The URL parameter is invalid.",
+      "decode_error": "Failed to decode the payload.",
+      "decompress_error": "Failed to decompress the payload (gzip).",
+      "json_error": "Failed to parse the payload JSON.",
+      "schema_error": "Required fields or types in import data are invalid.",
+      "too_large": "Import data size exceeds the limit.",
+      "expired": "Ended tournaments cannot be imported.",
+      "master_missing": "Cannot validate because song master data is missing.",
+      "chart_not_found": "Charts not found in song master data: {{chartIds}}",
+      "unsupported_version": "This data version is not supported.",
+      "period_conflict": "Import failed because the existing tournament with the same UUID has a conflicting period.",
+      "unexpected": "Unexpected error: {{message}}"
+    },
+    "confirm": {
+      "section": {
+        "charts": "Target charts",
+        "merge": "Existing tournament found (same UUID)",
+        "caution": "Caution"
+      },
+      "status": {
+        "upcoming": "Upcoming",
+        "active": "Active",
+        "ended": "Ended"
+      },
+      "value": {
+        "period": "{{from}} - {{to}}",
+        "chart_id": "chart:{{chartId}}",
+        "chart_detail": "{{playStyle}} {{difficulty}} Lv{{level}}"
+      },
+      "chart_missing": "Song master mismatch (chart:{{chartId}})",
+      "merge": {
+        "mode": "Apply mode: Merge (charts only)",
+        "added_charts": "Charts to add: {{count}}",
+        "same_charts": "Charts already existing: {{count}}",
+        "note": "Tournament name/owner/period/hashtag will not be updated."
+      },
+      "caution": {
+        "self_responsibility": "Use imported data at your own risk.",
+        "uuid_conflict": "When UUIDs conflict, tournament info is kept and only chart differences are applied."
+      }
+    }
+  },
   "settings": {
     "title": "Settings",
     "language": {

--- a/packages/web-app/src/i18n/locales/ja.json
+++ b/packages/web-app/src/i18n/locales/ja.json
@@ -10,6 +10,70 @@
     "not_available": "-",
     "unknown": "不明"
   },
+  "import": {
+    "title": "大会取込",
+    "description": "URLもしくは画像/テキストファイルを取り込めます。",
+    "warning": {
+      "song_master_unavailable": "曲マスタが未取得のため、大会取込は利用できません。",
+      "song_master_action": "設定画面の「曲データ」セクションで更新を確認してください。"
+    },
+    "input": {
+      "url_placeholder": "URLを貼り付け"
+    },
+    "action": {
+      "import_text": "テキスト取込",
+      "import_file": "ファイル取込",
+      "open_settings": "設定を開く",
+      "import": "取り込む",
+      "importing": "取り込み中..."
+    },
+    "state": {
+      "loading": "取り込みデータを検証しています..."
+    },
+    "error": {
+      "none": "URLインポートリンクを認識できませんでした。",
+      "invalid_param": "URLパラメータが不正です。",
+      "decode_error": "ペイロードのデコードに失敗しました。",
+      "decompress_error": "ペイロードのgzip展開に失敗しました。",
+      "json_error": "ペイロードJSONの解析に失敗しました。",
+      "schema_error": "取り込みデータの必須項目または型が不正です。",
+      "too_large": "取り込みデータサイズが上限を超えています。",
+      "expired": "終了済みの大会は取り込みできません。",
+      "master_missing": "曲マスタが未取得のため検証できません。",
+      "chart_not_found": "曲マスタに存在しない譜面があります: {{chartIds}}",
+      "unsupported_version": "対応していないデータバージョンです。",
+      "period_conflict": "UUID一致の既存大会と開催期間が矛盾するため取り込みできません。",
+      "unexpected": "予期しないエラー: {{message}}"
+    },
+    "confirm": {
+      "section": {
+        "charts": "対象譜面",
+        "merge": "既存大会が見つかりました（UUID一致）",
+        "caution": "注意"
+      },
+      "status": {
+        "upcoming": "未開催",
+        "active": "開催中",
+        "ended": "終了"
+      },
+      "value": {
+        "period": "{{from}} 〜 {{to}}",
+        "chart_id": "chart:{{chartId}}",
+        "chart_detail": "{{playStyle}} {{difficulty}} Lv{{level}}"
+      },
+      "chart_missing": "曲マスタ不一致 (chart:{{chartId}})",
+      "merge": {
+        "mode": "適用方式: マージ（譜面のみ）",
+        "added_charts": "追加される譜面数: {{count}}",
+        "same_charts": "既存と同一の譜面数: {{count}}",
+        "note": "大会名/開催者/期間/ハッシュタグは更新されません。"
+      },
+      "caution": {
+        "self_responsibility": "取り込みデータは自己責任で利用してください。",
+        "uuid_conflict": "UUID衝突時は大会情報を更新せず、譜面差分のみを適用します。"
+      }
+    }
+  },
   "settings": {
     "title": "設定",
     "language": {

--- a/packages/web-app/src/i18n/locales/ko.json
+++ b/packages/web-app/src/i18n/locales/ko.json
@@ -10,6 +10,70 @@
     "not_available": "-",
     "unknown": "알 수 없음"
   },
+  "import": {
+    "title": "대회 가져오기",
+    "description": "URL 또는 이미지/텍스트 파일에서 가져올 수 있습니다.",
+    "warning": {
+      "song_master_unavailable": "곡 마스터 데이터가 없어 대회 가져오기를 사용할 수 없습니다.",
+      "song_master_action": "설정 화면의 \"곡 데이터\" 섹션에서 업데이트를 확인하세요."
+    },
+    "input": {
+      "url_placeholder": "URL 붙여넣기"
+    },
+    "action": {
+      "import_text": "텍스트 가져오기",
+      "import_file": "파일 가져오기",
+      "open_settings": "설정 열기",
+      "import": "가져오기",
+      "importing": "가져오는 중..."
+    },
+    "state": {
+      "loading": "가져오기 데이터를 검증하는 중..."
+    },
+    "error": {
+      "none": "URL 가져오기 링크를 인식하지 못했습니다.",
+      "invalid_param": "URL 파라미터가 올바르지 않습니다.",
+      "decode_error": "페이로드 디코딩에 실패했습니다.",
+      "decompress_error": "페이로드 gzip 압축 해제에 실패했습니다.",
+      "json_error": "페이로드 JSON 파싱에 실패했습니다.",
+      "schema_error": "가져오기 데이터의 필수 항목 또는 타입이 올바르지 않습니다.",
+      "too_large": "가져오기 데이터 크기가 제한을 초과했습니다.",
+      "expired": "종료된 대회는 가져올 수 없습니다.",
+      "master_missing": "곡 마스터 데이터가 없어 검증할 수 없습니다.",
+      "chart_not_found": "곡 마스터 데이터에 없는 보면이 있습니다: {{chartIds}}",
+      "unsupported_version": "지원하지 않는 데이터 버전입니다.",
+      "period_conflict": "같은 UUID의 기존 대회와 기간이 충돌하여 가져올 수 없습니다.",
+      "unexpected": "예기치 않은 오류: {{message}}"
+    },
+    "confirm": {
+      "section": {
+        "charts": "대상 보면",
+        "merge": "기존 대회를 찾았습니다(UUID 일치)",
+        "caution": "주의"
+      },
+      "status": {
+        "upcoming": "개최 전",
+        "active": "개최 중",
+        "ended": "종료"
+      },
+      "value": {
+        "period": "{{from}} ~ {{to}}",
+        "chart_id": "chart:{{chartId}}",
+        "chart_detail": "{{playStyle}} {{difficulty}} Lv{{level}}"
+      },
+      "chart_missing": "곡 마스터 불일치 (chart:{{chartId}})",
+      "merge": {
+        "mode": "적용 방식: 병합(보면만)",
+        "added_charts": "추가되는 보면 수: {{count}}",
+        "same_charts": "기존과 동일한 보면 수: {{count}}",
+        "note": "대회명/개최자/기간/해시태그는 업데이트되지 않습니다."
+      },
+      "caution": {
+        "self_responsibility": "가져온 데이터는 본인 책임으로 사용하세요.",
+        "uuid_conflict": "UUID가 충돌하면 대회 정보는 유지하고 보면 차이만 적용합니다."
+      }
+    }
+  },
   "settings": {
     "title": "설정",
     "language": {

--- a/packages/web-app/src/pages/ImportTournamentPage.tsx
+++ b/packages/web-app/src/pages/ImportTournamentPage.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 
 interface ImportTournamentPageProps {
   songMasterReady: boolean;
@@ -9,6 +10,7 @@ interface ImportTournamentPageProps {
 }
 
 export function ImportTournamentPage(props: ImportTournamentPageProps): JSX.Element {
+  const { t } = useTranslation();
   const [importText, setImportText] = React.useState('');
   const importDisabled = !props.songMasterReady || props.busy;
 
@@ -16,17 +18,17 @@ export function ImportTournamentPage(props: ImportTournamentPageProps): JSX.Elem
     <div className="page">
       {!props.songMasterReady && (
         <section className="warningBox">
-          <p>曲マスタが未取得のため、大会取込は利用できません。</p>
+          <p>{t('import.warning.song_master_unavailable')}</p>
           {props.songMasterMessage && <p>{props.songMasterMessage}</p>}
-          <p>設定画面の「曲データ」セクションで更新を確認してください。</p>
+          <p>{t('import.warning.song_master_action')}</p>
         </section>
       )}
 
       <section className="detailCard importSection">
-        <h2>大会取込</h2>
-        <p className="hintText">URLもしくは画像/テキストファイルを取り込めます。</p>
+        <h2>{t('import.title')}</h2>
+        <p className="hintText">{t('import.description')}</p>
         <textarea
-          placeholder="URLを貼り付け"
+          placeholder={t('import.input.url_placeholder')}
           value={importText}
           onChange={(event) => setImportText(event.target.value)}
           rows={4}
@@ -39,10 +41,10 @@ export function ImportTournamentPage(props: ImportTournamentPageProps): JSX.Elem
               setImportText('');
             }}
           >
-            テキスト取込
+            {t('import.action.import_text')}
           </button>
           <label className={`fileButton ${importDisabled ? 'disabled' : ''}`}>
-            ファイル取込
+            {t('import.action.import_file')}
             <input
               type="file"
               accept="image/*,.txt,.json"


### PR DESCRIPTION
## 目的
取込フロー（Import）関連画面の直書き文字列をi18n化する。

## BASE_SHA
`5bacbbbe985847a0e2b40c4c2c0e26626b438cff`

## worktree
`C:\work\score_attack_manager\iidx_score_attack_manager-pr5-import-flow-i18n` で作業（worktree物理分離）。

## 変更点
- `ImportTournamentPage.tsx` の表示文言を `t(import.*)` / `t(common.*)` に置換
- `ImportConfirmPage.tsx` の表示文言を `t(import.*)` / `t(common.*)` に置換
- `ja/en/ko` locale に `import` 名前空間を追加（ja SSOTで追従）

## 非変更点
- Import関連ページの文字列置換 + 辞書追加のみ
- URLインポート仕様、遷移条件、ロック取得、QRスキャナ挙動、DOM構造/CSS/状態管理は未変更
- `ImportQrScannerDialog.tsx` は未変更

## 影響範囲
- `packages/web-app/src/pages/ImportTournamentPage.tsx`
- `packages/web-app/src/pages/ImportConfirmPage.tsx`
- `packages/web-app/src/i18n/locales/ja.json`
- `packages/web-app/src/i18n/locales/en.json`
- `packages/web-app/src/i18n/locales/ko.json`

## テスト内容
- `pnpm --filter web-app test`
- `pnpm --filter web-app lint`
- `pnpm --filter web-app build`