### PR TITLE
feat(i18n): localize tournament detail page

### DIFF
--- a/packages/web-app/src/i18n/locales/en.json
+++ b/packages/web-app/src/i18n/locales/en.json
@@ -264,5 +264,120 @@
       "copied": "Logs copied.",
       "copy_failed": "Failed to copy logs."
     }
+  },
+  "tournament_detail": {
+    "action": {
+      "share_tournament": "Share tournament",
+      "open_settings": "Settings",
+      "register": "Register",
+      "replace": "Replace",
+      "zoom_preview": "Zoom preview",
+      "export_image": "Save image",
+      "copy_text": "Copy text",
+      "copy_logs": "Copy logs",
+      "save_to_device": "Save to device",
+      "mark_send_completed": "Mark as sent",
+      "submit": "Send"
+    },
+    "status": {
+      "upcoming": "Not started",
+      "ended": "Ended",
+      "active_today": "Ends today",
+      "active_remaining_days": "{{count}} days left"
+    },
+    "summary": {
+      "period": "{{start}}〜{{end}}",
+      "period_with_space": "{{start}} 〜 {{end}}",
+      "progress": "Registered {{submitted}} / {{total}}",
+      "last_updated": "Last updated: {{date}}"
+    },
+    "chart": {
+      "heading": "Charts",
+      "level": "Lv{{level}}",
+      "status": {
+        "error": "Error",
+        "pending": "Not registered",
+        "submitted": "Registered",
+        "send_pending": "Pending send"
+      },
+      "resolve_issue": {
+        "mismatch": "Some charts do not match song data.",
+        "master_missing": "Song data has not been fetched.",
+        "chart_not_found": "Chart data does not match."
+      }
+    },
+    "notice": {
+      "share_canceled": "Share was canceled."
+    },
+    "share_image": {
+      "owner": "Host: {{owner}}",
+      "chart_heading": "Target Charts",
+      "import_hint": "Scan to import"
+    },
+    "share_dialog": {
+      "close_aria_label": "Close share dialog",
+      "definition_only": "Only tournament definition is shared (images are not included).",
+      "preview_title": "Preview",
+      "preview_image_size": "Generated image (1080x1920)",
+      "preview_alt": "Shared image preview",
+      "preview_generation_failed": "Failed to generate the shared image. Share and export are unavailable.",
+      "export_title": "Export",
+      "share_text_label": "Share text",
+      "debug_title": "Technical info",
+      "debug_payload_size": "payload_size: {{value}} bytes",
+      "debug_def_hash": "def_hash: {{value}}",
+      "debug_source_tournament_uuid": "source_tournament_uuid: {{value}}",
+      "debug_last_error": "last_error: {{value}}",
+      "preview_zoom_title": "Share preview",
+      "preview_zoom_alt": "Enlarged share preview",
+      "notice": {
+        "image_generation_failed": "Failed to generate the shared image.",
+        "image_saved": "Image saved.",
+        "share_unsupported_use_export": "Sharing is not available in this environment. Use export instead.",
+        "share_executed": "Share completed.",
+        "share_failed_use_export": "Sharing failed. Use export instead.",
+        "text_copied": "Text copied.",
+        "auto_copy_failed": "Auto copy failed. Please copy the displayed text manually.",
+        "debug_log_copied": "Technical logs copied.",
+        "debug_log_copy_failed": "Failed to copy technical logs."
+      },
+      "error": {
+        "qr_image_load_failed": "Failed to load QR image.",
+        "unresolved_level": "Cannot generate the promo image because target chart levels could not be resolved. Check song data in Settings and try again.",
+        "no_visible_charts": "Cannot generate the promo image because there are no displayable target charts.",
+        "png_generation_failed": "Failed to generate the shared image.",
+        "canvas_context_unavailable": "Could not acquire drawing context for shared image."
+      }
+    },
+    "submit_bar": {
+      "summary": "Pending send: {{count}}"
+    },
+    "submit_dialog": {
+      "title": "Send",
+      "images_title": "Images to send",
+      "images_description": "Images are shared outside this device.",
+      "target_count": "Targets: {{count}}",
+      "message_title": "Message to send",
+      "complete_title": "Mark as sent",
+      "complete_description": "Share success cannot be detected automatically. Run this only after confirming the recipient received it.",
+      "notice": {
+        "saved_images_count": "Saved {{count}} image(s).",
+        "save_images_failed": "Failed to save images.",
+        "shared_images_fallback_saved": "Sharing is not available in this environment, so images were saved to the device.",
+        "shared_images": "Images to send were shared.",
+        "share_images_failed": "Failed to share images.",
+        "message_copied": "Message to send was copied.",
+        "message_copy_failed": "Failed to copy message.",
+        "message_share_unsupported": "Message sharing is not supported in this environment.",
+        "message_shared": "Message to send was shared.",
+        "message_share_failed": "Failed to share message.",
+        "no_pending": "No pending sends.",
+        "completed_count": "Marked {{count}} item(s) as sent.",
+        "mark_completed_failed": "Failed to update sent status."
+      },
+      "error": {
+        "no_sendable_images": "There are no pending images that can be sent."
+      }
+    }
   }
 }

--- a/packages/web-app/src/i18n/locales/ja.json
+++ b/packages/web-app/src/i18n/locales/ja.json
@@ -264,5 +264,120 @@
       "copied": "ログをコピーしました。",
       "copy_failed": "ログコピーに失敗しました。"
     }
+  },
+  "tournament_detail": {
+    "action": {
+      "share_tournament": "大会を共有",
+      "open_settings": "設定",
+      "register": "登録",
+      "replace": "差し替え",
+      "zoom_preview": "拡大表示",
+      "export_image": "画像を保存",
+      "copy_text": "テキストをコピー",
+      "copy_logs": "ログコピー",
+      "save_to_device": "端末に保存",
+      "mark_send_completed": "送信完了にする",
+      "submit": "送信する"
+    },
+    "status": {
+      "upcoming": "未開催",
+      "ended": "終了",
+      "active_today": "今日まで",
+      "active_remaining_days": "残り{{count}}日"
+    },
+    "summary": {
+      "period": "{{start}}〜{{end}}",
+      "period_with_space": "{{start}} 〜 {{end}}",
+      "progress": "登録 {{submitted}} / {{total}}",
+      "last_updated": "最終更新: {{date}}"
+    },
+    "chart": {
+      "heading": "譜面一覧",
+      "level": "Lv{{level}}",
+      "status": {
+        "error": "エラー",
+        "pending": "未登録",
+        "submitted": "登録済",
+        "send_pending": "送信待ち"
+      },
+      "resolve_issue": {
+        "mismatch": "一部譜面が曲データと一致しません。",
+        "master_missing": "曲データが未取得です",
+        "chart_not_found": "譜面情報が一致しません"
+      }
+    },
+    "notice": {
+      "share_canceled": "共有をキャンセルしました。"
+    },
+    "share_image": {
+      "owner": "開催者: {{owner}}",
+      "chart_heading": "対象譜面",
+      "import_hint": "読み取って取り込む"
+    },
+    "share_dialog": {
+      "close_aria_label": "共有ダイアログを閉じる",
+      "definition_only": "共有されるのは大会定義のみ（画像は含まれません）",
+      "preview_title": "プレビュー",
+      "preview_image_size": "生成画像（1080x1920）",
+      "preview_alt": "共有画像プレビュー",
+      "preview_generation_failed": "共有画像の生成に失敗しました。共有とエクスポートは利用できません。",
+      "export_title": "エクスポート",
+      "share_text_label": "共有テキスト",
+      "debug_title": "技術情報",
+      "debug_payload_size": "payload_size: {{value}} bytes",
+      "debug_def_hash": "def_hash: {{value}}",
+      "debug_source_tournament_uuid": "source_tournament_uuid: {{value}}",
+      "debug_last_error": "last_error: {{value}}",
+      "preview_zoom_title": "共有プレビュー",
+      "preview_zoom_alt": "共有プレビュー拡大表示",
+      "notice": {
+        "image_generation_failed": "共有画像の生成に失敗しました。",
+        "image_saved": "画像を保存しました。",
+        "share_unsupported_use_export": "この環境では共有できません。エクスポートをご利用ください。",
+        "share_executed": "共有を実行しました。",
+        "share_failed_use_export": "共有に失敗しました。エクスポートをご利用ください。",
+        "text_copied": "テキストをコピーしました。",
+        "auto_copy_failed": "自動コピーできませんでした。表示されたテキストを手動でコピーしてください。",
+        "debug_log_copied": "技術ログをコピーしました。",
+        "debug_log_copy_failed": "技術ログのコピーに失敗しました。"
+      },
+      "error": {
+        "qr_image_load_failed": "QR画像の読み込みに失敗しました。",
+        "unresolved_level": "対象譜面のLvを解決できないため宣伝画像を生成できません。設定画面の曲データを確認後に再試行してください。",
+        "no_visible_charts": "表示可能な対象譜面がないため宣伝画像を生成できません。",
+        "png_generation_failed": "共有画像の生成に失敗しました。",
+        "canvas_context_unavailable": "共有画像の描画環境を取得できませんでした。"
+      }
+    },
+    "submit_bar": {
+      "summary": "送信待ち {{count}}件"
+    },
+    "submit_dialog": {
+      "title": "送信",
+      "images_title": "送信する画像",
+      "images_description": "画像が端末外に共有されます",
+      "target_count": "送信対象: {{count}}件",
+      "message_title": "送信するメッセージ",
+      "complete_title": "送信完了にする",
+      "complete_description": "共有の成否は自動判定できません。相手に届いたことを確認後に実行してください。",
+      "notice": {
+        "saved_images_count": "{{count}}件の画像を保存しました。",
+        "save_images_failed": "画像の保存に失敗しました。",
+        "shared_images_fallback_saved": "この環境では共有できないため、画像を端末に保存しました。",
+        "shared_images": "送信する画像を共有しました。",
+        "share_images_failed": "画像共有に失敗しました。",
+        "message_copied": "送信するメッセージをコピーしました。",
+        "message_copy_failed": "メッセージのコピーに失敗しました。",
+        "message_share_unsupported": "この環境ではメッセージ共有に対応していません。",
+        "message_shared": "送信するメッセージを共有しました。",
+        "message_share_failed": "メッセージ共有に失敗しました。",
+        "no_pending": "送信待ちはありません。",
+        "completed_count": "{{count}}件を送信完了にしました。",
+        "mark_completed_failed": "送信完了の更新に失敗しました。"
+      },
+      "error": {
+        "no_sendable_images": "送信できる送信待ち画像がありません。"
+      }
+    }
   }
 }

--- a/packages/web-app/src/i18n/locales/ko.json
+++ b/packages/web-app/src/i18n/locales/ko.json
@@ -264,5 +264,120 @@
       "copied": "로그를 복사했습니다.",
       "copy_failed": "로그 복사에 실패했습니다."
     }
+  },
+  "tournament_detail": {
+    "action": {
+      "share_tournament": "대회 공유",
+      "open_settings": "설정",
+      "register": "등록",
+      "replace": "교체",
+      "zoom_preview": "확대 보기",
+      "export_image": "이미지 저장",
+      "copy_text": "텍스트 복사",
+      "copy_logs": "로그 복사",
+      "save_to_device": "기기에 저장",
+      "mark_send_completed": "전송 완료로 표시",
+      "submit": "전송"
+    },
+    "status": {
+      "upcoming": "미개최",
+      "ended": "종료",
+      "active_today": "오늘까지",
+      "active_remaining_days": "{{count}}일 남음"
+    },
+    "summary": {
+      "period": "{{start}}〜{{end}}",
+      "period_with_space": "{{start}} 〜 {{end}}",
+      "progress": "등록 {{submitted}} / {{total}}",
+      "last_updated": "최종 업데이트: {{date}}"
+    },
+    "chart": {
+      "heading": "채보 목록",
+      "level": "Lv{{level}}",
+      "status": {
+        "error": "오류",
+        "pending": "미등록",
+        "submitted": "등록됨",
+        "send_pending": "전송 대기"
+      },
+      "resolve_issue": {
+        "mismatch": "일부 채보가 곡 데이터와 일치하지 않습니다.",
+        "master_missing": "곡 데이터를 아직 가져오지 않았습니다.",
+        "chart_not_found": "채보 정보가 일치하지 않습니다."
+      }
+    },
+    "notice": {
+      "share_canceled": "공유를 취소했습니다."
+    },
+    "share_image": {
+      "owner": "주최자: {{owner}}",
+      "chart_heading": "대상 채보",
+      "import_hint": "스캔해서 가져오기"
+    },
+    "share_dialog": {
+      "close_aria_label": "공유 대화상자 닫기",
+      "definition_only": "공유되는 것은 대회 정의만이며(이미지는 포함되지 않음)",
+      "preview_title": "미리보기",
+      "preview_image_size": "생성 이미지(1080x1920)",
+      "preview_alt": "공유 이미지 미리보기",
+      "preview_generation_failed": "공유 이미지 생성에 실패했습니다. 공유와 내보내기를 사용할 수 없습니다.",
+      "export_title": "내보내기",
+      "share_text_label": "공유 텍스트",
+      "debug_title": "기술 정보",
+      "debug_payload_size": "payload_size: {{value}} bytes",
+      "debug_def_hash": "def_hash: {{value}}",
+      "debug_source_tournament_uuid": "source_tournament_uuid: {{value}}",
+      "debug_last_error": "last_error: {{value}}",
+      "preview_zoom_title": "공유 미리보기",
+      "preview_zoom_alt": "공유 미리보기 확대",
+      "notice": {
+        "image_generation_failed": "공유 이미지 생성에 실패했습니다.",
+        "image_saved": "이미지를 저장했습니다.",
+        "share_unsupported_use_export": "이 환경에서는 공유할 수 없습니다. 내보내기를 이용하세요.",
+        "share_executed": "공유를 실행했습니다.",
+        "share_failed_use_export": "공유에 실패했습니다. 내보내기를 이용하세요.",
+        "text_copied": "텍스트를 복사했습니다.",
+        "auto_copy_failed": "자동 복사에 실패했습니다. 표시된 텍스트를 수동으로 복사하세요.",
+        "debug_log_copied": "기술 로그를 복사했습니다.",
+        "debug_log_copy_failed": "기술 로그 복사에 실패했습니다."
+      },
+      "error": {
+        "qr_image_load_failed": "QR 이미지 로드에 실패했습니다.",
+        "unresolved_level": "대상 채보 Lv를 해석할 수 없어 홍보 이미지를 생성할 수 없습니다. 설정 화면에서 곡 데이터를 확인한 뒤 다시 시도하세요.",
+        "no_visible_charts": "표시 가능한 대상 채보가 없어 홍보 이미지를 생성할 수 없습니다.",
+        "png_generation_failed": "공유 이미지 생성에 실패했습니다.",
+        "canvas_context_unavailable": "공유 이미지의 그리기 컨텍스트를 가져올 수 없었습니다."
+      }
+    },
+    "submit_bar": {
+      "summary": "전송 대기 {{count}}건"
+    },
+    "submit_dialog": {
+      "title": "전송",
+      "images_title": "전송할 이미지",
+      "images_description": "이미지가 기기 외부로 공유됩니다",
+      "target_count": "전송 대상: {{count}}건",
+      "message_title": "전송할 메시지",
+      "complete_title": "전송 완료로 표시",
+      "complete_description": "공유 성공 여부는 자동 판정할 수 없습니다. 상대에게 도달했는지 확인한 뒤 실행하세요.",
+      "notice": {
+        "saved_images_count": "{{count}}건의 이미지를 저장했습니다.",
+        "save_images_failed": "이미지 저장에 실패했습니다.",
+        "shared_images_fallback_saved": "이 환경에서는 공유할 수 없어 이미지를 기기에 저장했습니다.",
+        "shared_images": "전송할 이미지를 공유했습니다.",
+        "share_images_failed": "이미지 공유에 실패했습니다.",
+        "message_copied": "전송할 메시지를 복사했습니다.",
+        "message_copy_failed": "메시지 복사에 실패했습니다.",
+        "message_share_unsupported": "이 환경에서는 메시지 공유를 지원하지 않습니다.",
+        "message_shared": "전송할 메시지를 공유했습니다.",
+        "message_share_failed": "메시지 공유에 실패했습니다.",
+        "no_pending": "전송 대기가 없습니다.",
+        "completed_count": "{{count}}건을 전송 완료로 처리했습니다.",
+        "mark_completed_failed": "전송 완료 상태 업데이트에 실패했습니다."
+      },
+      "error": {
+        "no_sendable_images": "전송할 수 있는 전송 대기 이미지가 없습니다."
+      }
+    }
   }
 }

--- a/tasks/feat-i18n-tournament-detail-page.md
+++ b/tasks/feat-i18n-tournament-detail-page.md
@@ -1,0 +1,7 @@
+# feat/i18n-tournament-detail-page plan
+
+- [x] TournamentDetailPage の直書き表示文字列を全抽出し、`tournament_detail.*` のキー設計を確定する。
+- [x] `TournamentDetailPage.tsx` の表示文字列を `t()` / `common.*` へ置換し、named placeholder に統一する。
+- [x] `ja` を SSOT として `en` / `ko` に `tournament_detail` 辞書を追加する。
+- [x] 文言依存テストがある場合のみ最小修正し、言語切替で壊れない形へ調整する。
+- [x] 対象テスト実行と差分監査を行い、宣言スコープ外変更がないことを確認する。


### PR DESCRIPTION
## 目的
大会詳細画面の直書き文字列をi18n化し、`tournament_detail.*` 名前空間へ移行する。

## BASE_SHA
`5bacbbbe985847a0e2b40c4c2c0e26626b438cff`

## 作業環境
- git worktreeで物理分離して作業
- worktree: `C:\work\score_attack_manager\wt-i18n-tournament-detail`
- branch: `feat/i18n-tournament-detail-page`

## 変更点
- `TournamentDetailPage.tsx` の表示文言を `t()` / `common.*` / `tournament_detail.*` 経由に置換
- 文字列連結箇所をnamed placeholderへ置換
- `ja` をSSOTとして `en` / `ko` に `tournament_detail` 辞書を追加

## 非変更点
- 挙動・レイアウト・デザイン・状態管理の変更なし
- `shared/**` `services/**` `utils/**` への波及なし
- 共通コンポーネントの変更なし

## 影響範囲
- `packages/web-app/src/pages/TournamentDetailPage.tsx`
- `packages/web-app/src/i18n/locales/ja.json`
- `packages/web-app/src/i18n/locales/en.json`
- `packages/web-app/src/i18n/locales/ko.json`
- `tasks/feat-i18n-tournament-detail-page.md`

## テスト内容
- `pnpm --filter @iidx/web-app lint`
- `pnpm --filter @iidx/web-app test -- TournamentDetailPage`
- `pnpm --filter @iidx/web-app build`

## 回帰確認項目
- 大会詳細画面で直書き表示文字列が `t()` 経由になっていること
- `ja/en/ko` 切替で大会詳細画面が破綻しないこと
- 変更範囲が大会詳細ページ文字列置換＋辞書追加に限定されていること