### PR TITLE
feat(i18n): localize create and submit pages

### DIFF
--- a/packages/web-app/src/i18n/locales/en.json
+++ b/packages/web-app/src/i18n/locales/en.json
@@ -5,10 +5,176 @@
     "copy": "Copy",
     "share": "Share",
     "cancel": "Cancel",
+    "back": "Back",
+    "delete": "Delete",
     "next": "Next",
     "execute": "Run",
     "not_available": "-",
     "unknown": "Unknown"
+  },
+  "create_tournament": {
+    "wizard": {
+      "aria_label": "Tournament definition wizard",
+      "step": {
+        "basic": "Basic info",
+        "charts": "Charts",
+        "confirm": "Confirm"
+      },
+      "nav_item": "{{index}}. {{label}}"
+    },
+    "step": {
+      "basic_title": "1) Basic tournament info",
+      "charts_title": "2) Target charts ({{current}} / {{max}})",
+      "confirm_title": "3) Confirm"
+    },
+    "field": {
+      "name": {
+        "label": "Tournament name *",
+        "label_plain": "Tournament name",
+        "placeholder": "e.g.) Score Attack 2026"
+      },
+      "owner": {
+        "label": "Organizer *",
+        "label_plain": "Organizer",
+        "placeholder": "e.g.) IIDX Club"
+      },
+      "hashtag": {
+        "label": "Hashtag *",
+        "label_plain": "Hashtag",
+        "placeholder": "e.g.) ScoreAttack2026"
+      },
+      "period": {
+        "label": "Period *",
+        "label_plain": "Period",
+        "start_placeholder": "Start date",
+        "end_placeholder": "End date"
+      },
+      "song": {
+        "label": "Song title",
+        "placeholder": "Enter song title",
+        "no_options_empty_query": "Enter a song title.",
+        "no_options_not_found": "No matching songs found.",
+        "loading": "Loading..."
+      },
+      "play_style": {
+        "label": "Play style",
+        "disabled_hint": "You can change this after selecting a song.",
+        "sp": "SP",
+        "dp": "DP"
+      },
+      "difficulty": {
+        "label": "Difficulty",
+        "select_song_hint": "Select a song to choose difficulty.",
+        "no_available": "No selectable charts are available.",
+        "used_in_other": "This chart is already used in another selection.",
+        "value": "{{difficulty}} Lv{{level}}"
+      }
+    },
+    "text": {
+      "period_separator": "~",
+      "list_separator": ", "
+    },
+    "period": {
+      "empty": "-",
+      "range": "{{start}} to {{end}}",
+      "range_with_days": "{{start}} to {{end}} ({{count}} days)"
+    },
+    "action": {
+      "set_next_month": "Next month (1st to end of month)",
+      "next_with_step": "{{action}} ({{step}})",
+      "back_with_step": "{{action}} ({{step}})",
+      "create": "Create tournament",
+      "creating": "Creating..."
+    },
+    "progress": {
+      "completed": "Completed: {{count}}/4",
+      "missing": "Missing: {{items}}",
+      "none": "None"
+    },
+    "chart": {
+      "max_limit": "Up to {{max}} charts.",
+      "add": "+ Add",
+      "selection_label": "Selection {{index}}",
+      "selection_delete_aria": "Remove selection {{index}}"
+    },
+    "validation": {
+      "name_required": "Enter a tournament name.",
+      "owner_required": "Enter an organizer.",
+      "hashtag_required": "Enter a hashtag.",
+      "start_date_required": "Select a start date.",
+      "end_date_required": "Select an end date.",
+      "end_date_after_start": "End date must be on or after start date.",
+      "end_date_from_today": "End date must be today or later.",
+      "chart_required": "Select at least one chart.",
+      "chart_difficulty_required": "Select a difficulty for each chart.",
+      "chart_duplicate": "Duplicate chart registration is not allowed.",
+      "chart_duplicate_on_page": "The same chart is selected more than once.",
+      "check_input": "Please review your input.",
+      "check_chart_input": "Please review chart input.",
+      "missing_items": "Missing: {{items}}"
+    },
+    "confirm": {
+      "chart_list_title": "Chart list",
+      "chart_title": "Chart {{index}}",
+      "debug": {
+        "title": "Debug info",
+        "def_hash": "def_hash",
+        "source_tournament_uuid": "source_tournament_uuid",
+        "null": "null"
+      }
+    }
+  },
+  "submit_evidence": {
+    "chart": {
+      "level": "Lv{{level}}"
+    },
+    "status": {
+      "processing": "Submitting",
+      "failed": "Submission failed",
+      "submitted": "Submitted",
+      "submitted_with_date": "Submitted {{date}}",
+      "not_submitted": "Not submitted"
+    },
+    "step": {
+      "select_image": "Step 1) Select image",
+      "review_image": "Step 2) Review image"
+    },
+    "images": {
+      "preview_alt": "Submitted image preview",
+      "updated_at": "Last updated: {{date}}",
+      "action": {
+        "tap_to_select": "Tap to select an image",
+        "take_photo": "Take photo",
+        "pick_from_gallery": "Choose from gallery",
+        "reselect": "Select again"
+      }
+    },
+    "note": {
+      "local_only": "Images are saved only on this device.",
+      "not_sent": "Images are not sent to other people."
+    },
+    "action": {
+      "processing": "Submitting",
+      "update": "Update",
+      "save": "Save"
+    },
+    "menu": {
+      "actions_aria": "Submitted image actions"
+    },
+    "hint": {
+      "select_to_submit": "Select an image to submit."
+    },
+    "error": {
+      "submit_failed": "Submission failed",
+      "quota_exceeded": "Storage full",
+      "save_failed": "Failed to save",
+      "delete_failed": "Failed to delete"
+    },
+    "delete_dialog": {
+      "title": "Delete submitted image?",
+      "description": "This action cannot be undone.",
+      "confirm": "Delete"
+    }
   },
   "settings": {
     "title": "Settings",

--- a/packages/web-app/src/i18n/locales/ja.json
+++ b/packages/web-app/src/i18n/locales/ja.json
@@ -5,10 +5,176 @@
     "copy": "コピー",
     "share": "共有",
     "cancel": "キャンセル",
+    "back": "戻る",
+    "delete": "削除",
     "next": "次へ",
     "execute": "実行",
     "not_available": "-",
     "unknown": "不明"
+  },
+  "create_tournament": {
+    "wizard": {
+      "aria_label": "大会定義ウィザード",
+      "step": {
+        "basic": "基本情報",
+        "charts": "譜面",
+        "confirm": "確認"
+      },
+      "nav_item": "{{index}}. {{label}}"
+    },
+    "step": {
+      "basic_title": "1) 大会基本情報",
+      "charts_title": "2) 対象譜面 ({{current}} / {{max}})",
+      "confirm_title": "3) 確認"
+    },
+    "field": {
+      "name": {
+        "label": "大会名 *",
+        "label_plain": "大会名",
+        "placeholder": "例）スコアタ2026"
+      },
+      "owner": {
+        "label": "開催者 *",
+        "label_plain": "開催者",
+        "placeholder": "例）IIDX部"
+      },
+      "hashtag": {
+        "label": "ハッシュタグ *",
+        "label_plain": "ハッシュタグ",
+        "placeholder": "例）スコアタ2026"
+      },
+      "period": {
+        "label": "期間 *",
+        "label_plain": "期間",
+        "start_placeholder": "開始日",
+        "end_placeholder": "終了日"
+      },
+      "song": {
+        "label": "曲名",
+        "placeholder": "曲名を入力",
+        "no_options_empty_query": "曲名を入力してください。",
+        "no_options_not_found": "該当する曲がありません。",
+        "loading": "読み込み中..."
+      },
+      "play_style": {
+        "label": "プレイスタイル",
+        "disabled_hint": "曲を選択するまで変更できません。",
+        "sp": "SP",
+        "dp": "DP"
+      },
+      "difficulty": {
+        "label": "難易度",
+        "select_song_hint": "曲を選択すると選べます。",
+        "no_available": "選択可能な譜面がありません。",
+        "used_in_other": "他の選曲で譜面が使用中です。",
+        "value": "{{difficulty}} Lv{{level}}"
+      }
+    },
+    "text": {
+      "period_separator": "〜",
+      "list_separator": "、"
+    },
+    "period": {
+      "empty": "-",
+      "range": "{{start}} 〜 {{end}}",
+      "range_with_days": "{{start}} 〜 {{end}}（{{count}}日間）"
+    },
+    "action": {
+      "set_next_month": "来月（1日〜月末）",
+      "next_with_step": "{{action}}（{{step}}）",
+      "back_with_step": "{{action}}（{{step}}）",
+      "create": "大会を作成",
+      "creating": "作成中..."
+    },
+    "progress": {
+      "completed": "入力完了: {{count}}/4",
+      "missing": "未入力項目: {{items}}",
+      "none": "なし"
+    },
+    "chart": {
+      "max_limit": "最大{{max}}譜面までです。",
+      "add": "＋追加",
+      "selection_label": "選曲 {{index}}",
+      "selection_delete_aria": "選曲 {{index}} を削除"
+    },
+    "validation": {
+      "name_required": "大会名を入力してください。",
+      "owner_required": "開催者を入力してください。",
+      "hashtag_required": "ハッシュタグを入力してください。",
+      "start_date_required": "開始日を選択してください。",
+      "end_date_required": "終了日を選択してください。",
+      "end_date_after_start": "終了日は開始日以降を指定してください。",
+      "end_date_from_today": "終了日には今日以降の日付を指定してください。",
+      "chart_required": "譜面を1件以上選択してください。",
+      "chart_difficulty_required": "各譜面で難易度を選択してください。",
+      "chart_duplicate": "同一譜面を重複登録できません。",
+      "chart_duplicate_on_page": "同一譜面が重複しています。",
+      "check_input": "入力内容を確認してください。",
+      "check_chart_input": "譜面の入力内容を確認してください。",
+      "missing_items": "未入力項目: {{items}}"
+    },
+    "confirm": {
+      "chart_list_title": "譜面一覧",
+      "chart_title": "譜面 {{index}}",
+      "debug": {
+        "title": "デバッグ情報",
+        "def_hash": "def_hash",
+        "source_tournament_uuid": "source_tournament_uuid",
+        "null": "null"
+      }
+    }
+  },
+  "submit_evidence": {
+    "chart": {
+      "level": "Lv{{level}}"
+    },
+    "status": {
+      "processing": "提出処理中",
+      "failed": "提出失敗",
+      "submitted": "提出済み",
+      "submitted_with_date": "提出済み {{date}}",
+      "not_submitted": "未提出"
+    },
+    "step": {
+      "select_image": "Step 1) 画像を選ぶ",
+      "review_image": "Step 2) 画像を確認"
+    },
+    "images": {
+      "preview_alt": "提出画像プレビュー",
+      "updated_at": "最終更新: {{date}}",
+      "action": {
+        "tap_to_select": "タップして画像を選ぶ",
+        "take_photo": "カメラで撮る",
+        "pick_from_gallery": "ギャラリーから選ぶ",
+        "reselect": "選び直す"
+      }
+    },
+    "note": {
+      "local_only": "画像はこの端末の中だけに保存されます",
+      "not_sent": "他の人に画像は送られません"
+    },
+    "action": {
+      "processing": "提出処理中",
+      "update": "更新する",
+      "save": "保存する"
+    },
+    "menu": {
+      "actions_aria": "提出画像の操作"
+    },
+    "hint": {
+      "select_to_submit": "画像を選ぶと提出できます"
+    },
+    "error": {
+      "submit_failed": "提出に失敗しました",
+      "quota_exceeded": "容量不足",
+      "save_failed": "保存に失敗しました",
+      "delete_failed": "削除に失敗しました"
+    },
+    "delete_dialog": {
+      "title": "提出画像を削除しますか？",
+      "description": "削除すると元に戻せません。",
+      "confirm": "削除する"
+    }
   },
   "settings": {
     "title": "設定",

--- a/packages/web-app/src/i18n/locales/ko.json
+++ b/packages/web-app/src/i18n/locales/ko.json
@@ -5,10 +5,176 @@
     "copy": "복사",
     "share": "공유",
     "cancel": "취소",
+    "back": "뒤로",
+    "delete": "삭제",
     "next": "다음",
     "execute": "실행",
     "not_available": "-",
     "unknown": "알 수 없음"
+  },
+  "create_tournament": {
+    "wizard": {
+      "aria_label": "대회 정의 마법사",
+      "step": {
+        "basic": "기본 정보",
+        "charts": "채보",
+        "confirm": "확인"
+      },
+      "nav_item": "{{index}}. {{label}}"
+    },
+    "step": {
+      "basic_title": "1) 대회 기본 정보",
+      "charts_title": "2) 대상 채보 ({{current}} / {{max}})",
+      "confirm_title": "3) 확인"
+    },
+    "field": {
+      "name": {
+        "label": "대회명 *",
+        "label_plain": "대회명",
+        "placeholder": "예) 스코어어택 2026"
+      },
+      "owner": {
+        "label": "주최자 *",
+        "label_plain": "주최자",
+        "placeholder": "예) IIDX부"
+      },
+      "hashtag": {
+        "label": "해시태그 *",
+        "label_plain": "해시태그",
+        "placeholder": "예) 스코어어택2026"
+      },
+      "period": {
+        "label": "기간 *",
+        "label_plain": "기간",
+        "start_placeholder": "시작일",
+        "end_placeholder": "종료일"
+      },
+      "song": {
+        "label": "곡명",
+        "placeholder": "곡명을 입력",
+        "no_options_empty_query": "곡명을 입력해 주세요.",
+        "no_options_not_found": "일치하는 곡이 없습니다.",
+        "loading": "불러오는 중..."
+      },
+      "play_style": {
+        "label": "플레이 스타일",
+        "disabled_hint": "곡을 선택하면 변경할 수 있습니다.",
+        "sp": "SP",
+        "dp": "DP"
+      },
+      "difficulty": {
+        "label": "난이도",
+        "select_song_hint": "곡을 선택하면 고를 수 있습니다.",
+        "no_available": "선택 가능한 채보가 없습니다.",
+        "used_in_other": "다른 선택에서 이 채보를 이미 사용 중입니다.",
+        "value": "{{difficulty}} Lv{{level}}"
+      }
+    },
+    "text": {
+      "period_separator": "~",
+      "list_separator": ", "
+    },
+    "period": {
+      "empty": "-",
+      "range": "{{start}} ~ {{end}}",
+      "range_with_days": "{{start}} ~ {{end}} ({{count}}일)"
+    },
+    "action": {
+      "set_next_month": "다음 달 (1일~말일)",
+      "next_with_step": "{{action}} ({{step}})",
+      "back_with_step": "{{action}} ({{step}})",
+      "create": "대회 만들기",
+      "creating": "생성 중..."
+    },
+    "progress": {
+      "completed": "입력 완료: {{count}}/4",
+      "missing": "미입력 항목: {{items}}",
+      "none": "없음"
+    },
+    "chart": {
+      "max_limit": "최대 {{max}}개 채보까지 가능합니다.",
+      "add": "+ 추가",
+      "selection_label": "선곡 {{index}}",
+      "selection_delete_aria": "선곡 {{index}} 삭제"
+    },
+    "validation": {
+      "name_required": "대회명을 입력해 주세요.",
+      "owner_required": "주최자를 입력해 주세요.",
+      "hashtag_required": "해시태그를 입력해 주세요.",
+      "start_date_required": "시작일을 선택해 주세요.",
+      "end_date_required": "종료일을 선택해 주세요.",
+      "end_date_after_start": "종료일은 시작일 이후여야 합니다.",
+      "end_date_from_today": "종료일은 오늘 이후여야 합니다.",
+      "chart_required": "채보를 1개 이상 선택해 주세요.",
+      "chart_difficulty_required": "각 채보의 난이도를 선택해 주세요.",
+      "chart_duplicate": "동일 채보를 중복 등록할 수 없습니다.",
+      "chart_duplicate_on_page": "동일 채보가 중복 선택되었습니다.",
+      "check_input": "입력 내용을 확인해 주세요.",
+      "check_chart_input": "채보 입력 내용을 확인해 주세요.",
+      "missing_items": "미입력 항목: {{items}}"
+    },
+    "confirm": {
+      "chart_list_title": "채보 목록",
+      "chart_title": "채보 {{index}}",
+      "debug": {
+        "title": "디버그 정보",
+        "def_hash": "def_hash",
+        "source_tournament_uuid": "source_tournament_uuid",
+        "null": "null"
+      }
+    }
+  },
+  "submit_evidence": {
+    "chart": {
+      "level": "Lv{{level}}"
+    },
+    "status": {
+      "processing": "제출 처리 중",
+      "failed": "제출 실패",
+      "submitted": "제출됨",
+      "submitted_with_date": "제출됨 {{date}}",
+      "not_submitted": "미제출"
+    },
+    "step": {
+      "select_image": "Step 1) 이미지 선택",
+      "review_image": "Step 2) 이미지 확인"
+    },
+    "images": {
+      "preview_alt": "제출 이미지 미리보기",
+      "updated_at": "최종 업데이트: {{date}}",
+      "action": {
+        "tap_to_select": "탭해서 이미지 선택",
+        "take_photo": "카메라로 촬영",
+        "pick_from_gallery": "갤러리에서 선택",
+        "reselect": "다시 선택"
+      }
+    },
+    "note": {
+      "local_only": "이미지는 이 기기 안에만 저장됩니다.",
+      "not_sent": "다른 사람에게 이미지는 전송되지 않습니다."
+    },
+    "action": {
+      "processing": "제출 처리 중",
+      "update": "업데이트",
+      "save": "저장"
+    },
+    "menu": {
+      "actions_aria": "제출 이미지 작업"
+    },
+    "hint": {
+      "select_to_submit": "이미지를 선택하면 제출할 수 있습니다."
+    },
+    "error": {
+      "submit_failed": "제출에 실패했습니다",
+      "quota_exceeded": "저장 공간이 부족합니다",
+      "save_failed": "저장에 실패했습니다",
+      "delete_failed": "삭제에 실패했습니다"
+    },
+    "delete_dialog": {
+      "title": "제출 이미지를 삭제할까요?",
+      "description": "삭제하면 되돌릴 수 없습니다.",
+      "confirm": "삭제"
+    }
   },
   "settings": {
     "title": "설정",

--- a/packages/web-app/src/pages/create-tournament-draft.test.ts
+++ b/packages/web-app/src/pages/create-tournament-draft.test.ts
@@ -88,7 +88,7 @@ describe('create tournament draft helpers', () => {
       hashtag: '  ###  ',
     };
     const validation = resolveCreateTournamentValidation(draft, '2026-02-15');
-    expect(validation.hashtagError).toBe('ハッシュタグを入力してください。');
+    expect(validation.hashtagError).toBe('create_tournament.validation.hashtag_required');
     expect(validation.canProceed).toBe(false);
   });
 
@@ -138,7 +138,7 @@ describe('create tournament draft helpers', () => {
       endDate: '2026-02-14',
     };
     const validation = resolveCreateTournamentValidation(draft, '2026-02-15');
-    expect(validation.periodError).toBe('終了日には今日以降の日付を指定してください。');
+    expect(validation.periodError).toBe('create_tournament.validation.end_date_from_today');
     expect(validation.canProceed).toBe(false);
   });
 


### PR DESCRIPTION
## 目的
大会作成（Create）とスコア提出（Submit Evidence）画面の表示文言をi18n化し、`create_tournament.*` / `submit_evidence.*` 名前空間を追加する。

## BASE_SHA
`5bacbbbe985847a0e2b40c4c2c0e26626b438cff`

## worktree
`git worktree` で物理分離した専用作業ツリー（branch: `feat/i18n-create-submit-pr6`）で実施。

## 変更点
- `CreateTournamentPage` / `SubmitEvidencePage` の直書き表示文言を `t()` 経由に置換
- `ja` をSSOTとして `en/ko` へ `create_tournament.*` / `submit_evidence.*` を追加
- 共通語彙として `common.back` / `common.delete` を追加
- `create-tournament-draft` は表示文言を直接返さず、翻訳キーを返すように変更（表示はページ側で解決）
- 文字列依存テストの期待値を翻訳キーに合わせて最小修正

## 非変更点
- 大会作成フローの仕様（入力必須/デフォルト値/生成ロジック/ハッシュ）
- スコア提出仕様（画像処理・保存形式・共有方式・検証ロジック）
- UIレイアウト/DOM構造/class/style/状態管理
- `shared/**` `services/**` `utils/**` への横断変更（表示文言以外）

## 影響範囲
- `packages/web-app/src/pages/CreateTournamentPage.tsx`
- `packages/web-app/src/pages/create-tournament-draft.ts`
- `packages/web-app/src/pages/create-tournament-draft.test.ts`
- `packages/web-app/src/pages/SubmitEvidencePage.tsx`
- `packages/web-app/src/i18n/locales/ja.json`
- `packages/web-app/src/i18n/locales/en.json`
- `packages/web-app/src/i18n/locales/ko.json`

## テスト内容
- `pnpm -C packages/web-app lint`
- `pnpm -C packages/web-app test -- create-tournament-draft.test.ts`

## 回帰確認項目
- `ja/en/ko` 切替時に Create/Submit 画面表示が破綻しない
- 既存の作成/提出動線・状態遷移に変更がない