### PR TITLE
feat: QR取込モーダルにカメラ失敗フォールバックを追加

### DIFF
--- a/packages/web-app/src/App.tsx
+++ b/packages/web-app/src/App.tsx
@@ -927,7 +927,6 @@ export function App({ webLockAcquired = false }: AppProps = {}): JSX.Element {
   const isHomeRoute = route.name === 'home';
   const isDetailRoute = route.name === 'detail';
   const isSettingsRoute = route.name === 'settings';
-  const canUseQrImport = window.isSecureContext === true && typeof navigator.mediaDevices?.getUserMedia === 'function';
   const todayDate = todayJst();
   const swStatus = resolveServiceWorkerStatus(pwaUpdate, hasSwController);
   const appInfoSnapshot = React.useMemo<AppInfoCardData>(
@@ -1814,18 +1813,13 @@ export function App({ webLockAcquired = false }: AppProps = {}): JSX.Element {
     setQrImportDialogOpen(false);
   }, []);
 
-  const handleDetectedImportQr = React.useCallback(
-    (qrText: string) => {
+  const handleImportUrlFromQrDialog = React.useCallback(
+    (importUrl: string) => {
       setQrImportDialogOpen(false);
-      void importFromQrScan(qrText);
+      void importFromQrScan(importUrl);
     },
     [importFromQrScan],
   );
-
-  const openTextImportFromQrError = React.useCallback(() => {
-    setQrImportDialogOpen(false);
-    pushRoute({ name: 'import' });
-  }, [pushRoute]);
 
   const confirmImport = React.useCallback(
     async (payload: TournamentPayload) => {
@@ -2099,12 +2093,8 @@ export function App({ webLockAcquired = false }: AppProps = {}): JSX.Element {
       pushToast(t('common.import.page_require_song_master'));
       return;
     }
-    if (canUseQrImport) {
-      setQrImportDialogOpen(true);
-      return;
-    }
-    pushRoute({ name: 'import' });
-  }, [canUseQrImport, pushRoute, pushToast, songMasterReady, t]);
+    setQrImportDialogOpen(true);
+  }, [pushToast, songMasterReady, t]);
 
   const openSettingsPage = React.useCallback(() => {
     if (route.name === 'settings') {
@@ -2881,8 +2871,7 @@ export function App({ webLockAcquired = false }: AppProps = {}): JSX.Element {
         <ImportQrScannerDialog
           open={qrImportDialogOpen}
           onClose={closeQrImportDialog}
-          onDetected={handleDetectedImportQr}
-          onOpenTextImport={openTextImportFromQrError}
+          onImportUrl={handleImportUrlFromQrDialog}
         />
 
         <Dialog open={whatsNewDialogOpen} onClose={closeWhatsNewDialog} fullWidth maxWidth="sm">

--- a/packages/web-app/src/components/ImportQrScannerDialog.test.tsx
+++ b/packages/web-app/src/components/ImportQrScannerDialog.test.tsx
@@ -1,0 +1,142 @@
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { ImportQrScannerDialog } from './ImportQrScannerDialog';
+
+type MockTrack = {
+  stop: ReturnType<typeof vi.fn>;
+};
+
+function createMockStream(): { stream: MediaStream; track: MockTrack } {
+  const track: MockTrack = {
+    stop: vi.fn(),
+  };
+  const stream = {
+    getTracks: () => [track],
+  } as unknown as MediaStream;
+  return { stream, track };
+}
+
+describe('ImportQrScannerDialog', () => {
+  const originalSecureContext = window.isSecureContext;
+  const originalMediaDevices = navigator.mediaDevices;
+  let getUserMediaMock: ReturnType<typeof vi.fn>;
+  let playSpy: { mockRestore: () => void };
+  let pauseSpy: { mockRestore: () => void };
+  let requestAnimationFrameSpy: { mockRestore: () => void };
+  let cancelAnimationFrameSpy: { mockRestore: () => void };
+
+  beforeEach(() => {
+    Object.defineProperty(window, 'isSecureContext', {
+      configurable: true,
+      value: true,
+    });
+    getUserMediaMock = vi.fn();
+    Object.defineProperty(navigator, 'mediaDevices', {
+      configurable: true,
+      value: {
+        getUserMedia: getUserMediaMock,
+      },
+    });
+    playSpy = vi.spyOn(HTMLMediaElement.prototype, 'play').mockResolvedValue(undefined);
+    pauseSpy = vi.spyOn(HTMLMediaElement.prototype, 'pause').mockImplementation(() => undefined);
+    requestAnimationFrameSpy = vi.spyOn(window, 'requestAnimationFrame').mockImplementation(() => 1);
+    cancelAnimationFrameSpy = vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    cleanup();
+    playSpy.mockRestore();
+    pauseSpy.mockRestore();
+    requestAnimationFrameSpy.mockRestore();
+    cancelAnimationFrameSpy.mockRestore();
+    Object.defineProperty(window, 'isSecureContext', {
+      configurable: true,
+      value: originalSecureContext,
+    });
+    Object.defineProperty(navigator, 'mediaDevices', {
+      configurable: true,
+      value: originalMediaDevices,
+    });
+  });
+
+  it('shows QR scanner UI on camera startup success', async () => {
+    const { stream } = createMockStream();
+    getUserMediaMock.mockResolvedValue(stream);
+
+    render(<ImportQrScannerDialog open onClose={() => undefined} onImportUrl={() => undefined} />);
+
+    await waitFor(() => expect(getUserMediaMock).toHaveBeenCalledTimes(1));
+    expect(screen.getByText('QRコードをカメラにかざしてください。')).toBeTruthy();
+    expect(screen.queryByText('カメラが利用できません')).toBeNull();
+    expect(screen.queryByPlaceholderText('インポート用URLを貼り付け')).toBeNull();
+    expect(screen.queryByRole('button', { name: '原因と対処' })).toBeNull();
+  });
+
+  it('shows URL fallback and help accordion when camera startup fails', async () => {
+    getUserMediaMock.mockRejectedValue(new DOMException('Permission denied', 'NotAllowedError'));
+
+    render(<ImportQrScannerDialog open onClose={() => undefined} onImportUrl={() => undefined} />);
+
+    await screen.findByText('カメラが利用できません');
+    expect(document.body.querySelector('.importQrScannerViewport')).toBeNull();
+    expect(screen.getByText('投稿のリンクを開くか、インポート用URLを貼り付けてください。')).toBeTruthy();
+    expect(screen.getByPlaceholderText('インポート用URLを貼り付け')).toBeTruthy();
+    const helpButton = screen.getByRole('button', { name: '原因と対処' });
+    expect(helpButton).toBeTruthy();
+
+    await userEvent.click(helpButton);
+    expect(screen.getByText('ブラウザのカメラ権限を許可してください')).toBeTruthy();
+    expect(screen.getByText('HTTPSで開いてください')).toBeTruthy();
+    expect(screen.getByText('SNS内ブラウザでは動かない場合があります')).toBeTruthy();
+    expect(document.body.querySelector('.importQrScannerFallbackHelpPanel')?.children.length).toBe(3);
+  });
+
+  it('validates fallback URL input and keeps value on failure', async () => {
+    getUserMediaMock.mockRejectedValue(new DOMException('Permission denied', 'NotAllowedError'));
+    const onImportUrl = vi.fn();
+
+    render(<ImportQrScannerDialog open onClose={() => undefined} onImportUrl={onImportUrl} />);
+    await screen.findByText('カメラが利用できません');
+
+    const importButton = screen.getByRole('button', { name: '取り込む' }) as HTMLButtonElement;
+    expect(importButton.disabled).toBe(true);
+
+    const input = screen.getByPlaceholderText('インポート用URLを貼り付け') as HTMLInputElement;
+    await userEvent.type(input, 'abc');
+    expect(importButton.disabled).toBe(false);
+
+    await userEvent.click(importButton);
+    expect(screen.getByText('http(s):// で始まるURLを入力してください。')).toBeTruthy();
+    expect(input.value).toBe('abc');
+    expect(onImportUrl).toHaveBeenCalledTimes(0);
+
+    await userEvent.clear(input);
+    await userEvent.type(input, 'https://example.com/path?p=abc');
+    await userEvent.click(importButton);
+    expect(screen.getByText('インポート用URLを入力してください。')).toBeTruthy();
+    expect(input.value).toBe('https://example.com/path?p=abc');
+    expect(onImportUrl).toHaveBeenCalledTimes(0);
+
+    await userEvent.clear(input);
+    await userEvent.type(input, ' https://example.com/import/confirm?p=abc%2Bdef ');
+    await userEvent.click(importButton);
+    expect(onImportUrl).toHaveBeenCalledTimes(1);
+    expect(onImportUrl).toHaveBeenCalledWith('https://example.com/import/confirm?p=abc%2Bdef');
+  });
+
+  it('stops camera stream tracks when dialog is closed', async () => {
+    const { stream, track } = createMockStream();
+    getUserMediaMock.mockResolvedValue(stream);
+
+    const { rerender } = render(<ImportQrScannerDialog open onClose={() => undefined} onImportUrl={() => undefined} />);
+    await waitFor(() => expect(getUserMediaMock).toHaveBeenCalledTimes(1));
+
+    rerender(<ImportQrScannerDialog open={false} onClose={() => undefined} onImportUrl={() => undefined} />);
+
+    await waitFor(() => expect(track.stop).toHaveBeenCalledTimes(1));
+    expect(cancelAnimationFrameSpy).toHaveBeenCalled();
+  });
+});

--- a/packages/web-app/src/i18n/locales/en.json
+++ b/packages/web-app/src/i18n/locales/en.json
@@ -104,8 +104,24 @@
       "title": "QR scan",
       "description": "Hold the QR code in front of the camera.",
       "starting": "Starting camera...",
-      "action": {
-        "text_import": "Text import"
+      "fallback": {
+        "title": "Camera is unavailable",
+        "description": "Open the post link, or paste the import URL.",
+        "input_placeholder": "Paste import URL",
+        "action": {
+          "import": "Import"
+        },
+        "help_link": "Causes and fixes",
+        "help": {
+          "permission": "Allow camera permission in your browser",
+          "https": "Open the page over HTTPS",
+          "in_app_browser": "In-app browsers in social apps may not work"
+        },
+        "error": {
+          "empty": "Enter a URL.",
+          "absolute_url": "Enter a full URL starting with http(s)://.",
+          "import_link": "Enter an import URL."
+        }
       },
       "error": {
         "unavailable": "QR scanning is not available on this device.",

--- a/packages/web-app/src/i18n/locales/ja.json
+++ b/packages/web-app/src/i18n/locales/ja.json
@@ -104,8 +104,24 @@
       "title": "QR読み取り",
       "description": "QRコードをカメラにかざしてください。",
       "starting": "カメラ起動中...",
-      "action": {
-        "text_import": "テキスト取込"
+      "fallback": {
+        "title": "カメラが利用できません",
+        "description": "投稿のリンクを開くか、インポート用URLを貼り付けてください。",
+        "input_placeholder": "インポート用URLを貼り付け",
+        "action": {
+          "import": "取り込む"
+        },
+        "help_link": "原因と対処",
+        "help": {
+          "permission": "ブラウザのカメラ権限を許可してください",
+          "https": "HTTPSで開いてください",
+          "in_app_browser": "SNS内ブラウザでは動かない場合があります"
+        },
+        "error": {
+          "empty": "URLを入力してください。",
+          "absolute_url": "http(s):// で始まるURLを入力してください。",
+          "import_link": "インポート用URLを入力してください。"
+        }
       },
       "error": {
         "unavailable": "この端末ではQR読み取りを利用できません。",

--- a/packages/web-app/src/i18n/locales/ko.json
+++ b/packages/web-app/src/i18n/locales/ko.json
@@ -104,8 +104,24 @@
       "title": "QR 읽기",
       "description": "QR 코드를 카메라에 비춰 주세요.",
       "starting": "카메라 시작 중...",
-      "action": {
-        "text_import": "텍스트 가져오기"
+      "fallback": {
+        "title": "카메라를 사용할 수 없습니다",
+        "description": "게시물 링크를 열거나 가져오기 URL을 붙여 넣어 주세요.",
+        "input_placeholder": "가져오기 URL 붙여넣기",
+        "action": {
+          "import": "가져오기"
+        },
+        "help_link": "원인과 해결 방법",
+        "help": {
+          "permission": "브라우저에서 카메라 권한을 허용해 주세요",
+          "https": "HTTPS로 열어 주세요",
+          "in_app_browser": "SNS 내 브라우저에서는 동작하지 않을 수 있습니다"
+        },
+        "error": {
+          "empty": "URL을 입력해 주세요.",
+          "absolute_url": "http(s)://로 시작하는 전체 URL을 입력해 주세요.",
+          "import_link": "가져오기 URL을 입력해 주세요."
+        }
       },
       "error": {
         "unavailable": "이 기기에서는 QR 읽기를 사용할 수 없습니다.",

--- a/packages/web-app/src/styles.css
+++ b/packages/web-app/src/styles.css
@@ -1831,6 +1831,33 @@ label {
   display: none;
 }
 
+.importQrScannerFallback {
+  display: grid;
+  gap: 10px;
+}
+
+.importQrScannerFallbackForm {
+  display: grid;
+  gap: 8px;
+}
+
+.importQrScannerFallbackForm input {
+  width: 100%;
+}
+
+.importQrScannerFallbackHelpLink {
+  justify-self: start;
+  min-width: 0;
+  padding-left: 0;
+  text-transform: none;
+  font-size: 12px;
+}
+
+.importQrScannerFallbackHelpPanel {
+  display: grid;
+  gap: 2px;
+}
+
 .importQrScannerErrorBlock {
   display: grid;
   gap: 6px;

--- a/tasks/feat-qr-camera-fallback.md
+++ b/tasks/feat-qr-camera-fallback.md
@@ -1,0 +1,76 @@
+# Task Plan: feat-qr-camera-fallback
+
+## 目的
+- QR取込モーダルでカメラ起動失敗時に、安全にURL貼り付けフォールバックできるようにする。
+- 常設のテキスト取込導線を廃止し、取込導線を「QR」または「URL直アクセス」に寄せる。
+- 失敗時のみ最小ヘルプ（原因と対処）をモーダル内アコーディオンで提示する。
+
+## 非目的
+- Import payload仕様・DB schema・既存import確定ロジックの変更。
+- Web Locks / Single-tab invariant / Service Worker の変更。
+- 依存関係更新・CI/CD変更。
+- マルチタブ挙動の設計変更。
+
+## 変更点
+- FAB押下時の遷移を「カメラ可否判定でページ遷移」から「常にQR取込モーダル表示」に変更。
+- QR取込モーダルに `cameraState`（`initializing`/`ready`/`failed`）を導入。
+- `getUserMedia` 失敗時にQRプレビューを非表示化し、URL貼り付けフォールバックUIへ切替。
+- フォールバックUIにURL入力・取り込みボタン・失敗時のみの「原因と対処」アコーディオンを追加。
+- 既存の「テキスト取込」導線（QRモーダル内ボタン）を削除。
+- QR読取結果URLと貼り付けURLを同一の取込ハンドラに流す。
+- カメラ停止・スキャナ停止処理をモーダルclose時に必ず実行する。
+
+## 影響範囲
+- ユーザー:
+  - 取込FAB押下時に常にモーダルが開く。
+  - カメラ失敗時は同モーダル内でURL貼り付け取り込みが可能になる。
+  - 常設テキスト取込導線は表示されなくなる。
+- データ:
+  - 永続データ形式への変更なし。
+- 互換性:
+  - 既存のImport Confirmフロー（`/import/confirm?p=`）は維持。
+  - QR/URLとも既存の取込処理パスを利用し、挙動互換を保つ。
+
+## 実装方針（対象ファイル単位）
+- `packages/web-app/src/components/ImportQrScannerDialog.tsx`
+  - カメラ状態管理・例外ハンドリング・フォールバックUI・URLバリデーション・ヘルプアコーディオンを実装。
+  - QR読取成功とURL貼り付け送信を同一コールバックで通知。
+- `packages/web-app/src/App.tsx`
+  - FAB押下時は常にQRモーダルを開くように変更。
+  - 既存のテキスト取込遷移コールバックを削除し、共通取込ハンドラへ統合。
+- `packages/web-app/src/styles.css`
+  - フォールバックUI（見出し、入力行、ヘルプリンク、アコーディオン）の最小スタイルを追加。
+- `packages/web-app/src/i18n/locales/ja.json`
+- `packages/web-app/src/i18n/locales/en.json`
+- `packages/web-app/src/i18n/locales/ko.json`
+  - QR取込モーダルのフォールバック文言と入力エラー文言を追加し、不要な文言を整理。
+- `packages/web-app/src/components/ImportQrScannerDialog.test.tsx`
+  - 成功/失敗表示分岐、ヘルプ表示、入力バリデーション、submit挙動のテストを追加。
+
+## テスト観点
+- カメラ成功時:
+  - QR UI（video領域）が表示される。
+  - URL入力/原因と対処リンクが表示されない。
+- カメラ失敗時:
+  - QR UIが表示されない。
+  - 見出し/説明/URL入力/取り込むボタン/原因と対処リンクが表示される。
+  - 原因と対処の展開内容が3行のみ表示される。
+- URL貼り付け:
+  - 空文字は送信不可またはエラー表示。
+  - `http(s)://` 以外はエラー表示。
+  - `/import/confirm?p=` 形式に一致しないURLはエラー表示。
+  - 失敗時に入力値が保持される。
+- リソース解放:
+  - モーダルcloseでMediaStream trackとscan loopが停止する。
+  - 再open時に再初期化できる。
+
+## ロールバック方針
+- 本タスク差分をrevertし、QRモーダルを従来仕様へ戻す。
+- `App.tsx` のFAB挙動をrevertし、既存導線へ復帰する。
+- 追加したi18nキーとCSSを巻き戻す。
+
+## Commit Plan
+1. `plan`: tasksファイル追加（本ファイル）。
+2. `qr-dialog-fallback`: QRモーダル状態機械・フォールバックUI・URLバリデーション実装。
+3. `app-flow-and-i18n-style`: App導線統合とi18n/CSS更新。
+4. `tests`: QRモーダルの分岐/バリデーションテスト追加。


### PR DESCRIPTION
## 目的
- QR取込モーダルでカメラ起動失敗時に、モーダル内でURL貼り付けフォールバックできるようにする
- 常設のテキスト取込導線を廃止し、取込導線をQR中心に統一する

## 変更点
- FAB押下時はカメラ可否に関係なく常にQR取込モーダルを開くよう変更
- ImportQrScannerDialog に cameraState（initializing/ready/failed）と失敗時フォールバックUIを追加
- フォールバックUIにURL入力・取り込むボタン・失敗時のみ表示の「原因と対処」アコーディオンを追加
- URL入力バリデーションを追加（空文字不可、http(s)必須、/import/confirm?p= の軽検査）
- QR読取結果URLと貼り付けURLを同一取り込みハンドラへ統合
- close時のMediaStream track停止・scan loop停止を維持
- ja/en/koの文言と最小スタイルを追加
- ImportQrScannerDialog のテストを新規追加

## 非変更点
- import payload仕様、DB schema、import確定ロジック
- Web Locks / Single-tab invariant
- Service Worker / COOP-COEP
- 依存関係更新、CI/CD変更

## 影響範囲
- ユーザー: カメラ失敗時のみ、同モーダル内でURL貼り付け取込が可能
- データ: 永続化形式変更なし
- 互換性: 既存の /import/confirm?p= フローを維持

## テスト内容
- pnpm --filter @iidx/web-app lint
- pnpm --filter @iidx/web-app test -- src/components/ImportQrScannerDialog.test.tsx

## 回帰確認項目
- カメラ成功時にQR UIのみ表示され、URL入力/ヘルプが非表示
- カメラ失敗時にQR UI非表示で、見出し/説明/URL入力/原因と対処が表示
- ヘルプ展開時の案内が3行のみ表示
- close時にカメラ解放され、再openで再初期化できる
- URL貼り付けの成功/失敗動作と、失敗時入力保持