### PR TITLE
refactor(i18n): unify “大会” to Score Attack in UI strings

### DIFF
--- a/packages/web-app/src/i18n/locales/en.json
+++ b/packages/web-app/src/i18n/locales/en.json
@@ -42,7 +42,7 @@
         "saved_in_browser": "Data is stored in your browser.",
         "no_auto_sync": "No automatic server sync is performed.",
         "may_be_lost": "Changing devices or clearing browser data may erase data.",
-        "import_available": "You can import tournaments via QR code or URL.",
+        "import_available": "You can import Score Attacks via QR code or URL.",
         "consider_backup": "Consider backups when needed."
       },
       "understood": "I understand the above",
@@ -91,7 +91,7 @@
       },
       "preview": {
         "title": "Import preview",
-        "tournament_name": "Tournament: {{value}}",
+        "tournament_name": "Score Attack: {{value}}",
         "owner": "Owner: {{value}}",
         "period": "Period: {{start}} to {{end}}",
         "chart_count": "Charts: {{count}}",
@@ -149,10 +149,10 @@
     },
     "import": {
       "require_song_master": "Song master is not available, so create/import cannot be used.",
-      "page_require_song_master": "Song master is not available, so tournament import cannot be used.",
+      "page_require_song_master": "Song master is not available, so Score Attack import cannot be used.",
       "unrecognized_data": "Could not recognize import data.",
       "qr_not_found": "No QR code found in the image.",
-      "incompatible_period": "Import failed because tournament period conflicts with existing tournaments.",
+      "incompatible_period": "Import failed because Score Attack period conflicts with existing Score Attacks.",
       "no_change": "No changes",
       "completed": "Imported",
       "delegation": {
@@ -170,15 +170,15 @@
       "cleanup_log": "Storage cleanup executed. (Images {{count}} / Freed {{released}})"
     },
     "page_title": {
-      "home": "Tournament list",
-      "import": "Tournament import",
+      "home": "Score Attack list",
+      "import": "Score Attack import",
       "import_confirm": "Import confirmation",
-      "create": "Create tournament",
-      "detail": "Tournament detail",
+      "create": "Create Score Attack",
+      "detail": "Score Attack detail",
       "submit": "Submit score"
     },
     "create": {
-      "require_song_master": "Song master is not available, so tournament creation cannot be used."
+      "require_song_master": "Song master is not available, so Score Attack creation cannot be used."
     },
     "pwa": {
       "apply_update_log": "Applying app update."
@@ -188,15 +188,15 @@
       "copy_failed": "Failed to copy technical log."
     },
     "tournament": {
-      "create": "Create tournament",
-      "actions": "Tournament actions",
-      "deleted": "Tournament deleted."
+      "create": "Create Score Attack",
+      "actions": "Score Attack actions",
+      "deleted": "Score Attack deleted."
     },
     "local_reset": {
       "executed": "Local reset executed."
     },
     "home": {
-      "search_placeholder": "Tournament / Owner / Hashtag",
+      "search_placeholder": "Score Attack / Owner / Hashtag",
       "search_chip": "Search: \"{{value}}\""
     },
     "tournament_status": {
@@ -236,8 +236,8 @@
       "result_count": "Current results: {{count}}"
     },
     "delete_tournament_confirm": {
-      "title": "Delete this tournament?",
-      "description": "Tournament data and images will be deleted and cannot be restored."
+      "title": "Delete this Score Attack?",
+      "description": "Score Attack data and images will be deleted and cannot be restored."
     }
   },
   "home": {
@@ -247,7 +247,7 @@
       "ended": "Ended"
     },
     "empty": {
-      "text": "No tournaments available to display.",
+      "text": "No Score Attacks available to display.",
       "action": {
         "open_filter": "Open filters"
       }
@@ -267,10 +267,10 @@
     }
   },
   "import": {
-    "title": "Import tournament",
+    "title": "Import Score Attack",
     "description": "You can import from a URL or image/text files.",
     "warning": {
-      "song_master_unavailable": "Tournament import is unavailable because song master data is missing.",
+      "song_master_unavailable": "Score Attack import is unavailable because song master data is missing.",
       "song_master_action": "Check updates in the \"Song data\" section on the settings screen."
     },
     "input": {
@@ -294,17 +294,17 @@
       "json_error": "Failed to parse the payload JSON.",
       "schema_error": "Required fields or types in import data are invalid.",
       "too_large": "Import data size exceeds the limit.",
-      "expired": "Ended tournaments cannot be imported.",
+      "expired": "Ended Score Attacks cannot be imported.",
       "master_missing": "Cannot validate because song master data is missing.",
       "chart_not_found": "Charts not found in song master data: {{chartIds}}",
       "unsupported_version": "This data version is not supported.",
-      "period_conflict": "Import failed because the existing tournament with the same UUID has a conflicting period.",
+      "period_conflict": "Import failed because the existing Score Attack with the same UUID has a conflicting period.",
       "unexpected": "Unexpected error: {{message}}"
     },
     "confirm": {
       "section": {
         "charts": "Target charts",
-        "merge": "Existing tournament found (same UUID)",
+        "merge": "Existing Score Attack found (same UUID)",
         "caution": "Caution"
       },
       "status": {
@@ -322,11 +322,11 @@
         "mode": "Apply mode: Merge (charts only)",
         "added_charts": "Charts to add: {{count}}",
         "same_charts": "Charts already existing: {{count}}",
-        "note": "Tournament name/owner/period/hashtag will not be updated."
+        "note": "Score Attack name/owner/period/hashtag will not be updated."
       },
       "caution": {
         "self_responsibility": "Use imported data at your own risk.",
-        "uuid_conflict": "When UUIDs conflict, tournament info is kept and only chart differences are applied."
+        "uuid_conflict": "When UUIDs conflict, Score Attack info is kept and only chart differences are applied."
       }
     }
   },
@@ -369,15 +369,15 @@
     "out_of_range": "The input is out of range.",
     "check_input": "Please check your input.",
     "tournament": {
-      "name_required": "Please enter a tournament name.",
-      "name_too_long": "Tournament name must be {{max}} characters or fewer.",
+      "name_required": "Please enter a Score Attack name.",
+      "name_too_long": "Score Attack name must be {{max}} characters or fewer.",
       "owner_required": "Please enter an organizer.",
       "owner_too_long": "Organizer must be {{max}} characters or fewer.",
       "hashtag_required": "Please enter a hashtag.",
       "start_date_invalid_format": "Start date must be in YYYY-MM-DD format.",
       "end_date_invalid_format": "End date must be in YYYY-MM-DD format.",
       "date_range_invalid": "Start date must be on or before end date.",
-      "past_date_not_allowed": "Cannot register a tournament that has already ended.",
+      "past_date_not_allowed": "Cannot register a Score Attack that has already ended.",
       "chart_required": "Select at least one chart.",
       "chart_too_many": "You can select up to {{max}} charts.",
       "chart_duplicate": "Duplicate charts cannot be registered."
@@ -391,7 +391,7 @@
   },
   "create_tournament": {
     "wizard": {
-      "aria_label": "Tournament definition wizard",
+      "aria_label": "Score Attack definition wizard",
       "step": {
         "basic": "Basic info",
         "charts": "Charts",
@@ -400,14 +400,14 @@
       "nav_item": "{{index}}. {{label}}"
     },
     "step": {
-      "basic_title": "1) Basic tournament info",
+      "basic_title": "1) Basic Score Attack info",
       "charts_title": "2) Target charts ({{current}} / {{max}})",
       "confirm_title": "3) Confirm"
     },
     "field": {
       "name": {
-        "label": "Tournament name *",
-        "label_plain": "Tournament name",
+        "label": "Score Attack name *",
+        "label_plain": "Score Attack name",
         "placeholder": "e.g.) Score Attack 2026"
       },
       "owner": {
@@ -460,7 +460,7 @@
       "set_next_month": "Next month (1st to end of month)",
       "next_with_step": "{{action}} ({{step}})",
       "back_with_step": "{{action}} ({{step}})",
-      "create": "Create tournament",
+      "create": "Create Score Attack",
       "creating": "Creating..."
     },
     "progress": {
@@ -475,7 +475,7 @@
       "selection_delete_aria": "Remove selection {{index}}"
     },
     "validation": {
-      "name_required": "Enter a tournament name.",
+      "name_required": "Enter a Score Attack name.",
       "owner_required": "Enter an organizer.",
       "hashtag_required": "Enter a hashtag.",
       "start_date_required": "Select a start date.",
@@ -684,7 +684,7 @@
       "auto_delete": {
         "enable": "Enable automatic image deletion",
         "days_label": "Delete images N days after end",
-        "helper": "Tournament data remains; only images are deleted (not restorable)."
+        "helper": "Score Attack data remains; only images are deleted (not restorable)."
       },
       "detail": {
         "last_run_at": "Last run",
@@ -695,7 +695,7 @@
       "cleanup_dialog": {
         "title": "Clean up storage",
         "loading": "Loading estimate...",
-        "target_tournament_count": "Target tournaments to delete: {{value}}",
+        "target_tournament_count": "Target Score Attacks to delete: {{value}}",
         "target_image_count": "Target images to delete: {{value}}",
         "estimated_release": "Estimated release size: {{size}}",
         "not_restorable": "Not restorable",
@@ -780,7 +780,7 @@
       "title": "Danger zone",
       "description": "Running local reset deletes the following items.",
       "items": {
-        "tournament": "Tournament data",
+        "tournament": "Score Attack data",
         "images": "Submitted images",
         "song_data": "Song data"
       },
@@ -810,7 +810,7 @@
   },
   "tournament_detail": {
     "action": {
-      "share_tournament": "Share tournament",
+      "share_tournament": "Share Score Attack",
       "open_settings": "Settings",
       "register": "Register",
       "replace": "Replace",
@@ -859,7 +859,7 @@
     },
     "share_dialog": {
       "close_aria_label": "Close share dialog",
-      "definition_only": "Only tournament definition is shared (images are not included).",
+      "definition_only": "Only Score Attack definition is shared (images are not included).",
       "preview_title": "Preview",
       "preview_image_size": "Generated image (1080x1920)",
       "preview_alt": "Shared image preview",

--- a/packages/web-app/src/i18n/locales/ja.json
+++ b/packages/web-app/src/i18n/locales/ja.json
@@ -42,7 +42,7 @@
         "saved_in_browser": "データはご利用中のブラウザ内に保存されます",
         "no_auto_sync": "サーバーへの自動同期は行われません",
         "may_be_lost": "端末変更やブラウザデータ削除で消える場合があります",
-        "import_available": "QRコードやURLアクセスで大会をインポートすることができます",
+        "import_available": "QRコードやURLアクセスでスコアタをインポートすることができます",
         "consider_backup": "必要に応じてバックアップをご検討ください"
       },
       "understood": "上記を理解しました",
@@ -91,7 +91,7 @@
       },
       "preview": {
         "title": "取り込み内容プレビュー",
-        "tournament_name": "大会名: {{value}}",
+        "tournament_name": "スコアタ名: {{value}}",
         "owner": "開催者: {{value}}",
         "period": "期間: {{start}} 〜 {{end}}",
         "chart_count": "譜面数: {{count}}",
@@ -148,11 +148,11 @@
       "initialization_error": "初期化エラー: {{message}}"
     },
     "import": {
-      "require_song_master": "曲マスタが未取得のため、大会作成/取込は利用できません。",
-      "page_require_song_master": "曲マスタが未取得のため大会取込は利用できません。",
+      "require_song_master": "曲マスタが未取得のため、スコアタ作成/取込は利用できません。",
+      "page_require_song_master": "曲マスタが未取得のためスコアタ取込は利用できません。",
       "unrecognized_data": "取込データを認識できません。",
       "qr_not_found": "画像内にQRコードが見つかりませんでした。",
-      "incompatible_period": "既存大会と開催期間が矛盾するため取り込みできません。",
+      "incompatible_period": "既存スコアタと開催期間が矛盾するため取り込みできません。",
       "no_change": "変更なし",
       "completed": "取り込みました",
       "delegation": {
@@ -170,15 +170,15 @@
       "cleanup_log": "容量整理を実行しました。（画像 {{count}} 件 / 解放 {{released}}）"
     },
     "page_title": {
-      "home": "大会一覧",
-      "import": "大会取込",
+      "home": "スコアタ一覧",
+      "import": "スコアタ取込",
       "import_confirm": "取り込み確認",
-      "create": "大会作成",
-      "detail": "大会詳細",
+      "create": "スコアタ作成",
+      "detail": "スコアタ詳細",
       "submit": "スコア提出"
     },
     "create": {
-      "require_song_master": "曲マスタが未取得のため大会作成は利用できません。"
+      "require_song_master": "曲マスタが未取得のためスコアタ作成は利用できません。"
     },
     "pwa": {
       "apply_update_log": "アプリ更新を適用します。"
@@ -188,15 +188,15 @@
       "copy_failed": "技術ログのコピーに失敗しました。"
     },
     "tournament": {
-      "create": "大会を作成",
-      "actions": "大会アクション",
-      "deleted": "大会を削除しました。"
+      "create": "スコアタを作成",
+      "actions": "スコアタアクション",
+      "deleted": "スコアタを削除しました。"
     },
     "local_reset": {
       "executed": "ローカル初期化を実行しました。"
     },
     "home": {
-      "search_placeholder": "大会名 / 開催者 / ハッシュタグ",
+      "search_placeholder": "スコアタ名 / 開催者 / ハッシュタグ",
       "search_chip": "検索: \"{{value}}\""
     },
     "tournament_status": {
@@ -236,8 +236,8 @@
       "result_count": "現在の結果: {{count}}件"
     },
     "delete_tournament_confirm": {
-      "title": "大会を削除しますか？",
-      "description": "大会データと画像は削除され、復元できません"
+      "title": "スコアタを削除しますか？",
+      "description": "スコアタデータと画像は削除され、復元できません"
     }
   },
   "home": {
@@ -247,7 +247,7 @@
       "ended": "終了"
     },
     "empty": {
-      "text": "表示できる大会がありません。",
+      "text": "表示できるスコアタがありません。",
       "action": {
         "open_filter": "フィルタを開く"
       }
@@ -267,10 +267,10 @@
     }
   },
   "import": {
-    "title": "大会取込",
+    "title": "スコアタ取込",
     "description": "URLもしくは画像/テキストファイルを取り込めます。",
     "warning": {
-      "song_master_unavailable": "曲マスタが未取得のため、大会取込は利用できません。",
+      "song_master_unavailable": "曲マスタが未取得のため、スコアタ取込は利用できません。",
       "song_master_action": "設定画面の「曲データ」セクションで更新を確認してください。"
     },
     "input": {
@@ -294,17 +294,17 @@
       "json_error": "ペイロードJSONの解析に失敗しました。",
       "schema_error": "取り込みデータの必須項目または型が不正です。",
       "too_large": "取り込みデータサイズが上限を超えています。",
-      "expired": "終了済みの大会は取り込みできません。",
+      "expired": "終了済みのスコアタは取り込みできません。",
       "master_missing": "曲マスタが未取得のため検証できません。",
       "chart_not_found": "曲マスタに存在しない譜面があります: {{chartIds}}",
       "unsupported_version": "対応していないデータバージョンです。",
-      "period_conflict": "UUID一致の既存大会と開催期間が矛盾するため取り込みできません。",
+      "period_conflict": "UUID一致の既存スコアタと開催期間が矛盾するため取り込みできません。",
       "unexpected": "予期しないエラー: {{message}}"
     },
     "confirm": {
       "section": {
         "charts": "対象譜面",
-        "merge": "既存大会が見つかりました（UUID一致）",
+        "merge": "既存スコアタが見つかりました（UUID一致）",
         "caution": "注意"
       },
       "status": {
@@ -322,11 +322,11 @@
         "mode": "適用方式: マージ（譜面のみ）",
         "added_charts": "追加される譜面数: {{count}}",
         "same_charts": "既存と同一の譜面数: {{count}}",
-        "note": "大会名/開催者/期間/ハッシュタグは更新されません。"
+        "note": "スコアタ名/開催者/期間/ハッシュタグは更新されません。"
       },
       "caution": {
         "self_responsibility": "取り込みデータは自己責任で利用してください。",
-        "uuid_conflict": "UUID衝突時は大会情報を更新せず、譜面差分のみを適用します。"
+        "uuid_conflict": "UUID衝突時はスコアタ情報を更新せず、譜面差分のみを適用します。"
       }
     }
   },
@@ -369,15 +369,15 @@
     "out_of_range": "入力範囲が正しくありません。",
     "check_input": "入力内容を確認してください。",
     "tournament": {
-      "name_required": "大会名を入力してください。",
-      "name_too_long": "大会名は{{max}}文字以内で入力してください。",
+      "name_required": "スコアタ名を入力してください。",
+      "name_too_long": "スコアタ名は{{max}}文字以内で入力してください。",
       "owner_required": "開催者を入力してください。",
       "owner_too_long": "開催者は{{max}}文字以内で入力してください。",
       "hashtag_required": "ハッシュタグを入力してください。",
       "start_date_invalid_format": "開始日はYYYY-MM-DD形式で入力してください。",
       "end_date_invalid_format": "終了日はYYYY-MM-DD形式で入力してください。",
       "date_range_invalid": "開始日は終了日以前を指定してください。",
-      "past_date_not_allowed": "過去に終了した大会は登録できません。",
+      "past_date_not_allowed": "過去に終了したスコアタは登録できません。",
       "chart_required": "譜面を1件以上選択してください。",
       "chart_too_many": "譜面は最大{{max}}件です。",
       "chart_duplicate": "同一譜面を重複登録できません。"
@@ -391,7 +391,7 @@
   },
   "create_tournament": {
     "wizard": {
-      "aria_label": "大会定義ウィザード",
+      "aria_label": "スコアタ定義ウィザード",
       "step": {
         "basic": "基本情報",
         "charts": "譜面",
@@ -400,14 +400,14 @@
       "nav_item": "{{index}}. {{label}}"
     },
     "step": {
-      "basic_title": "1) 大会基本情報",
+      "basic_title": "1) スコアタ基本情報",
       "charts_title": "2) 対象譜面 ({{current}} / {{max}})",
       "confirm_title": "3) 確認"
     },
     "field": {
       "name": {
-        "label": "大会名 *",
-        "label_plain": "大会名",
+        "label": "スコアタ名 *",
+        "label_plain": "スコアタ名",
         "placeholder": "例）スコアタ2026"
       },
       "owner": {
@@ -460,7 +460,7 @@
       "set_next_month": "来月（1日〜月末）",
       "next_with_step": "{{action}}（{{step}}）",
       "back_with_step": "{{action}}（{{step}}）",
-      "create": "大会を作成",
+      "create": "スコアタを作成",
       "creating": "作成中..."
     },
     "progress": {
@@ -475,7 +475,7 @@
       "selection_delete_aria": "選曲 {{index}} を削除"
     },
     "validation": {
-      "name_required": "大会名を入力してください。",
+      "name_required": "スコアタ名を入力してください。",
       "owner_required": "開催者を入力してください。",
       "hashtag_required": "ハッシュタグを入力してください。",
       "start_date_required": "開始日を選択してください。",
@@ -684,7 +684,7 @@
       "auto_delete": {
         "enable": "画像自動削除を有効にする",
         "days_label": "終了後N日で画像削除",
-        "helper": "大会データは残り、画像のみ削除（復元不可）"
+        "helper": "スコアタデータは残り、画像のみ削除（復元不可）"
       },
       "detail": {
         "last_run_at": "直近実行日時",
@@ -695,7 +695,7 @@
       "cleanup_dialog": {
         "title": "容量を整理",
         "loading": "見積りを取得中...",
-        "target_tournament_count": "削除対象大会数: {{value}} 件",
+        "target_tournament_count": "削除対象スコアタ数: {{value}} 件",
         "target_image_count": "削除対象画像枚数: {{value}} 枚",
         "estimated_release": "解放見込み容量（概算）: {{size}}",
         "not_restorable": "復元不可",
@@ -780,7 +780,7 @@
       "title": "危険操作",
       "description": "ローカル初期化を実行すると以下を削除します。",
       "items": {
-        "tournament": "大会データ",
+        "tournament": "スコアタデータ",
         "images": "提出画像",
         "song_data": "曲データ"
       },
@@ -810,7 +810,7 @@
   },
   "tournament_detail": {
     "action": {
-      "share_tournament": "大会を共有",
+      "share_tournament": "スコアタを共有",
       "open_settings": "設定",
       "register": "登録",
       "replace": "差し替え",
@@ -859,7 +859,7 @@
     },
     "share_dialog": {
       "close_aria_label": "共有ダイアログを閉じる",
-      "definition_only": "共有されるのは大会定義のみ（画像は含まれません）",
+      "definition_only": "共有されるのはスコアタ定義のみ（画像は含まれません）",
       "preview_title": "プレビュー",
       "preview_image_size": "生成画像（1080x1920）",
       "preview_alt": "共有画像プレビュー",

--- a/packages/web-app/src/i18n/locales/ko.json
+++ b/packages/web-app/src/i18n/locales/ko.json
@@ -42,7 +42,7 @@
         "saved_in_browser": "데이터는 현재 사용 중인 브라우저 안에 저장됩니다",
         "no_auto_sync": "서버로 자동 동기화되지 않습니다",
         "may_be_lost": "기기 변경이나 브라우저 데이터 삭제 시 사라질 수 있습니다",
-        "import_available": "QR 코드나 URL 접근으로 대회를 가져올 수 있습니다",
+        "import_available": "QR 코드나 URL 접근으로 스코어 어택을 가져올 수 있습니다",
         "consider_backup": "필요하면 백업을 권장합니다"
       },
       "understood": "위 내용을 이해했습니다",
@@ -91,7 +91,7 @@
       },
       "preview": {
         "title": "가져오기 내용 미리보기",
-        "tournament_name": "대회명: {{value}}",
+        "tournament_name": "스코어 어택명: {{value}}",
         "owner": "주최자: {{value}}",
         "period": "기간: {{start}} ~ {{end}}",
         "chart_count": "채보 수: {{count}}",
@@ -148,11 +148,11 @@
       "initialization_error": "초기화 오류: {{message}}"
     },
     "import": {
-      "require_song_master": "곡 마스터가 없어 대회 생성/가져오기를 사용할 수 없습니다.",
-      "page_require_song_master": "곡 마스터가 없어 대회 가져오기를 사용할 수 없습니다.",
+      "require_song_master": "곡 마스터가 없어 스코어 어택 생성/가져오기를 사용할 수 없습니다.",
+      "page_require_song_master": "곡 마스터가 없어 스코어 어택 가져오기를 사용할 수 없습니다.",
       "unrecognized_data": "가져오기 데이터를 인식할 수 없습니다.",
       "qr_not_found": "이미지에서 QR 코드를 찾지 못했습니다.",
-      "incompatible_period": "기존 대회와 기간이 충돌하여 가져올 수 없습니다.",
+      "incompatible_period": "기존 스코어 어택과 기간이 충돌하여 가져올 수 없습니다.",
       "no_change": "변경 없음",
       "completed": "가져왔습니다",
       "delegation": {
@@ -170,15 +170,15 @@
       "cleanup_log": "용량 정리를 실행했습니다. (이미지 {{count}}건 / 해제 {{released}})"
     },
     "page_title": {
-      "home": "대회 목록",
-      "import": "대회 가져오기",
+      "home": "스코어 어택 목록",
+      "import": "스코어 어택 가져오기",
       "import_confirm": "가져오기 확인",
-      "create": "대회 생성",
-      "detail": "대회 상세",
+      "create": "스코어 어택 생성",
+      "detail": "스코어 어택 상세",
       "submit": "점수 제출"
     },
     "create": {
-      "require_song_master": "곡 마스터가 없어 대회 생성을 사용할 수 없습니다."
+      "require_song_master": "곡 마스터가 없어 스코어 어택 생성을 사용할 수 없습니다."
     },
     "pwa": {
       "apply_update_log": "앱 업데이트를 적용합니다."
@@ -188,15 +188,15 @@
       "copy_failed": "기술 로그 복사에 실패했습니다."
     },
     "tournament": {
-      "create": "대회 생성",
-      "actions": "대회 작업",
-      "deleted": "대회를 삭제했습니다."
+      "create": "스코어 어택 생성",
+      "actions": "스코어 어택 작업",
+      "deleted": "스코어 어택을 삭제했습니다."
     },
     "local_reset": {
       "executed": "로컬 초기화를 실행했습니다."
     },
     "home": {
-      "search_placeholder": "대회명 / 주최자 / 해시태그",
+      "search_placeholder": "스코어 어택명 / 주최자 / 해시태그",
       "search_chip": "검색: \"{{value}}\""
     },
     "tournament_status": {
@@ -236,8 +236,8 @@
       "result_count": "현재 결과: {{count}}건"
     },
     "delete_tournament_confirm": {
-      "title": "이 대회를 삭제할까요?",
-      "description": "대회 데이터와 이미지는 삭제되며 복원할 수 없습니다."
+      "title": "이 스코어 어택을 삭제할까요?",
+      "description": "스코어 어택 데이터와 이미지는 삭제되며 복원할 수 없습니다."
     }
   },
   "home": {
@@ -247,7 +247,7 @@
       "ended": "종료"
     },
     "empty": {
-      "text": "표시할 수 있는 대회가 없습니다.",
+      "text": "표시할 수 있는 스코어 어택이 없습니다.",
       "action": {
         "open_filter": "필터 열기"
       }
@@ -267,10 +267,10 @@
     }
   },
   "import": {
-    "title": "대회 가져오기",
+    "title": "스코어 어택 가져오기",
     "description": "URL 또는 이미지/텍스트 파일에서 가져올 수 있습니다.",
     "warning": {
-      "song_master_unavailable": "곡 마스터 데이터가 없어 대회 가져오기를 사용할 수 없습니다.",
+      "song_master_unavailable": "곡 마스터 데이터가 없어 스코어 어택 가져오기를 사용할 수 없습니다.",
       "song_master_action": "설정 화면의 \"곡 데이터\" 섹션에서 업데이트를 확인하세요."
     },
     "input": {
@@ -294,17 +294,17 @@
       "json_error": "페이로드 JSON 파싱에 실패했습니다.",
       "schema_error": "가져오기 데이터의 필수 항목 또는 타입이 올바르지 않습니다.",
       "too_large": "가져오기 데이터 크기가 제한을 초과했습니다.",
-      "expired": "종료된 대회는 가져올 수 없습니다.",
+      "expired": "종료된 스코어 어택은 가져올 수 없습니다.",
       "master_missing": "곡 마스터 데이터가 없어 검증할 수 없습니다.",
       "chart_not_found": "곡 마스터 데이터에 없는 보면이 있습니다: {{chartIds}}",
       "unsupported_version": "지원하지 않는 데이터 버전입니다.",
-      "period_conflict": "같은 UUID의 기존 대회와 기간이 충돌하여 가져올 수 없습니다.",
+      "period_conflict": "같은 UUID의 기존 스코어 어택과 기간이 충돌하여 가져올 수 없습니다.",
       "unexpected": "예기치 않은 오류: {{message}}"
     },
     "confirm": {
       "section": {
         "charts": "대상 보면",
-        "merge": "기존 대회를 찾았습니다(UUID 일치)",
+        "merge": "기존 스코어 어택을 찾았습니다(UUID 일치)",
         "caution": "주의"
       },
       "status": {
@@ -322,11 +322,11 @@
         "mode": "적용 방식: 병합(보면만)",
         "added_charts": "추가되는 보면 수: {{count}}",
         "same_charts": "기존과 동일한 보면 수: {{count}}",
-        "note": "대회명/개최자/기간/해시태그는 업데이트되지 않습니다."
+        "note": "스코어 어택명/개최자/기간/해시태그는 업데이트되지 않습니다."
       },
       "caution": {
         "self_responsibility": "가져온 데이터는 본인 책임으로 사용하세요.",
-        "uuid_conflict": "UUID가 충돌하면 대회 정보는 유지하고 보면 차이만 적용합니다."
+        "uuid_conflict": "UUID가 충돌하면 스코어 어택 정보는 유지하고 보면 차이만 적용합니다."
       }
     }
   },
@@ -369,15 +369,15 @@
     "out_of_range": "입력 범위가 올바르지 않습니다.",
     "check_input": "입력 내용을 확인해 주세요.",
     "tournament": {
-      "name_required": "대회명을 입력해 주세요.",
-      "name_too_long": "대회명은 {{max}}자 이하로 입력해 주세요.",
+      "name_required": "스코어 어택명을 입력해 주세요.",
+      "name_too_long": "스코어 어택명은 {{max}}자 이하로 입력해 주세요.",
       "owner_required": "개최자를 입력해 주세요.",
       "owner_too_long": "개최자는 {{max}}자 이하로 입력해 주세요.",
       "hashtag_required": "해시태그를 입력해 주세요.",
       "start_date_invalid_format": "시작일은 YYYY-MM-DD 형식으로 입력해 주세요.",
       "end_date_invalid_format": "종료일은 YYYY-MM-DD 형식으로 입력해 주세요.",
       "date_range_invalid": "시작일은 종료일 이전(또는 동일)이어야 합니다.",
-      "past_date_not_allowed": "이미 종료된 대회는 등록할 수 없습니다.",
+      "past_date_not_allowed": "이미 종료된 스코어 어택은 등록할 수 없습니다.",
       "chart_required": "보면을 1개 이상 선택해 주세요.",
       "chart_too_many": "보면은 최대 {{max}}개까지 선택할 수 있습니다.",
       "chart_duplicate": "동일한 보면은 중복 등록할 수 없습니다."
@@ -391,7 +391,7 @@
   },
   "create_tournament": {
     "wizard": {
-      "aria_label": "대회 정의 마법사",
+      "aria_label": "스코어 어택 정의 마법사",
       "step": {
         "basic": "기본 정보",
         "charts": "채보",
@@ -400,14 +400,14 @@
       "nav_item": "{{index}}. {{label}}"
     },
     "step": {
-      "basic_title": "1) 대회 기본 정보",
+      "basic_title": "1) 스코어 어택 기본 정보",
       "charts_title": "2) 대상 채보 ({{current}} / {{max}})",
       "confirm_title": "3) 확인"
     },
     "field": {
       "name": {
-        "label": "대회명 *",
-        "label_plain": "대회명",
+        "label": "스코어 어택명 *",
+        "label_plain": "스코어 어택명",
         "placeholder": "예) 스코어어택 2026"
       },
       "owner": {
@@ -460,7 +460,7 @@
       "set_next_month": "다음 달 (1일~말일)",
       "next_with_step": "{{action}} ({{step}})",
       "back_with_step": "{{action}} ({{step}})",
-      "create": "대회 만들기",
+      "create": "스코어 어택 만들기",
       "creating": "생성 중..."
     },
     "progress": {
@@ -475,7 +475,7 @@
       "selection_delete_aria": "선곡 {{index}} 삭제"
     },
     "validation": {
-      "name_required": "대회명을 입력해 주세요.",
+      "name_required": "스코어 어택명을 입력해 주세요.",
       "owner_required": "주최자를 입력해 주세요.",
       "hashtag_required": "해시태그를 입력해 주세요.",
       "start_date_required": "시작일을 선택해 주세요.",
@@ -684,7 +684,7 @@
       "auto_delete": {
         "enable": "이미지 자동 삭제를 활성화합니다",
         "days_label": "종료 후 N일 뒤 이미지 삭제",
-        "helper": "대회 데이터는 유지되고 이미지만 삭제됩니다(복원 불가)."
+        "helper": "스코어 어택 데이터는 유지되고 이미지만 삭제됩니다(복원 불가)."
       },
       "detail": {
         "last_run_at": "최근 실행 시각",
@@ -695,7 +695,7 @@
       "cleanup_dialog": {
         "title": "저장 공간 정리",
         "loading": "예상치를 가져오는 중...",
-        "target_tournament_count": "삭제 대상 대회 수: {{value}}",
+        "target_tournament_count": "삭제 대상 스코어 어택 수: {{value}}",
         "target_image_count": "삭제 대상 이미지 수: {{value}}",
         "estimated_release": "예상 해제 용량: {{size}}",
         "not_restorable": "복원할 수 없습니다",
@@ -780,7 +780,7 @@
       "title": "위험 작업",
       "description": "로컬 초기화를 실행하면 아래 항목을 삭제합니다.",
       "items": {
-        "tournament": "대회 데이터",
+        "tournament": "스코어 어택 데이터",
         "images": "제출 이미지",
         "song_data": "곡 데이터"
       },
@@ -810,7 +810,7 @@
   },
   "tournament_detail": {
     "action": {
-      "share_tournament": "대회 공유",
+      "share_tournament": "스코어 어택 공유",
       "open_settings": "설정",
       "register": "등록",
       "replace": "교체",
@@ -859,7 +859,7 @@
     },
     "share_dialog": {
       "close_aria_label": "공유 대화상자 닫기",
-      "definition_only": "공유되는 것은 대회 정의만이며(이미지는 포함되지 않음)",
+      "definition_only": "공유되는 것은 스코어 어택 정의만이며(이미지는 포함되지 않음)",
       "preview_title": "미리보기",
       "preview_image_size": "생성 이미지(1080x1920)",
       "preview_alt": "공유 이미지 미리보기",


### PR DESCRIPTION
- [x] WORKFLOW.md を確認した
- [x] QUALITY.md を満たしている

## 方針
- 日本語: 大会 -> スコアタ
- 英語: Tournament -> Score Attack
- 韓国語: 대회 -> 스코어 어택

## 変更内容
- i18n キーは変更せず、表示文言のみを `ja/en/ko` 辞書で更新
- 対象ファイル:
  - `packages/web-app/src/i18n/locales/ja.json`
  - `packages/web-app/src/i18n/locales/en.json`
  - `packages/web-app/src/i18n/locales/ko.json`

## 直書き置換
- なし（`packages/web-app/src` の実装コード側に対象直書きなし）
