### PR TITLE
feat: redesign tournament detail share flow and chart meta presentation

### DIFF
--- a/packages/db/src/app-db.ts
+++ b/packages/db/src/app-db.ts
@@ -1422,4 +1422,23 @@ export class AppDatabase {
       [tournamentUuid, ...ids],
     );
   }
+
+  async markEvidenceSendPending(tournamentUuid: string, chartIds: number[]): Promise<void> {
+    const ids = chartIds
+      .map((value) => Number(value))
+      .filter((value) => Number.isInteger(value) && value > 0);
+    if (ids.length === 0) {
+      return;
+    }
+    const placeholders = ids.map(() => '?').join(', ');
+    await this.exec(
+      `UPDATE evidences
+       SET needs_send = 1
+       WHERE tournament_uuid = ?
+         AND file_deleted = 0
+         AND update_seq > 0
+         AND chart_id IN (${placeholders})`,
+      [tournamentUuid, ...ids],
+    );
+  }
 }

--- a/packages/web-app/src/i18n/locales/en.json
+++ b/packages/web-app/src/i18n/locales/en.json
@@ -813,7 +813,7 @@
   },
   "tournament_detail": {
     "action": {
-      "share_tournament": "Share Score Attack",
+      "share_tournament": "Share Tournament (QR)",
       "open_settings": "Settings",
       "register": "Register",
       "replace": "Replace",
@@ -822,8 +822,8 @@
       "copy_text": "Copy text",
       "copy_logs": "Copy logs",
       "save_to_device": "Save to device",
-      "mark_send_completed": "Mark as sent",
-      "submit": "Send"
+      "mark_send_completed": "Delete",
+      "submit": "Share"
     },
     "status": {
       "upcoming": "Not started",
@@ -835,6 +835,7 @@
       "period": "{{start}}〜{{end}}",
       "period_with_space": "{{start}} 〜 {{end}}",
       "progress": "Registered {{submitted}} / {{total}}",
+      "state_counts": "Shared {{shared}} ・ Unshared {{unshared}} ・ Unregistered {{unregistered}}",
       "last_updated": "Last updated: {{date}}"
     },
     "chart": {
@@ -843,8 +844,11 @@
       "status": {
         "error": "Error",
         "pending": "Not registered",
-        "submitted": "Registered",
-        "send_pending": "Pending send"
+        "submitted": "Shared",
+        "send_pending": "Unshared",
+        "unregistered": "Not registered",
+        "unshared": "Unshared",
+        "shared": "Shared"
       },
       "resolve_issue": {
         "mismatch": "Some charts do not match song data.",
@@ -862,7 +866,7 @@
     },
     "share_dialog": {
       "close_aria_label": "Close share dialog",
-      "definition_only": "Only Score Attack definition is shared (images are not included).",
+      "definition_only": "Only tournament info is shared.",
       "preview_title": "Preview",
       "preview_image_size": "Generated image (1080x1920)",
       "preview_alt": "Shared image preview",
@@ -896,16 +900,19 @@
       }
     },
     "submit_bar": {
-      "summary": "Pending send: {{count}}"
+      "summary": "Unshared: {{count}}",
+      "cta": "Share ({{count}})"
     },
     "submit_dialog": {
-      "title": "Send",
+      "title": "Share",
+      "confirm_message": "Share unshared charts ({{count}}).",
       "images_title": "Images to send",
       "images_description": "Images are shared outside this device.",
-      "target_count": "Targets: {{count}}",
+      "target_count": "Unshared targets: {{count}}",
       "message_title": "Message to send",
       "complete_title": "Mark as sent",
       "complete_description": "Share success cannot be detected automatically. Run this only after confirming the recipient received it.",
+      "undo_action": "Undo",
       "notice": {
         "saved_images_count": "Saved {{count}} image(s).",
         "save_images_failed": "Failed to save images.",
@@ -917,12 +924,16 @@
         "message_share_unsupported": "Message sharing is not supported in this environment.",
         "message_shared": "Message to send was shared.",
         "message_share_failed": "Failed to share message.",
-        "no_pending": "No pending sends.",
+        "no_pending": "No unshared charts.",
+        "marked_shared": "Marked as shared.",
+        "fallback_copy_failed": "Images were downloaded, but copying the message failed.",
+        "undo_applied": "Reverted to unshared.",
+        "undo_failed": "Failed to undo the latest share update.",
         "completed_count": "Marked {{count}} item(s) as sent.",
         "mark_completed_failed": "Failed to update sent status."
       },
       "error": {
-        "no_sendable_images": "There are no pending images that can be sent."
+        "no_sendable_images": "There are no unshared images available for sharing."
       }
     }
   },

--- a/packages/web-app/src/i18n/locales/ja.json
+++ b/packages/web-app/src/i18n/locales/ja.json
@@ -813,7 +813,7 @@
   },
   "tournament_detail": {
     "action": {
-      "share_tournament": "スコアタを共有",
+      "share_tournament": "大会を共有（QR）",
       "open_settings": "設定",
       "register": "登録",
       "replace": "差し替え",
@@ -822,8 +822,8 @@
       "copy_text": "テキストをコピー",
       "copy_logs": "ログコピー",
       "save_to_device": "端末に保存",
-      "mark_send_completed": "送信完了にする",
-      "submit": "送信する"
+      "mark_send_completed": "削除",
+      "submit": "共有する"
     },
     "status": {
       "upcoming": "未開催",
@@ -835,6 +835,7 @@
       "period": "{{start}}〜{{end}}",
       "period_with_space": "{{start}} 〜 {{end}}",
       "progress": "登録 {{submitted}} / {{total}}",
+      "state_counts": "共有済 {{shared}} ・ 未共有 {{unshared}} ・ 未登録 {{unregistered}}",
       "last_updated": "最終更新: {{date}}"
     },
     "chart": {
@@ -843,8 +844,11 @@
       "status": {
         "error": "エラー",
         "pending": "未登録",
-        "submitted": "登録済",
-        "send_pending": "送信待ち"
+        "submitted": "共有済",
+        "send_pending": "未共有",
+        "unregistered": "未登録",
+        "unshared": "未共有",
+        "shared": "共有済"
       },
       "resolve_issue": {
         "mismatch": "一部譜面が曲データと一致しません。",
@@ -862,7 +866,7 @@
     },
     "share_dialog": {
       "close_aria_label": "共有ダイアログを閉じる",
-      "definition_only": "共有されるのはスコアタ定義のみ（画像は含まれません）",
+      "definition_only": "大会の情報のみ共有します",
       "preview_title": "プレビュー",
       "preview_image_size": "生成画像（1080x1920）",
       "preview_alt": "共有画像プレビュー",
@@ -896,16 +900,19 @@
       }
     },
     "submit_bar": {
-      "summary": "送信待ち {{count}}件"
+      "summary": "未共有 {{count}}件",
+      "cta": "共有する（{{count}}）"
     },
     "submit_dialog": {
-      "title": "送信",
+      "title": "共有",
+      "confirm_message": "未共有の曲を共有します（{{count}}件）",
       "images_title": "送信する画像",
       "images_description": "画像が端末外に共有されます",
-      "target_count": "送信対象: {{count}}件",
+      "target_count": "未共有対象: {{count}}件",
       "message_title": "送信するメッセージ",
       "complete_title": "送信完了にする",
       "complete_description": "共有の成否は自動判定できません。相手に届いたことを確認後に実行してください。",
+      "undo_action": "元に戻す",
       "notice": {
         "saved_images_count": "{{count}}件の画像を保存しました。",
         "save_images_failed": "画像の保存に失敗しました。",
@@ -917,12 +924,16 @@
         "message_share_unsupported": "この環境ではメッセージ共有に対応していません。",
         "message_shared": "送信するメッセージを共有しました。",
         "message_share_failed": "メッセージ共有に失敗しました。",
-        "no_pending": "送信待ちはありません。",
+        "no_pending": "未共有はありません。",
+        "marked_shared": "共有済にしました",
+        "fallback_copy_failed": "画像を保存しましたが、メッセージのコピーに失敗しました。",
+        "undo_applied": "未共有に戻しました。",
+        "undo_failed": "元に戻す処理に失敗しました。",
         "completed_count": "{{count}}件を送信完了にしました。",
         "mark_completed_failed": "送信完了の更新に失敗しました。"
       },
       "error": {
-        "no_sendable_images": "送信できる送信待ち画像がありません。"
+        "no_sendable_images": "共有できる未共有画像がありません。"
       }
     }
   },

--- a/packages/web-app/src/i18n/locales/ko.json
+++ b/packages/web-app/src/i18n/locales/ko.json
@@ -813,7 +813,7 @@
   },
   "tournament_detail": {
     "action": {
-      "share_tournament": "스코어 어택 공유",
+      "share_tournament": "대회를 공유(QR)",
       "open_settings": "설정",
       "register": "등록",
       "replace": "교체",
@@ -822,8 +822,8 @@
       "copy_text": "텍스트 복사",
       "copy_logs": "로그 복사",
       "save_to_device": "기기에 저장",
-      "mark_send_completed": "전송 완료로 표시",
-      "submit": "전송"
+      "mark_send_completed": "삭제",
+      "submit": "공유하기"
     },
     "status": {
       "upcoming": "미개최",
@@ -835,6 +835,7 @@
       "period": "{{start}}〜{{end}}",
       "period_with_space": "{{start}} 〜 {{end}}",
       "progress": "등록 {{submitted}} / {{total}}",
+      "state_counts": "공유 완료 {{shared}} ・ 미공유 {{unshared}} ・ 미등록 {{unregistered}}",
       "last_updated": "최종 업데이트: {{date}}"
     },
     "chart": {
@@ -843,8 +844,11 @@
       "status": {
         "error": "오류",
         "pending": "미등록",
-        "submitted": "등록됨",
-        "send_pending": "전송 대기"
+        "submitted": "공유 완료",
+        "send_pending": "미공유",
+        "unregistered": "미등록",
+        "unshared": "미공유",
+        "shared": "공유 완료"
       },
       "resolve_issue": {
         "mismatch": "일부 채보가 곡 데이터와 일치하지 않습니다.",
@@ -862,7 +866,7 @@
     },
     "share_dialog": {
       "close_aria_label": "공유 대화상자 닫기",
-      "definition_only": "공유되는 것은 스코어 어택 정의만이며(이미지는 포함되지 않음)",
+      "definition_only": "대회 정보만 공유합니다",
       "preview_title": "미리보기",
       "preview_image_size": "생성 이미지(1080x1920)",
       "preview_alt": "공유 이미지 미리보기",
@@ -896,16 +900,19 @@
       }
     },
     "submit_bar": {
-      "summary": "전송 대기 {{count}}건"
+      "summary": "미공유 {{count}}건",
+      "cta": "공유하기({{count}})"
     },
     "submit_dialog": {
-      "title": "전송",
+      "title": "공유",
+      "confirm_message": "미공유 곡을 공유합니다({{count}}건)",
       "images_title": "전송할 이미지",
       "images_description": "이미지가 기기 외부로 공유됩니다",
-      "target_count": "전송 대상: {{count}}건",
+      "target_count": "미공유 대상: {{count}}건",
       "message_title": "전송할 메시지",
       "complete_title": "전송 완료로 표시",
       "complete_description": "공유 성공 여부는 자동 판정할 수 없습니다. 상대에게 도달했는지 확인한 뒤 실행하세요.",
+      "undo_action": "되돌리기",
       "notice": {
         "saved_images_count": "{{count}}건의 이미지를 저장했습니다.",
         "save_images_failed": "이미지 저장에 실패했습니다.",
@@ -917,12 +924,16 @@
         "message_share_unsupported": "이 환경에서는 메시지 공유를 지원하지 않습니다.",
         "message_shared": "전송할 메시지를 공유했습니다.",
         "message_share_failed": "메시지 공유에 실패했습니다.",
-        "no_pending": "전송 대기가 없습니다.",
+        "no_pending": "미공유가 없습니다.",
+        "marked_shared": "공유 완료로 처리했습니다.",
+        "fallback_copy_failed": "이미지는 저장했지만 메시지 복사에 실패했습니다.",
+        "undo_applied": "미공유로 되돌렸습니다.",
+        "undo_failed": "되돌리기에 실패했습니다.",
         "completed_count": "{{count}}건을 전송 완료로 처리했습니다.",
         "mark_completed_failed": "전송 완료 상태 업데이트에 실패했습니다."
       },
       "error": {
-        "no_sendable_images": "전송할 수 있는 전송 대기 이미지가 없습니다."
+        "no_sendable_images": "공유할 수 있는 미공유 이미지가 없습니다."
       }
     }
   },

--- a/packages/web-app/src/styles.css
+++ b/packages/web-app/src/styles.css
@@ -1039,6 +1039,41 @@ label {
   gap: 10px;
 }
 
+.detailStateProgressBar {
+  width: 100%;
+  height: 10px;
+  border-radius: 999px;
+  background: #e2e8f0;
+  overflow: hidden;
+  display: flex;
+}
+
+.detailStateProgressSegment {
+  height: 100%;
+  min-width: 0;
+}
+
+.detailStateProgressSegment-shared {
+  background: #9fd4ac;
+}
+
+.detailStateProgressSegment-unshared {
+  background: #f2d3a2;
+}
+
+.detailStateProgressSegment-unregistered {
+  background: #cfd8e3;
+}
+
+.detailStateProgressSummary {
+  margin: 0;
+  color: #475569;
+  font-size: 13px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .detailRemainingBadge {
   display: inline-flex;
   align-items: center;
@@ -1069,12 +1104,25 @@ label {
   background: #e2e8f0;
 }
 
+.detailShareArea {
+  display: grid;
+  justify-items: end;
+  gap: 6px;
+  min-width: 180px;
+}
+
 .detailShareButton {
-  min-width: 120px;
-  border-color: #bfdbfe;
-  background: #eff6ff;
-  color: #1e40af;
+  min-width: 168px;
+  border-color: #cbd5e1;
+  background: #ffffff;
+  color: #334155;
   font-weight: 700;
+}
+
+.detailShareHint {
+  margin: 0;
+  color: #64748b;
+  font-size: 12px;
 }
 
 .detailLastUpdated {
@@ -1141,43 +1189,33 @@ label {
   gap: 6px;
   flex-wrap: nowrap;
   overflow: hidden;
-}
-
-.chartPlayStyleText,
-.chartDifficultyTag,
-.chartLevelTag {
-  display: inline-flex;
-  align-items: center;
-  font-size: 12px;
-  font-weight: 700;
-  line-height: 1;
+  font-size: 13px;
+  line-height: 1.35;
 }
 
 .chartPlayStyleText {
+  display: inline-flex;
+  align-items: center;
+  font-weight: 700;
   color: #334155;
   white-space: nowrap;
 }
 
-.chartDifficultyTag {
-  border-radius: 999px;
-  border: 2px solid #cbd5e1;
-  border-width: 2px;
-  padding: 4px 8px;
-  text-transform: uppercase;
+.chartMetaSeparator {
+  color: #94a3b8;
+  font-weight: 700;
   white-space: nowrap;
 }
 
-.chartLevelTag {
-  border-radius: 999px;
-  border: 1px solid #cbd5e1;
-  padding: 4px 8px;
-  color: #0f172a;
-  background: #e2e8f0;
+.chartDifficultyLevelText {
+  font-weight: 700;
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
-.chartSubmitLabel {
-  min-width: 56px;
+.chartStateBadge {
+  min-width: 64px;
   text-align: center;
   border-radius: 999px;
   font-size: 12px;
@@ -1185,37 +1223,25 @@ label {
   padding: 4px 8px;
 }
 
-.chartSubmitLabel.pending {
-  color: #334155;
+.chartStateBadge-unregistered {
+  color: #475569;
   background: #e2e8f0;
 }
 
-.chartSubmitLabel.submitted {
-  color: #166534;
-  background: #dcfce7;
+.chartStateBadge-unshared {
+  color: #9a3412;
+  background: #ffedd5;
 }
 
-.chartSubmitLabel.error {
-  color: #b91c1c;
-  background: #fee2e2;
+.chartStateBadge-shared {
+  color: #166534;
+  background: #dcfce7;
 }
 
 .chartStatusLine {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-}
-
-.chartSendPendingBadge {
-  display: inline-flex;
-  align-items: center;
-  border-radius: 999px;
-  padding: 4px 8px;
-  font-size: 11px;
-  font-weight: 700;
-  color: #9a3412;
-  background: #ffedd5;
-  white-space: nowrap;
 }
 
 .chartActions {
@@ -1723,6 +1749,11 @@ label {
   .tournamentDetailHeader {
     flex-direction: column;
     align-items: stretch;
+  }
+
+  .detailShareArea {
+    justify-items: stretch;
+    min-width: 0;
   }
 
   .detailShareButton {

--- a/tasks/feat-share-state3-redesign.md
+++ b/tasks/feat-share-state3-redesign.md
@@ -1,0 +1,121 @@
+# Plan: feat/share-state3-redesign
+
+## 目的
+
+- スコアタ詳細の提出導線を「送信」から「共有」に統一する。
+- 譜面状態を `未登録 / 未共有 / 共有済` の3状態で明確化する。
+- 進捗表示を登録率ではなく状態分布（3分割バー）に再設計する。
+- 共有完了後に `needs_send` を自動更新し、直前操作のみ UNDO 可能にする。
+
+## 非目的
+
+- DB スキーマ変更（`user_version` 変更、マイグレーション追加）は行わない。
+- Single-tab（Web Locks）関連ロジックは変更しない。
+- 大会定義共有（QR）画像生成ロジック自体の仕様変更は行わない。
+- SubmitEvidencePage など詳細ページ外のUX刷新は行わない。
+
+## 変更点
+
+- 用語置換: UI文言を「送信」系から「共有」系へ更新（内部名 `needs_send` は維持）。
+- 譜面カード状態の導出を3状態に再定義し、バッジ表示を単一化。
+- 譜面属性表示をバッジから1行テキストに簡素化（`DP/SP ・ 難易度 レベル`、難易度側のみ文字色）。
+- 進捗エリアを3分割状態バー + 横並び件数表示へ置換。
+- 下部固定CTAを単一ボタン「共有する（n）」に統一（`n=未共有件数`、0件で無効）。
+- 提出共有UIを確認ダイアログ化（本文 + キャンセル + 共有する）し、冗長導線を排除。
+- 共有処理を Web Share files 対応有無で内部分岐し、非対応時は保存+コピーへフォールバック。
+- 共有成功時のみ `needs_send=false` を永続化し、UNDOで直前操作分を `needs_send=true` に戻せるようにする。
+- 共有結果通知は下部スナックバー（3〜5秒）に統一し、UNDOを同一通知上で提供する。
+- 差し替え時に `needs_send=true` となる既存挙動（未共有復帰）を維持。
+- ヘッダの大会定義共有ボタンを「大会を共有（QR）」文言で継続配置。
+
+## 影響範囲
+
+- ユーザー影響:
+  - 詳細画面の状態表示、進捗表示、下部CTA、提出共有モーダルの操作が変更される。
+  - 共有成功後は手動確定不要で自動的に共有済へ遷移し、短時間UNDO可能になる。
+- データ影響:
+  - `needs_send` 更新タイミングのみ変更（共有成功時/UNDO時）。
+  - スキーマ、既存レコード形式、`update_seq` 運用は不変。
+- 互換性:
+  - 既存DBとの互換性維持（マイグレーションなし）。
+  - Web Share API 非対応環境でも保存+コピーで操作継続可能。
+
+## 実装方針（対象ファイル単位）
+
+- `packages/web-app/src/pages/TournamentDetailPage.tsx`
+  - 状態導出ロジック（未登録/未共有/共有済）を追加。
+  - 3分割バー表示データを計算し、従来進捗バーを置換。
+  - 譜面カードバッジ表示を単一化し、属性バッジ（DP/SP・難易度・Lv）を撤去してテキスト表示に置換。
+  - 下部CTA文言/有効条件を変更。
+  - submit dialog を確認ダイアログ（キャンセル/共有する）へ変更。
+  - 共有処理を統合し、成功時の `needs_send=false` 更新 + UNDO処理を追加。
+  - 共有後通知をスナックバー化し、表示秒数を3〜5秒に調整。
+  - 共有（QR）ボタン文言と補助説明を調整。
+- `packages/db/src/app-db.ts`
+  - `needs_send=true` へ戻すための更新メソッドを追加（UNDO専用）。
+  - 既存 `markEvidenceSendCompleted` と同等の安全条件（`file_deleted=0`, `update_seq>0`）を維持。
+- `packages/web-app/src/styles.css`
+  - 3状態バッジ、3分割バー、件数表示、下部CTAの見た目を追加/調整。
+  - 彩度抑制トーンで配色調整。
+- `packages/web-app/src/i18n/locales/ja.json`
+  - `tournament_detail` 配下の提出共有関連文言を新仕様へ更新。
+- `packages/web-app/src/i18n/locales/en.json`
+  - 同キーの英語文言を同期更新。
+- `packages/web-app/src/i18n/locales/ko.json`
+  - 同キーの韓国語文言を同期更新。
+- `packages/web-app/src/pages/TournamentDetailPage.test.tsx`
+  - 新UI/新遷移（3状態、CTA、モーダル単一ボタン、自動確定+UNDO）に合わせてテスト更新。
+
+## テスト観点
+
+- 譜面カード:
+  - 各譜面でバッジが必ず1つのみ表示される。
+  - `evidenceなし or file_deleted=true` は未登録、`needs_send=true` は未共有、`needs_send=false` は共有済。
+  - DP/SP と 難易度+レベルが1行テキスト（`DP ・ ANOTHER 10`）で表示され、属性背景バッジが存在しない。
+- 進捗表示:
+  - 3分割バー比率が `共有済/未共有/未登録` 件数に一致する。
+  - 件数表示が横並びで表示される。
+- CTA/モーダル:
+  - 下部ボタンは1つのみ、未共有0件で無効。
+  - 提出共有は確認ダイアログ（本文 + キャンセル + 共有する）で表示される。
+- 共有処理:
+  - Web Share files 対応時は `navigator.share({ files, text })` が呼ばれる。
+  - 非対応時は画像保存 + クリップボードコピーのフォールバックが動作する。
+  - 成功時のみ `needs_send=false` が反映される。
+  - 通知はスナックバー表示となり、UNDOで直前共有分のみ `needs_send=true` に戻る。
+- 回帰:
+  - 差し替え保存後は未共有に戻る（既存 `upsertEvidenceMetadata` 挙動を維持）。
+  - 大会定義共有（QR）ボタンがヘッダに残る。
+
+## ロールバック方針
+
+- UIのみ不具合の場合:
+  - `TournamentDetailPage.tsx` / `styles.css` / i18n差分を丸ごと戻す。
+- `needs_send` 更新不具合の場合:
+  - `app-db.ts` の追加メソッド呼び出しを戻し、従来の手動完了フローへ復帰。
+- ロールバック単位:
+  - 共有モーダル再設計
+  - 3状態表示/3分割バー
+  - 自動確定+UNDO
+  を論理単位で分離して戻せるようにコミット分割する。
+
+## Commit Plan
+
+1. detailページの状態導出・3分割バー・カードバッジ/CTA変更。
+2. 提出共有モーダル1ボタン化と共有分岐ロジック統合（成功時自動確定含む）。
+3. DBの `needs_send` 復帰メソッド追加とUNDO連携。
+4. i18n（ja/en/ko）文言更新。
+5. テスト更新と検証（lint/test/build、差分スコープ確認）。
+
+## Scope Declaration
+
+- 変更対象は以下に限定する。
+  - `tasks/feat-share-state3-redesign.md`
+  - `packages/web-app/src/pages/TournamentDetailPage.tsx`
+  - `packages/web-app/src/pages/TournamentDetailPage.test.tsx`
+  - `packages/web-app/src/styles.css`
+  - `packages/web-app/src/i18n/locales/ja.json`
+  - `packages/web-app/src/i18n/locales/en.json`
+  - `packages/web-app/src/i18n/locales/ko.json`
+  - `packages/db/src/app-db.ts`
+- 上記以外のファイル変更は禁止（必要が出た場合は本tasksを更新してから実施）。


### PR DESCRIPTION
## 目的
- スコアタ詳細の提出共有導線を「確認ダイアログ + 実行後スナックバー(UNDO付き)」へ簡素化する。
- 譜面カードの属性表示をノイズ削減し、状態バッジ（未登録/未共有/共有済）を主役にする。

## 変更点
- 譜面属性バッジ（DP/SP・難易度・Lv）を撤去し、`DP ・ ANOTHER 10` 形式の1行テキストに置換。
- 難易度+レベルは文字色のみで難易度トーン適用（背景バッジなし）。
- 提出共有UIを確認ダイアログ化（タイトル/本文/キャンセル/共有する）。
- 提出共有の冗長UI（保存/コピー/個別共有/手動完了）を画面から削除。
- 共有処理を1ボタンに集約（Web Share files対応時はshare、非対応/失敗時は保存+Clipboardフォールバック）。
- 成功条件を満たした場合のみ `needs_send=false` に更新し、スナックバーで `共有済にしました [元に戻す]` を表示。
- UNDOで直前共有分のみ `needs_send=true` に復元。
- `AppDatabase` に UNDO 用 `markEvidenceSendPending` を追加。
- ja/en/ko の `tournament_detail` 文言を新仕様へ同期。
- 詳細ページテストを新UI/新遷移に合わせて更新。

## 非変更点
- DBスキーマ変更なし（migrationなし、`user_version` 変更なし）。
- Single-tab invariant（Web Locks/BroadcastChannel/storage event）関連変更なし。
- 大会定義共有（QR）機能のコアロジック変更なし。

## 影響範囲
- ユーザー: スコアタ詳細の譜面属性表示、提出共有ダイアログ、共有完了通知UXが変更。
- データ: `needs_send` の更新タイミング/復元導線のみ変更。
- 互換性: 既存データ互換性維持、Web Share非対応環境はフォールバックで継続利用可能。

## テスト内容
- `pnpm --filter @iidx/web-app lint`
- `pnpm --filter @iidx/db lint`
- `pnpm --filter @iidx/web-app test`
- `pnpm --filter @iidx/db test`
- `pnpm --filter @iidx/web-app build`
- `pnpm --filter @iidx/db build`

## 回帰確認項目
- 譜面カード状態バッジが常に1つのみ表示される。
- DP/SPが常に表示され、属性は1行テキスト表示で背景バッジがない。
- 下部CTAが `共有する（n）` で、未共有0件時は無効。
- 提出共有ダイアログが確認用途のみ（キャンセル/共有する）である。
- 成功時のみ `needs_send=false` 更新され、UNDOで直前分のみ戻せる。
- 共有後通知が下部スナックバー表示である。

## Commit Plan (実施)
1. docs(tasks): add share-state3 redesign execution plan
2. feat(web-app): simplify chart meta and submit share confirmation UI
3. feat(db): add needs_send restore method for undo
4. chore(i18n): update tournament detail share strings
5. test(web-app): cover chart meta simplification and share confirm dialog
