### PR TITLE
feat(web-app): add debug sample seeding for home filter coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,28 @@ pnpm build
 pnpm test
 ```
 
+## 一覧フィルタ確認用サンプルデータ
+
+ホーム一覧のフィルタ確認用に、デバッグモード限定でサンプル大会を自動生成できます。
+
+1. 設定画面でアプリバージョンを 7 回タップしてデバッグモードを有効化
+2. ブラウザ DevTools Console で以下を実行
+
+```js
+await window.__IIDX_DEBUG__?.seedHomeFilterSamples?.();
+```
+
+- サンプルのみ削除したい場合:
+
+```js
+await window.__IIDX_DEBUG__?.clearHomeFilterSamples?.();
+```
+
+- 生成データは `state(active/upcoming/ended)`、`category(pending/completed)`、
+  `attr(imported/created/send-waiting)` を確認できる構成です。
+- 詳細画面/提出画面の遷移保証のため、投入時は曲マスタから有効な `chart_id` を収集します。
+  曲マスタ未取得状態では seed はエラーになります。
+
 ## i18n 運用ルール
 - 新規の表示文言は必ず i18n キーを追加し、UI 直書きを禁止する
 - i18n キーは不変とし、文言修正時は辞書 (`ja/en/ko`) のみ更新する

--- a/packages/web-app/src/App.tsx
+++ b/packages/web-app/src/App.tsx
@@ -75,6 +75,7 @@ import {
 import { resolveErrorMessage } from './utils/error-i18n';
 import { consumeWhatsNewVisibility } from './utils/whats-new';
 import { CURRENT_VERSION } from './version';
+import { registerHomeFilterSampleDebugApi } from './debug/home-filter-sample-seed';
 
 function todayJst(): string {
   const now = new Date();
@@ -763,7 +764,7 @@ async function resolveOpfsStatus(): Promise<AppInfoCardData['opfsStatus']> {
 }
 
 export function App({ webLockAcquired = false }: AppProps = {}): JSX.Element {
-  const { appDb, songMasterService } = useAppServices();
+  const { appDb, opfs, songMasterService } = useAppServices();
   const { t } = useTranslation();
 
   const [routeStack, setRouteStack] = React.useState<RouteState[]>(() => createInitialRouteStack());
@@ -2151,6 +2152,18 @@ export function App({ webLockAcquired = false }: AppProps = {}): JSX.Element {
     }
     setDetailTechnicalDialogOpen(false);
   }, [debugModeEnabled]);
+
+  React.useEffect(() => {
+    return registerHomeFilterSampleDebugApi({
+      enabled: debugModeEnabled,
+      appDb,
+      opfs,
+      todayDate,
+      onDataChanged: async () => {
+        await refreshTournamentList();
+      },
+    });
+  }, [appDb, debugModeEnabled, opfs, refreshTournamentList, todayDate]);
 
   if (fatalError) {
     return <UnsupportedScreen title={t('common.song_master.startup_error_title')} reasons={[fatalError]} />;

--- a/packages/web-app/src/debug/home-filter-sample-seed.test.ts
+++ b/packages/web-app/src/debug/home-filter-sample-seed.test.ts
@@ -1,0 +1,299 @@
+import type { AppDatabase, OpfsStorage } from '@iidx/db';
+import { describe, expect, it, vi } from 'vitest';
+
+import { buildHomeFilterSampleDefinitions, seedHomeFilterSamples } from './home-filter-sample-seed';
+
+function toDate(value: string): Date {
+  return new Date(`${value}T00:00:00.000Z`);
+}
+
+interface MockSeedEnvironmentOptions {
+  unresolvedDetail?: boolean;
+  insufficientSelectableCharts?: boolean;
+}
+
+interface MockEvidenceState {
+  updateSeq: number;
+  needsSend: boolean;
+  fileDeleted: boolean;
+}
+
+interface MockStoredTournament {
+  tournamentUuid: string;
+  chartIds: number[];
+  evidenceByChartId: Map<number, MockEvidenceState>;
+}
+
+function createMockSeedEnvironment(options: MockSeedEnvironmentOptions = {}): {
+  appDb: AppDatabase;
+  opfs: OpfsStorage;
+  getTournamentDetailMock: ReturnType<typeof vi.fn>;
+  markEvidenceSendCompletedMock: ReturnType<typeof vi.fn>;
+  writeFileAtomicMock: ReturnType<typeof vi.fn>;
+} {
+  const clock = {
+    todayJst: vi.fn(() => '2026-03-01'),
+  };
+  const tournaments = new Map<string, MockStoredTournament>();
+  const listRowsByTab: Record<'active' | 'upcoming' | 'ended', unknown[]> = {
+    active: [],
+    upcoming: [],
+    ended: [],
+  };
+  const songs = options.insufficientSelectableCharts
+    ? [{ musicId: 1 }]
+    : Array.from({ length: 9 }, (_, index) => ({
+      musicId: index + 1,
+    }));
+  const chartBySongAndStyle = new Map<number, { SP: number | null; DP: number | null }>();
+  let nextChartId = 910001;
+  songs.forEach((song) => {
+    const sp = nextChartId;
+    nextChartId += 1;
+    const dp = options.insufficientSelectableCharts ? null : nextChartId;
+    if (!options.insufficientSelectableCharts) {
+      nextChartId += 1;
+    }
+    chartBySongAndStyle.set(song.musicId, { SP: sp, DP: dp });
+  });
+  let createdSeq = 0;
+
+  const listTournamentsMock = vi.fn(async (tab: 'active' | 'upcoming' | 'ended') => listRowsByTab[tab] ?? []);
+  const deleteTournamentMock = vi.fn(async (_tournamentUuid: string) => undefined);
+  const searchSongsByPrefixMock = vi.fn(async (_prefix: string, _limit: number) => songs);
+  const getChartsByMusicAndStyleMock = vi.fn(async (musicId: number, style: 'SP' | 'DP') => {
+    const pair = chartBySongAndStyle.get(musicId);
+    const chartId = pair ? pair[style] : null;
+    if (!chartId) {
+      return [];
+    }
+    return [
+      {
+        chartId,
+        level: '12',
+        isActive: 1,
+      },
+    ];
+  });
+
+  const createTournamentMock = vi.fn(async (input: { chartIds: number[]; endDate: string }) => {
+    if (input.endDate < clock.todayJst()) {
+      throw new Error('TOURNAMENT_PAST_DATE_NOT_ALLOWED');
+    }
+    createdSeq += 1;
+    const tournamentUuid = `created-${createdSeq}`;
+    tournaments.set(tournamentUuid, {
+      tournamentUuid,
+      chartIds: [...input.chartIds],
+      evidenceByChartId: new Map(),
+    });
+    return tournamentUuid;
+  });
+  const importTournamentMock = vi.fn(async (payload: { uuid: string; charts: number[]; end: string }) => {
+    if (payload.end < clock.todayJst()) {
+      throw new Error('PAST_TOURNAMENT');
+    }
+    const tournamentUuid = payload.uuid;
+    tournaments.set(tournamentUuid, {
+      tournamentUuid,
+      chartIds: [...payload.charts],
+      evidenceByChartId: new Map(),
+    });
+    return {
+      tournamentUuid,
+    };
+  });
+
+  const getEvidenceRelativePathMock = vi.fn(async (tournamentUuid: string, chartId: number) => {
+    return `evidences/${tournamentUuid}/${chartId}.jpg`;
+  });
+  const upsertEvidenceMetadataMock = vi.fn(async (input: { tournamentUuid: string; chartId: number }) => {
+    const row = tournaments.get(input.tournamentUuid);
+    if (!row) {
+      throw new Error(`Tournament not found: ${input.tournamentUuid}`);
+    }
+    row.evidenceByChartId.set(input.chartId, {
+      updateSeq: 1,
+      needsSend: true,
+      fileDeleted: false,
+    });
+  });
+  const markEvidenceSendCompletedMock = vi.fn(async (tournamentUuid: string, chartIds: number[]) => {
+    const row = tournaments.get(tournamentUuid);
+    if (!row) {
+      throw new Error(`Tournament not found: ${tournamentUuid}`);
+    }
+    chartIds.forEach((chartId) => {
+      const existing = row.evidenceByChartId.get(chartId);
+      if (!existing) {
+        throw new Error(`Evidence not found: ${tournamentUuid}/${chartId}`);
+      }
+      row.evidenceByChartId.set(chartId, {
+        ...existing,
+        needsSend: false,
+      });
+    });
+  });
+
+  const getTournamentDetailMock = vi.fn(async (tournamentUuid: string) => {
+    const row = tournaments.get(tournamentUuid);
+    if (!row) {
+      return null;
+    }
+    return {
+      tournamentUuid,
+      charts: row.chartIds.map((chartId, index) => {
+        const evidence = row.evidenceByChartId.get(chartId);
+        return {
+          chartId,
+          resolveIssue: options.unresolvedDetail && index === 0 ? 'missing_song_master' : null,
+          updateSeq: evidence?.updateSeq ?? 0,
+          fileDeleted: evidence?.fileDeleted ?? false,
+          needsSend: evidence?.needsSend ?? false,
+        };
+      }),
+    };
+  });
+
+  const appDb = {
+    clock,
+    listTournaments: listTournamentsMock,
+    deleteTournament: deleteTournamentMock,
+    searchSongsByPrefix: searchSongsByPrefixMock,
+    getChartsByMusicAndStyle: getChartsByMusicAndStyleMock,
+    createTournament: createTournamentMock,
+    importTournament: importTournamentMock,
+    getEvidenceRelativePath: getEvidenceRelativePathMock,
+    upsertEvidenceMetadata: upsertEvidenceMetadataMock,
+    markEvidenceSendCompleted: markEvidenceSendCompletedMock,
+    getTournamentDetail: getTournamentDetailMock,
+  } as unknown as AppDatabase;
+
+  const writeFileAtomicMock = vi.fn(async (_path: string, _bytes: Uint8Array) => undefined);
+  const opfs = {
+    writeFileAtomic: writeFileAtomicMock,
+  } as unknown as OpfsStorage;
+
+  return {
+    appDb,
+    opfs,
+    getTournamentDetailMock,
+    markEvidenceSendCompletedMock,
+    writeFileAtomicMock,
+  };
+}
+
+describe('home-filter-sample-seed', () => {
+  it('builds definitions that cover state/source/category/send-waiting filters', () => {
+    const today = '2026-03-01';
+    const rows = buildHomeFilterSampleDefinitions(today);
+
+    expect(rows.length).toBeGreaterThanOrEqual(6);
+
+    const states = new Set(rows.map((row) => row.state));
+    expect(states).toEqual(new Set(['active', 'upcoming', 'ended']));
+
+    const sources = new Set(rows.map((row) => row.source));
+    expect(sources).toEqual(new Set(['created', 'imported']));
+
+    const hasSendWaiting = rows.some((row) => row.unsharedChartIndexes.length > 0);
+    expect(hasSendWaiting).toBe(true);
+
+    const hasNoEvidenceFlow = rows.some((row) => row.sharedChartIndexes.length + row.unsharedChartIndexes.length < row.chartIds.length);
+    const hasSharedFlow = rows.some((row) => row.sharedChartIndexes.length > 0);
+    const hasUnsharedFlow = rows.some((row) => row.unsharedChartIndexes.length > 0);
+    expect(hasNoEvidenceFlow).toBe(true);
+    expect(hasSharedFlow).toBe(true);
+    expect(hasUnsharedFlow).toBe(true);
+
+    const categories = new Set(
+      rows.map((row) => {
+        const submittedCount = row.sharedChartIndexes.length + row.unsharedChartIndexes.length;
+        return submittedCount === row.chartIds.length ? 'completed' : 'pending';
+      }),
+    );
+    expect(categories).toEqual(new Set(['pending', 'completed']));
+  });
+
+  it('assigns date ranges by state relative to today', () => {
+    const today = '2026-03-01';
+    const todayDate = toDate(today);
+    const rows = buildHomeFilterSampleDefinitions(today);
+
+    rows.forEach((row) => {
+      const start = toDate(row.startDate);
+      const end = toDate(row.endDate);
+      expect(start.getTime()).toBeLessThanOrEqual(end.getTime());
+
+      if (row.state === 'active') {
+        expect(start.getTime()).toBeLessThanOrEqual(todayDate.getTime());
+        expect(end.getTime()).toBeGreaterThanOrEqual(todayDate.getTime());
+      } else if (row.state === 'upcoming') {
+        expect(start.getTime()).toBeGreaterThan(todayDate.getTime());
+      } else {
+        expect(end.getTime()).toBeLessThan(todayDate.getTime());
+      }
+    });
+  });
+
+  it('seeds tournaments that keep detail/submit flows resolvable', async () => {
+    const mock = createMockSeedEnvironment();
+    const result = await seedHomeFilterSamples({
+      appDb: mock.appDb,
+      opfs: mock.opfs,
+      todayDate: '2026-03-01',
+    });
+
+    expect(result.createdSampleCount).toBeGreaterThan(0);
+    expect(mock.writeFileAtomicMock).toHaveBeenCalled();
+    expect(mock.markEvidenceSendCompletedMock).toHaveBeenCalled();
+
+    let hasNoEvidenceChart = false;
+    let hasUnsharedEvidenceChart = false;
+    let hasSharedEvidenceChart = false;
+
+    for (const entry of result.created) {
+      const detail = await mock.getTournamentDetailMock(entry.tournamentUuid);
+      expect(detail).not.toBeNull();
+      for (const chart of detail.charts) {
+        expect(chart.resolveIssue).toBeNull();
+        const localSaved = chart.updateSeq > 0 && !chart.fileDeleted;
+        if (!localSaved) {
+          hasNoEvidenceChart = true;
+        } else if (chart.needsSend) {
+          hasUnsharedEvidenceChart = true;
+        } else {
+          hasSharedEvidenceChart = true;
+        }
+      }
+    }
+
+    expect(hasNoEvidenceChart).toBe(true);
+    expect(hasUnsharedEvidenceChart).toBe(true);
+    expect(hasSharedEvidenceChart).toBe(true);
+  });
+
+  it('fails fast when detail is not resolvable', async () => {
+    const mock = createMockSeedEnvironment({ unresolvedDetail: true });
+
+    await expect(
+      seedHomeFilterSamples({
+        appDb: mock.appDb,
+        opfs: mock.opfs,
+        todayDate: '2026-03-01',
+      }),
+    ).rejects.toThrow(/Sample tournament has unresolved charts/);
+  });
+
+  it('fails fast when song master charts are insufficient', async () => {
+    const mock = createMockSeedEnvironment({ insufficientSelectableCharts: true });
+
+    await expect(
+      seedHomeFilterSamples({
+        appDb: mock.appDb,
+        opfs: mock.opfs,
+        todayDate: '2026-03-01',
+      }),
+    ).rejects.toThrow(/Not enough selectable charts from song master/);
+  });
+});

--- a/packages/web-app/src/debug/home-filter-sample-seed.ts
+++ b/packages/web-app/src/debug/home-filter-sample-seed.ts
@@ -1,0 +1,585 @@
+import type { AppDatabase, ChartSummary, OpfsStorage, TournamentListItem, TournamentTab } from '@iidx/db';
+import { PAYLOAD_VERSION, normalizeHashtag, sha256Hex, type TournamentPayload } from '@iidx/shared';
+
+const HOME_FILTER_SAMPLE_HASHTAG = 'FILTER_SAMPLE';
+const HOME_FILTER_SAMPLE_OWNER = 'sample-bot';
+const SAMPLE_IMAGE_BASE64 =
+  '/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAkGBxAQEBUQEBAVFRUVFRUVFRUVFRUVFRUVFRUWFhUVFRUYHSggGBolGxUVITEhJSkrLi4uFx8zODMsNygtLisBCgoKDg0OFQ8PFSsdFR0rKystKy0rKysrKysrKysrKysrKysrKysrKysrKysrKysrKysrKysrKysrKysrKysrK//AABEIAAEAAQMBIgACEQEDEQH/xAAbAAADAQEBAQEAAAAAAAAAAAAABQYDBEcCAf/EADUQAAIBAgQDBgQEBwAAAAAAAAECEQADBBIhMQVBUQYiYXGBEzKRobHR8EJScoKS4SNDU3L/xAAaAQADAQEBAQAAAAAAAAAAAAABAgMABAUH/8QAKREAAgICAgEDBAMBAAAAAAAAAAECEQMhEjEEE0FRImFxgZGhsfAUMkL/2gAMAwEAAhEDEQA/ANxREQBERAEREAREQBERAEREAREQBERAEREAREQBERAEREA//9k=';
+
+type SampleTournamentState = 'active' | 'upcoming' | 'ended';
+type SampleTournamentSource = 'created' | 'imported';
+type SampleCategory = 'pending' | 'completed';
+
+interface HomeFilterSampleDefinition {
+  key: string;
+  name: string;
+  source: SampleTournamentSource;
+  state: SampleTournamentState;
+  chartIds: number[];
+  sharedChartIndexes: number[];
+  unsharedChartIndexes: number[];
+  startDate: string;
+  endDate: string;
+}
+
+interface HomeFilterSampleTemplate {
+  key: string;
+  name: string;
+  source: SampleTournamentSource;
+  state: SampleTournamentState;
+  chartCount: number;
+  sharedChartIndexes: number[];
+  unsharedChartIndexes: number[];
+}
+
+export interface HomeFilterSampleSeedItem {
+  key: string;
+  name: string;
+  tournamentUuid: string;
+  source: SampleTournamentSource;
+  state: SampleTournamentState;
+  chartCount: number;
+  submittedCount: number;
+  sendWaitingCount: number;
+  category: SampleCategory;
+}
+
+export interface HomeFilterSampleSeedResult {
+  deletedSampleCount: number;
+  createdSampleCount: number;
+  created: HomeFilterSampleSeedItem[];
+}
+
+export interface HomeFilterSampleClearResult {
+  deletedSampleCount: number;
+}
+
+interface HomeFilterSampleSeedOptions {
+  appDb: AppDatabase;
+  opfs: OpfsStorage;
+  todayDate: string;
+  resetExisting?: boolean;
+}
+
+const SONG_SEARCH_LIMIT = 120;
+const SAMPLE_SEED_VALIDATION_BACKDATE_DAYS = -30;
+
+interface RegisterHomeFilterSampleDebugApiOptions {
+  enabled: boolean;
+  appDb: AppDatabase;
+  opfs: OpfsStorage;
+  todayDate: string;
+  onDataChanged?: () => Promise<void> | void;
+}
+
+type SeedHomeFilterSamplesFn = (options?: { resetExisting?: boolean }) => Promise<HomeFilterSampleSeedResult>;
+type ClearHomeFilterSamplesFn = () => Promise<HomeFilterSampleClearResult>;
+
+interface IidxDebugApi {
+  seedHomeFilterSamples?: SeedHomeFilterSamplesFn;
+  clearHomeFilterSamples?: ClearHomeFilterSamplesFn;
+  [key: string]: unknown;
+}
+
+declare global {
+  interface Window {
+    __IIDX_DEBUG__?: IidxDebugApi;
+  }
+}
+
+function addDays(dateText: string, days: number): string {
+  const base = new Date(`${dateText}T00:00:00.000Z`);
+  base.setUTCDate(base.getUTCDate() + days);
+  return base.toISOString().slice(0, 10);
+}
+
+interface AppDatabaseClockAccessor {
+  clock?: {
+    todayJst?: () => string;
+  };
+}
+
+async function withTemporaryAppDatabaseToday<T>(
+  appDb: AppDatabase,
+  temporaryTodayDate: string,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const accessor = appDb as unknown as AppDatabaseClockAccessor;
+  const clock = accessor.clock;
+  if (!clock || typeof clock.todayJst !== 'function') {
+    return operation();
+  }
+  const originalTodayJst = clock.todayJst;
+  clock.todayJst = () => temporaryTodayDate;
+  try {
+    return await operation();
+  } finally {
+    clock.todayJst = originalTodayJst;
+  }
+}
+
+function resolveStatePeriod(state: SampleTournamentState, todayDate: string): { startDate: string; endDate: string } {
+  if (state === 'active') {
+    return {
+      startDate: addDays(todayDate, -4),
+      endDate: addDays(todayDate, 6),
+    };
+  }
+  if (state === 'upcoming') {
+    return {
+      startDate: addDays(todayDate, 2),
+      endDate: addDays(todayDate, 10),
+    };
+  }
+  return {
+    startDate: addDays(todayDate, -12),
+    endDate: addDays(todayDate, -2),
+  };
+}
+
+function decodeBase64(base64: string): Uint8Array {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+function indexesToChartIds(chartIds: number[], indexes: number[]): number[] {
+  const result: number[] = [];
+  indexes.forEach((index) => {
+    if (!Number.isInteger(index) || index < 0 || index >= chartIds.length) {
+      throw new Error(`Invalid sample chart index: ${index}`);
+    }
+    const chartId = chartIds[index];
+    if (chartId === undefined) {
+      throw new Error(`Chart ID not found for sample index: ${index}`);
+    }
+    result.push(chartId);
+  });
+  return result;
+}
+
+function dedupeByTournamentUuid(items: TournamentListItem[]): TournamentListItem[] {
+  const map = new Map<string, TournamentListItem>();
+  items.forEach((item) => {
+    map.set(item.tournamentUuid, item);
+  });
+  return Array.from(map.values());
+}
+
+async function listAllTournaments(appDb: AppDatabase): Promise<TournamentListItem[]> {
+  const tabs: TournamentTab[] = ['active', 'upcoming', 'ended'];
+  const rows = await Promise.all(tabs.map((tab) => appDb.listTournaments(tab)));
+  return dedupeByTournamentUuid(rows.flat());
+}
+
+function isSampleTournament(item: TournamentListItem): boolean {
+  return normalizeHashtag(item.hashtag) === HOME_FILTER_SAMPLE_HASHTAG;
+}
+
+function buildSampleTemplate(): HomeFilterSampleTemplate[] {
+  const templates: HomeFilterSampleTemplate[] = [
+    {
+      key: 'created-active-pending-send-waiting',
+      name: 'SAMPLE Created Active Pending SendWaiting',
+      source: 'created',
+      state: 'active',
+      chartCount: 3,
+      sharedChartIndexes: [],
+      unsharedChartIndexes: [0],
+    },
+    {
+      key: 'created-active-completed-shared',
+      name: 'SAMPLE Created Active Completed Shared',
+      source: 'created',
+      state: 'active',
+      chartCount: 2,
+      sharedChartIndexes: [0, 1],
+      unsharedChartIndexes: [],
+    },
+    {
+      key: 'imported-active-completed-send-waiting',
+      name: 'SAMPLE Imported Active Completed SendWaiting',
+      source: 'imported',
+      state: 'active',
+      chartCount: 2,
+      sharedChartIndexes: [0],
+      unsharedChartIndexes: [1],
+    },
+    {
+      key: 'imported-upcoming-pending-unregistered',
+      name: 'SAMPLE Imported Upcoming Pending Unregistered',
+      source: 'imported',
+      state: 'upcoming',
+      chartCount: 3,
+      sharedChartIndexes: [],
+      unsharedChartIndexes: [],
+    },
+    {
+      key: 'created-upcoming-completed-shared',
+      name: 'SAMPLE Created Upcoming Completed Shared',
+      source: 'created',
+      state: 'upcoming',
+      chartCount: 1,
+      sharedChartIndexes: [0],
+      unsharedChartIndexes: [],
+    },
+    {
+      key: 'created-upcoming-pending-shared',
+      name: 'SAMPLE Created Upcoming Pending Shared',
+      source: 'created',
+      state: 'upcoming',
+      chartCount: 2,
+      sharedChartIndexes: [0],
+      unsharedChartIndexes: [],
+    },
+    {
+      key: 'imported-ended-pending-send-waiting',
+      name: 'SAMPLE Imported Ended Pending SendWaiting',
+      source: 'imported',
+      state: 'ended',
+      chartCount: 2,
+      sharedChartIndexes: [],
+      unsharedChartIndexes: [0],
+    },
+    {
+      key: 'created-ended-completed-send-waiting',
+      name: 'SAMPLE Created Ended Completed SendWaiting',
+      source: 'created',
+      state: 'ended',
+      chartCount: 2,
+      sharedChartIndexes: [0],
+      unsharedChartIndexes: [1],
+    },
+    {
+      key: 'imported-ended-completed-shared',
+      name: 'SAMPLE Imported Ended Completed Shared',
+      source: 'imported',
+      state: 'ended',
+      chartCount: 1,
+      sharedChartIndexes: [0],
+      unsharedChartIndexes: [],
+    },
+  ];
+  return templates;
+}
+
+function countRequiredCharts(templates: HomeFilterSampleTemplate[]): number {
+  return templates.reduce((total, template) => total + template.chartCount, 0);
+}
+
+function buildFallbackChartPool(requiredCount: number): number[] {
+  return Array.from({ length: requiredCount }, (_, index) => 810001 + index);
+}
+
+function assignChartsToTemplates(
+  templates: HomeFilterSampleTemplate[],
+  chartPool: number[],
+  todayDate: string,
+): HomeFilterSampleDefinition[] {
+  const requiredCount = countRequiredCharts(templates);
+  if (chartPool.length < requiredCount) {
+    throw new Error(`Insufficient chart IDs for sample seed. required=${requiredCount}, got=${chartPool.length}`);
+  }
+
+  let cursor = 0;
+  return templates.map((template) => {
+    const chartIds = chartPool.slice(cursor, cursor + template.chartCount);
+    cursor += template.chartCount;
+    const period = resolveStatePeriod(template.state, todayDate);
+    return {
+      ...template,
+      chartIds,
+      startDate: period.startDate,
+      endDate: period.endDate,
+    };
+  });
+}
+
+export function buildHomeFilterSampleDefinitions(todayDate: string): HomeFilterSampleDefinition[] {
+  const templates = buildSampleTemplate();
+  const fallbackChartPool = buildFallbackChartPool(countRequiredCharts(templates));
+  return assignChartsToTemplates(templates, fallbackChartPool, todayDate);
+}
+
+function isSelectableChart(chart: ChartSummary): boolean {
+  if (!Number.isInteger(chart.chartId) || chart.chartId <= 0) {
+    return false;
+  }
+  if (chart.isActive !== 1) {
+    return false;
+  }
+  const levelText = String(chart.level ?? '').trim();
+  return levelText.length > 0 && levelText !== '0' && levelText !== '-';
+}
+
+async function collectSongMasterChartPool(appDb: AppDatabase, requiredCount: number): Promise<number[]> {
+  const songs = await appDb.searchSongsByPrefix('', SONG_SEARCH_LIMIT);
+  if (songs.length === 0) {
+    throw new Error('Song master is required to seed home filter samples. No songs found.');
+  }
+
+  const chartPool: number[] = [];
+  const seen = new Set<number>();
+  for (const song of songs) {
+    const [spCharts, dpCharts] = await Promise.all([
+      appDb.getChartsByMusicAndStyle(song.musicId, 'SP'),
+      appDb.getChartsByMusicAndStyle(song.musicId, 'DP'),
+    ]);
+    [...spCharts, ...dpCharts]
+      .filter(isSelectableChart)
+      .forEach((chart) => {
+        if (seen.has(chart.chartId)) {
+          return;
+        }
+        seen.add(chart.chartId);
+        chartPool.push(chart.chartId);
+      });
+    if (chartPool.length >= requiredCount) {
+      break;
+    }
+  }
+
+  if (chartPool.length < requiredCount) {
+    throw new Error(
+      `Not enough selectable charts from song master. required=${requiredCount}, available=${chartPool.length}`,
+    );
+  }
+  return chartPool;
+}
+
+async function buildHomeFilterSampleDefinitionsFromSongMaster(
+  appDb: AppDatabase,
+  todayDate: string,
+): Promise<HomeFilterSampleDefinition[]> {
+  const templates = buildSampleTemplate();
+  const requiredCount = countRequiredCharts(templates);
+  const chartPool = await collectSongMasterChartPool(appDb, requiredCount);
+  return assignChartsToTemplates(templates, chartPool, todayDate);
+}
+
+async function createSampleTournament(
+  appDb: AppDatabase,
+  definition: HomeFilterSampleDefinition,
+): Promise<string> {
+  if (definition.source === 'created') {
+    return appDb.createTournament({
+      tournamentName: definition.name,
+      owner: HOME_FILTER_SAMPLE_OWNER,
+      hashtag: HOME_FILTER_SAMPLE_HASHTAG,
+      startDate: definition.startDate,
+      endDate: definition.endDate,
+      chartIds: definition.chartIds,
+    });
+  }
+
+  const payload: TournamentPayload = {
+    v: PAYLOAD_VERSION,
+    uuid: crypto.randomUUID(),
+    name: definition.name,
+    owner: HOME_FILTER_SAMPLE_OWNER,
+    hashtag: HOME_FILTER_SAMPLE_HASHTAG,
+    start: definition.startDate,
+    end: definition.endDate,
+    charts: definition.chartIds,
+  };
+  const imported = await appDb.importTournament(payload);
+  return imported.tournamentUuid;
+}
+
+async function upsertEvidenceSet(
+  appDb: AppDatabase,
+  opfs: OpfsStorage,
+  tournamentUuid: string,
+  chartIds: number[],
+  imageBytes: Uint8Array,
+  sha256: string,
+): Promise<void> {
+  for (const chartId of chartIds) {
+    const relativePath = await appDb.getEvidenceRelativePath(tournamentUuid, chartId);
+    await opfs.writeFileAtomic(relativePath, imageBytes);
+    await appDb.upsertEvidenceMetadata({
+      tournamentUuid,
+      chartId,
+      sha256,
+      width: 1,
+      height: 1,
+    });
+  }
+}
+
+function toSampleItem(definition: HomeFilterSampleDefinition, tournamentUuid: string): HomeFilterSampleSeedItem {
+  const submittedCount = definition.sharedChartIndexes.length + definition.unsharedChartIndexes.length;
+  const sendWaitingCount = definition.unsharedChartIndexes.length;
+  return {
+    key: definition.key,
+    name: definition.name,
+    tournamentUuid,
+    source: definition.source,
+    state: definition.state,
+    chartCount: definition.chartIds.length,
+    submittedCount,
+    sendWaitingCount,
+    category: submittedCount === definition.chartIds.length ? 'completed' : 'pending',
+  };
+}
+
+async function validateSeededTournaments(
+  appDb: AppDatabase,
+  created: HomeFilterSampleSeedItem[],
+): Promise<void> {
+  let hasNoEvidenceChart = false;
+  let hasUnsharedEvidenceChart = false;
+  let hasSharedEvidenceChart = false;
+
+  for (const entry of created) {
+    const detail = await appDb.getTournamentDetail(entry.tournamentUuid);
+    if (!detail) {
+      throw new Error(`Sample tournament detail not found: ${entry.tournamentUuid}`);
+    }
+    const unresolved = detail.charts.filter((chart) => chart.resolveIssue !== null);
+    if (unresolved.length > 0) {
+      throw new Error(
+        `Sample tournament has unresolved charts (${entry.tournamentUuid}): ${unresolved
+          .map((chart) => String(chart.chartId))
+          .join(', ')}`,
+      );
+    }
+
+    detail.charts.forEach((chart) => {
+      const localSaved = chart.updateSeq > 0 && !chart.fileDeleted;
+      if (!localSaved) {
+        hasNoEvidenceChart = true;
+        return;
+      }
+      if (chart.needsSend) {
+        hasUnsharedEvidenceChart = true;
+        return;
+      }
+      hasSharedEvidenceChart = true;
+    });
+  }
+
+  if (!hasNoEvidenceChart) {
+    throw new Error('Sample seed validation failed: no chart available for first-time submission flow.');
+  }
+  if (!hasUnsharedEvidenceChart) {
+    throw new Error('Sample seed validation failed: no chart available for unshared submission flow.');
+  }
+  if (!hasSharedEvidenceChart) {
+    throw new Error('Sample seed validation failed: no chart available for shared/resubmit flow.');
+  }
+}
+
+export async function clearHomeFilterSamples(appDb: AppDatabase): Promise<HomeFilterSampleClearResult> {
+  const all = await listAllTournaments(appDb);
+  const targets = all.filter((item) => isSampleTournament(item));
+  for (const item of targets) {
+    await appDb.deleteTournament(item.tournamentUuid);
+  }
+  return { deletedSampleCount: targets.length };
+}
+
+export async function seedHomeFilterSamples(options: HomeFilterSampleSeedOptions): Promise<HomeFilterSampleSeedResult> {
+  const {
+    appDb,
+    opfs,
+    todayDate,
+    resetExisting = true,
+  } = options;
+
+  let deletedSampleCount = 0;
+  if (resetExisting) {
+    const cleared = await clearHomeFilterSamples(appDb);
+    deletedSampleCount = cleared.deletedSampleCount;
+  }
+
+  const definitions = await buildHomeFilterSampleDefinitionsFromSongMaster(appDb, todayDate);
+  const imageBytes = decodeBase64(SAMPLE_IMAGE_BASE64);
+  const imageSha256 = sha256Hex(imageBytes);
+  const created: HomeFilterSampleSeedItem[] = [];
+  const seedValidationTodayDate = addDays(todayDate, SAMPLE_SEED_VALIDATION_BACKDATE_DAYS);
+
+  await withTemporaryAppDatabaseToday(appDb, seedValidationTodayDate, async () => {
+    for (const definition of definitions) {
+      const tournamentUuid = await createSampleTournament(appDb, definition);
+      const sharedChartIds = indexesToChartIds(definition.chartIds, definition.sharedChartIndexes);
+      const unsharedChartIds = indexesToChartIds(definition.chartIds, definition.unsharedChartIndexes);
+      const evidenceTargets = [...sharedChartIds, ...unsharedChartIds];
+
+      await upsertEvidenceSet(appDb, opfs, tournamentUuid, evidenceTargets, imageBytes, imageSha256);
+      if (sharedChartIds.length > 0) {
+        await appDb.markEvidenceSendCompleted(tournamentUuid, sharedChartIds);
+      }
+      created.push(toSampleItem(definition, tournamentUuid));
+    }
+  });
+
+  await validateSeededTournaments(appDb, created);
+
+  return {
+    deletedSampleCount,
+    createdSampleCount: created.length,
+    created,
+  };
+}
+
+export function registerHomeFilterSampleDebugApi(options: RegisterHomeFilterSampleDebugApiOptions): () => void {
+  if (typeof window === 'undefined') {
+    return () => undefined;
+  }
+
+  const seedFn: SeedHomeFilterSamplesFn = async (seedOptions) => {
+    const result = await seedHomeFilterSamples({
+      appDb: options.appDb,
+      opfs: options.opfs,
+      todayDate: options.todayDate,
+      ...(seedOptions?.resetExisting === undefined ? {} : { resetExisting: seedOptions.resetExisting }),
+    });
+    if (options.onDataChanged) {
+      await Promise.resolve(options.onDataChanged());
+    }
+    return result;
+  };
+
+  const clearFn: ClearHomeFilterSamplesFn = async () => {
+    const result = await clearHomeFilterSamples(options.appDb);
+    if (options.onDataChanged) {
+      await Promise.resolve(options.onDataChanged());
+    }
+    return result;
+  };
+
+  const currentApi: IidxDebugApi = { ...(window.__IIDX_DEBUG__ ?? {}) };
+  if (options.enabled) {
+    currentApi.seedHomeFilterSamples = seedFn;
+    currentApi.clearHomeFilterSamples = clearFn;
+  } else {
+    delete currentApi.seedHomeFilterSamples;
+    delete currentApi.clearHomeFilterSamples;
+  }
+
+  if (Object.keys(currentApi).length === 0) {
+    delete window.__IIDX_DEBUG__;
+  } else {
+    window.__IIDX_DEBUG__ = currentApi;
+  }
+
+  return () => {
+    const activeApi = window.__IIDX_DEBUG__;
+    if (!activeApi) {
+      return;
+    }
+    if (activeApi.seedHomeFilterSamples === seedFn) {
+      delete activeApi.seedHomeFilterSamples;
+    }
+    if (activeApi.clearHomeFilterSamples === clearFn) {
+      delete activeApi.clearHomeFilterSamples;
+    }
+    if (Object.keys(activeApi).length === 0) {
+      delete window.__IIDX_DEBUG__;
+    }
+  };
+}

--- a/tasks/feat-home-filter-sample-data.md
+++ b/tasks/feat-home-filter-sample-data.md
@@ -1,0 +1,89 @@
+# Plan: feat/home-filter-sample-data
+
+## 目的
+
+- スコアタ一覧フィルタ確認用に、手作業なしでサンプル大会データを投入できるスクリプトを追加する。
+- `state(active/upcoming/ended)` / `category(pending/completed)` / `attr(imported/created/send-waiting)` を横断確認できる最小構成を提供する。
+- サンプル投入後、スコアタ詳細画面/提出画面に遷移できるデータ整合性（曲解決可能な chart_id）を担保する。
+
+## 非目的
+
+- 本番導線（通常ユーザーUI）に新ボタンを追加しない。
+- DB schema変更・マイグレーションは行わない。
+- Web Locks / Service Worker / import仕様の本体ロジックは変更しない。
+
+## 変更点
+
+- デバッグ用のサンプルデータ投入モジュールを追加。
+  - 既存サンプルの削除（対象はハッシュタグ一致のみ）
+  - created/imported を混在した大会データ投入
+  - evidence登録（shared/unshared）により send-waiting 状態を再現
+  - 曲マスタから有効な chart_id を収集して割り当て（固定ダミーIDを廃止）
+  - seed中のみ AppDatabase の「今日」判定を一時的に巻き戻し、ended サンプル投入後に復元
+  - 生成後に detail データを検証し、resolve issue が残る場合はエラーにする
+- `App.tsx` からデバッグモード時のみ `window.__IIDX_DEBUG__` API を公開。
+  - `seedHomeFilterSamples()`
+  - `clearHomeFilterSamples()`
+- README に実行手順を追記。
+
+## 影響範囲（ユーザー / データ / 互換性）
+
+- ユーザー:
+  - 通常UIへの影響なし（デバッグモード + DevTools console 限定）。
+- データ:
+  - ローカルDBにサンプル大会/evidenceを追加・削除する。
+  - 削除対象はサンプル識別用ハッシュタグに限定。
+- 互換性:
+  - 永続化フォーマット・既存大会データ構造は変更しない。
+
+## 実装方針（対象ファイル単位）
+
+- `packages/web-app/src/debug/home-filter-sample-seed.ts`（新規）
+  - サンプル定義生成、投入、削除、debug API 登録処理を実装。
+- `packages/web-app/src/App.tsx`
+  - デバッグモード時の API 登録/解除 effect を追加。
+- `README.md`
+  - デバッグコンソール実行手順を追加。
+- `packages/web-app/src/debug/home-filter-sample-seed.test.ts`（新規）
+  - サンプル定義（状態・属性の網羅）と日付範囲の基本検証を追加。
+  - `seedHomeFilterSamples()` が detail/submit フロー前提を満たすこと（resolveIssueなし、shared/unshared/no-evidenceの混在）を検証。
+  - 保証条件不成立時の fail-fast（曲マスタ不足、detail未解決）を検証。
+
+### 変更スコープ固定
+
+- 上記4ファイル + 本 tasks ファイルのみ変更。
+
+## テスト観点
+
+- `seedHomeFilterSamples()` 実行後に以下が成立すること。
+  - active/upcoming/ended すべて存在
+  - imported/created すべて存在
+  - pending/completed すべて存在
+  - send-waiting > 0 の大会が存在
+- サンプル大会の detail 取得時に `resolveIssue` が発生しないこと（提出画面遷移可能条件）。
+- `clearHomeFilterSamples()` でサンプル識別ハッシュタグの大会のみ削除されること。
+- 型チェック・既存テストが通ること。
+
+## ロールバック方針
+
+- 追加した debug module と App 側 effect をコミット単位で revert する。
+- README 追記は別コミットで revert 可能に分離する。
+
+## Commit Plan（コミット分割計画）
+
+1. サンプルデータ投入モジュール + 単体テスト追加。
+2. App への debug API 連携。
+3. README への手順追記。
+
+## 実行チェックリスト
+
+- [x] 変更が宣言スコープ内に限定されていることを確認
+- [x] `pnpm --filter @iidx/web-app lint`
+- [x] `pnpm --filter @iidx/web-app test -- --run src/debug/home-filter-sample-seed.test.ts`
+- [x] `pnpm lint`
+- [x] `pnpm test`
+- [x] `git diff` で無関係差分がないことを確認
+
+Validation note:
+- `pnpm --filter @iidx/web-app test -- --run ...` は既存 package script の都合で全テスト実行になったが、全件pass。
+- 追加後の最新実行でも `pnpm lint` / `pnpm test`（workspace全体）ともに pass。


### PR DESCRIPTION
## 目的
- ホーム一覧フィルタ確認用のサンプル大会データを、手作業なしで投入できるようにする。
- サンプルデータが詳細画面/提出画面でも利用可能であることを保証する。

## 変更点
- `packages/web-app/src/debug/home-filter-sample-seed.ts` を追加。
  - `window.__IIDX_DEBUG__?.seedHomeFilterSamples?.()` / `clearHomeFilterSamples?.()` を提供。
  - `state(active/upcoming/ended)` / `category(pending/completed)` / `attr(imported/created/send-waiting)` を網羅するサンプルを投入。
  - 曲マスタから有効な `chart_id` を収集して割り当て、seed後に `resolveIssue` を検証。
  - `PAST_TOURNAMENT` 回避のため、seed中のみ AppDatabase の `todayJst()` を一時的に巻き戻して ended/imported サンプル投入後に復元。
- `packages/web-app/src/debug/home-filter-sample-seed.test.ts` を追加。
  - フィルタ網羅、detail/submit 前提（no-evidence/unshared/shared）を検証。
  - detail未解決、曲マスタ不足時の fail-fast を検証。
- `packages/web-app/src/App.tsx`
  - デバッグモード時のみ debug API を登録する effect を追加。
- `README.md`
  - サンプル seed/clear の実行手順と前提（曲マスタ未取得時はエラー）を追記。
- `tasks/feat-home-filter-sample-data.md`
  - 計画と検証ログを追記。

## 非変更点
- 本番UIに seed 操作用ボタンは追加しない。
- DB schema / payload 仕様 / Service Worker / Web Locks は変更しない。

## 影響範囲
- ユーザー影響: なし（デバッグモード + DevTools 実行時のみ有効）。
- データ影響: ローカルDBのサンプル大会/evidenceを追加・削除（サンプルハッシュタグ対象のみ）。
- 互換性: 永続化形式/既存データ構造の変更なし。

## テスト内容
- `pnpm --filter @iidx/web-app lint`
- `pnpm --filter @iidx/web-app test -- --run src/debug/home-filter-sample-seed.test.ts`
- `pnpm lint`
- `pnpm test`

## 回帰確認項目
- debug mode OFF で `window.__IIDX_DEBUG__.seedHomeFilterSamples` が露出しない。
- debug mode ON で seed/clear API が利用可能。
- seed後にホーム一覧フィルタ（state/category/attr）が確認できる。
- seed後の大会で詳細画面/提出画面遷移時に `resolveIssue` 起因の崩れが発生しない。

- [x] WORKFLOW.md を確認した
- [x] QUALITY.md を満たしている