### PR TITLE
feat(i18n): move whats-new content to locale array ssot

### DIFF
--- a/packages/web-app/src/App.tsx
+++ b/packages/web-app/src/App.tsx
@@ -75,7 +75,6 @@ import {
 import { resolveErrorMessage } from './utils/error-i18n';
 import { consumeWhatsNewVisibility } from './utils/whats-new';
 import { CURRENT_VERSION } from './version';
-import { WHATS_NEW_LINES, WHATS_NEW_MODAL_DESCRIPTION, WHATS_NEW_MODAL_TITLE } from './whats-new-content';
 
 function todayJst(): string {
   const now = new Date();
@@ -839,6 +838,9 @@ export function App({ webLockAcquired = false }: AppProps = {}): JSX.Element {
   const homeTypeAttr = resolveHomeTypeAttr(homeQuery.attrs);
   const homeNonMajorChipCount =
     (homeQuery.attrs.includes('send-waiting') ? 1 : 0) + (homeQuery.sort === 'default' ? 0 : 1);
+  const rawWhatsNewItems = t('whats_new.items', { returnObjects: true }) as unknown;
+  const whatsNewItems =
+    Array.isArray(rawWhatsNewItems) ? rawWhatsNewItems.filter((value): value is string => typeof value === 'string') : [];
 
   const openHomeFilterSheet = React.useCallback(
     (focusSection: HomeFilterSheetFocusSection = null) => {
@@ -2460,15 +2462,15 @@ export function App({ webLockAcquired = false }: AppProps = {}): JSX.Element {
         />
 
         <Dialog open={whatsNewDialogOpen} onClose={closeWhatsNewDialog} fullWidth maxWidth="sm">
-          <DialogTitle>{WHATS_NEW_MODAL_TITLE}</DialogTitle>
+          <DialogTitle>{t('whats_new.modal.title')}</DialogTitle>
           <DialogContent>
             <Typography variant="body2" sx={{ mb: 1.5 }}>
-              {WHATS_NEW_MODAL_DESCRIPTION}
+              {t('whats_new.modal.description')}
             </Typography>
             <Box component="ul" sx={{ margin: 0, paddingLeft: 3, display: 'grid', gap: 1 }}>
-              {WHATS_NEW_LINES.map((line) => (
-                <Typography key={line} component="li" variant="body2">
-                  {line}
+              {whatsNewItems.map((text, index) => (
+                <Typography key={index} component="li" variant="body2">
+                  {text}
                 </Typography>
               ))}
             </Box>

--- a/packages/web-app/src/i18n/locales/en.json
+++ b/packages/web-app/src/i18n/locales/en.json
@@ -199,6 +199,9 @@
       "search_placeholder": "Tournament / Owner / Hashtag",
       "search_chip": "Search: \"{{value}}\""
     },
+    "tournament_status": {
+      "days_until_start": "Starts in {{count}} days"
+    },
     "home_filter": {
       "section": {
         "state": "State",
@@ -919,5 +922,15 @@
         "no_sendable_images": "There are no pending images that can be sent."
       }
     }
+  },
+  "whats_new": {
+    "modal": {
+      "title": "What's New (v0.1.3)",
+      "description": "This update includes:"
+    },
+    "items": [
+      "Improved search and filter flow on the home list.",
+      "Refined chip display and actions for better readability."
+    ]
   }
 }

--- a/packages/web-app/src/i18n/locales/ja.json
+++ b/packages/web-app/src/i18n/locales/ja.json
@@ -199,6 +199,9 @@
       "search_placeholder": "大会名 / 開催者 / ハッシュタグ",
       "search_chip": "検索: \"{{value}}\""
     },
+    "tournament_status": {
+      "days_until_start": "あと{{count}}日"
+    },
     "home_filter": {
       "section": {
         "state": "状態",
@@ -919,5 +922,15 @@
         "no_sendable_images": "送信できる送信待ち画像がありません。"
       }
     }
+  },
+  "whats_new": {
+    "modal": {
+      "title": "アップデートのお知らせ(v0.1.3)",
+      "description": "今回のアップデート内容:"
+    },
+    "items": [
+      "ホーム一覧の検索とフィルタ導線を使いやすくしたよ",
+      "チップ表示と操作まわりを整理して見やすくしたよ"
+    ]
   }
 }

--- a/packages/web-app/src/i18n/locales/ko.json
+++ b/packages/web-app/src/i18n/locales/ko.json
@@ -199,6 +199,9 @@
       "search_placeholder": "대회명 / 주최자 / 해시태그",
       "search_chip": "검색: \"{{value}}\""
     },
+    "tournament_status": {
+      "days_until_start": "시작까지 {{count}}일"
+    },
     "home_filter": {
       "section": {
         "state": "상태",
@@ -919,5 +922,15 @@
         "no_sendable_images": "전송할 수 있는 전송 대기 이미지가 없습니다."
       }
     }
+  },
+  "whats_new": {
+    "modal": {
+      "title": "업데이트 소식(v0.1.3)",
+      "description": "이번 업데이트 내용:"
+    },
+    "items": [
+      "홈 목록의 검색과 필터 동선을 더 사용하기 쉽게 개선했어요.",
+      "칩 표시와 조작 주변을 정리해 보기 쉽게 만들었어요."
+    ]
   }
 }

--- a/packages/web-app/src/utils/iidx.ts
+++ b/packages/web-app/src/utils/iidx.ts
@@ -1,3 +1,5 @@
+import i18n from '../i18n';
+
 export const DIFFICULTY_COLORS: Record<string, string> = {
   BEGINNER: '#79D100',
   NORMAL: '#20A8FF',
@@ -65,18 +67,18 @@ export function versionLabel(version: unknown): string {
 export function statusLabel(status: 'active' | 'upcoming' | 'ended', days?: number): string {
   if (status === 'active') {
     if (days !== undefined && days <= 0) {
-      return '本日まで';
+      return i18n.t('tournament_detail.status.active_today');
     }
     if (days !== undefined) {
-      return `残り${days}日`;
+      return i18n.t('tournament_detail.status.active_remaining_days', { count: days });
     }
-    return '開催中';
+    return i18n.t('home.state.active');
   }
   if (status === 'upcoming') {
     if (days !== undefined) {
-      return `あと${days}日`;
+      return i18n.t('common.tournament_status.days_until_start', { count: days });
     }
-    return '開催前';
+    return i18n.t('home.state.upcoming');
   }
-  return '終了';
+  return i18n.t('home.state.ended');
 }

--- a/packages/web-app/src/utils/tournament-status.ts
+++ b/packages/web-app/src/utils/tournament-status.ts
@@ -1,4 +1,5 @@
 import { remainingDaysUntilEnd } from '@iidx/shared';
+import i18n from '../i18n';
 
 export type TournamentStatus =
   | 'upcoming'
@@ -22,7 +23,7 @@ export function resolveTournamentCardStatus(
   if (todayDate < startDate) {
     return {
       status: 'upcoming',
-      label: '未開催',
+      label: i18n.t('tournament_detail.status.upcoming'),
       daysLeft: null,
     };
   }
@@ -30,7 +31,7 @@ export function resolveTournamentCardStatus(
   if (todayDate > endDate) {
     return {
       status: 'ended',
-      label: '終了',
+      label: i18n.t('tournament_detail.status.ended'),
       daysLeft: null,
     };
   }
@@ -39,27 +40,27 @@ export function resolveTournamentCardStatus(
   if (daysLeft === 0) {
     return {
       status: 'active-today',
-      label: '今日まで',
+      label: i18n.t('tournament_detail.status.active_today'),
       daysLeft,
     };
   }
   if (daysLeft <= 2) {
     return {
       status: 'active-danger',
-      label: `残り${daysLeft}日`,
+      label: i18n.t('tournament_detail.status.active_remaining_days', { count: daysLeft }),
       daysLeft,
     };
   }
   if (daysLeft <= 7) {
     return {
       status: 'active-warning',
-      label: `残り${daysLeft}日`,
+      label: i18n.t('tournament_detail.status.active_remaining_days', { count: daysLeft }),
       daysLeft,
     };
   }
   return {
     status: 'active-normal',
-    label: `残り${daysLeft}日`,
+    label: i18n.t('tournament_detail.status.active_remaining_days', { count: daysLeft }),
     daysLeft,
   };
 }

--- a/packages/web-app/src/whats-new-content.ts
+++ b/packages/web-app/src/whats-new-content.ts
@@ -1,7 +1,0 @@
-export const WHATS_NEW_MODAL_TITLE = 'アップデートのお知らせ(v0.1.3)';
-export const WHATS_NEW_MODAL_DESCRIPTION = '今回のアップデート内容:';
-
-export const WHATS_NEW_LINES = [
-  'ホーム一覧の検索とフィルタ導線を使いやすくしたよ',
-  'チップ表示と操作まわりを整理して見やすくしたよ',
-];

--- a/tasks/feat-i18n-whatsnew-utils-pr8c.md
+++ b/tasks/feat-i18n-whatsnew-utils-pr8c.md
@@ -1,0 +1,33 @@
+- [x] Scope declaration
+- [x] Audit hardcoded UI strings in whats-new-content.ts and utils/*
+- [x] Implement i18n replacements (no logic/DOM/style changes)
+- [x] Update ja/en/ko locale dictionaries
+- [x] Re-run extraction and validate no remaining targeted hardcoded UI strings
+- [x] Run quality checks (web-app lint/test)
+- [x] Prepare PR notes (BASE_SHA, commands, changed files, exclusions)
+
+Worktree:
+- path: C:\work\score_attack_manager\iidx_score_attack_manager-pr8c-whatsnew-utils
+- branch: feat/i18n-whatsnew-utils-pr8c
+- BASE_SHA: 87fbb6ed9bfe4163a5cb1a6c9ee4527300523e7b
+
+Commit plan:
+1. i18n migration for whats-new-content.ts and relevant utils consumers
+2. locale key additions for ja/en/ko
+3. verification and task note updates
+
+Extraction commands:
+1. `rg -n --no-heading "whats-new-content|WHATS_NEW_" packages/web-app/src`
+2. `rg -n --no-heading --glob '!*.test.*' "[ぁ-んァ-ヶ一-龠]" packages/web-app/src/App.tsx packages/web-app/src/utils/iidx.ts packages/web-app/src/utils/tournament-status.ts`
+3. `rg -n --no-heading "title=|placeholder=|aria-label=" packages/web-app/src/App.tsx packages/web-app/src/utils/iidx.ts packages/web-app/src/utils/tournament-status.ts`
+
+Result summary:
+- `whats-new-content.ts` is removed and source-of-truth moved to locale JSON (`whats_new.modal`, `whats_new.items`).
+- Modal now reads `t("whats_new.items", { returnObjects: true })` as `string[]` and falls back to `[]` when invalid.
+- Targeted hardcoded UI strings in target `utils/*` remain migrated to i18n.
+- Remaining literal `aria-label` values in `App.tsx` are fixed IDs for selector/stability (`search-close`, `search-clear`, `home-filter`, `global-settings-menu`, `back`, `detail-actions-menu`, `home-applied-filters`, `home-search-entry`).
+- Existing behavior for visibility timing / seen-version storage is unchanged.
+
+Verification:
+- `pnpm --filter @iidx/web-app lint` : passed
+- `pnpm --filter @iidx/web-app test` : passed


### PR DESCRIPTION
## 目的
- `whats-new-content.ts` を廃止し、更新情報の可変部分を辞書 (`ja/en/ko`) 側へ寄せる
- `whats_new.items` を `string[]` 化し、バージョン更新時の変更を辞書差分のみで完結させる

## 変更点
- `packages/web-app/src/whats-new-content.ts` を削除
- `App.tsx` の更新情報モーダルを辞書直接参照へ変更
  - `t("whats_new.modal.title")`
  - `t("whats_new.modal.description")`
  - `t("whats_new.items", { returnObjects: true })` 取得
- `whats_new.items` は `Array.isArray` でランタイム検証し、不正時は `[]` にフォールバック
- `whatsNewItems` 描画は `string[]` を `index` key で描画（順序固定）
- `ja/en/ko` の `whats_new.items` を `{ id, text }[]` から `string[]` へ統一
- PR-8cスコープとして `utils/iidx.ts` / `utils/tournament-status.ts` の直書き文言も i18n 化

## 非変更点
- 既読管理ロジック（`consumeWhatsNewVisibility` / localStorage key / 比較条件）
- 更新情報モーダルの表示タイミング
- モーダルUI/レイアウト
- Web Locks / BroadcastChannel / storage event 委譲経路

## 影響範囲
- `packages/web-app/src/App.tsx`
- `packages/web-app/src/whats-new-content.ts` (deleted)
- `packages/web-app/src/utils/iidx.ts`
- `packages/web-app/src/utils/tournament-status.ts`
- `packages/web-app/src/i18n/locales/ja.json`
- `packages/web-app/src/i18n/locales/en.json`
- `packages/web-app/src/i18n/locales/ko.json`
- `tasks/feat-i18n-whatsnew-utils-pr8c.md`

## テスト内容
- `pnpm --filter @iidx/web-app lint` : passed
- `pnpm --filter @iidx/web-app test` : passed (55 passed)

## 回帰確認項目
- `ja/en/ko` で `whats_new.modal.*` と `whats_new.items` が解決されること
- `whats_new.items` が不正値でもクラッシュせず空配列描画になること
- 既読管理挙動が従来通りであること（コード上のロジック不変）

## 監査情報
- BASE_SHA: `87fbb6ed9bfe4163a5cb1a6c9ee4527300523e7b`
- 抽出コマンド:
  - `rg -n --no-heading "whats-new-content|WHATS_NEW_" packages/web-app/src`
  - `rg -n --no-heading --glob '!*.test.*' "[ぁ-んァ-ヶ一-龠]" packages/web-app/src/App.tsx packages/web-app/src/utils/iidx.ts packages/web-app/src/utils/tournament-status.ts`
  - `rg -n --no-heading "title=|placeholder=|aria-label=" packages/web-app/src/App.tsx packages/web-app/src/utils/iidx.ts packages/web-app/src/utils/tournament-status.ts`
