### PR TITLE
feat(web-app): MUIテーマ先行移行 (Phase 1)

### DIFF
--- a/packages/web-app/src/App.tsx
+++ b/packages/web-app/src/App.tsx
@@ -2429,10 +2429,8 @@ export function App({ webLockAcquired = false }: AppProps = {}): JSX.Element {
                   anchorEl={homeMenuAnchorEl}
                   open={homeMenuOpen}
                   onClose={closeHomeMenu}
-                  PaperProps={{ className: 'appMenuPaper' }}
                 >
                   <MenuItem
-                    className="appMenuItem"
                     onClick={() => {
                       closeHomeMenu();
                       openSettingsPage();
@@ -2486,18 +2484,16 @@ export function App({ webLockAcquired = false }: AppProps = {}): JSX.Element {
                         anchorEl={detailMenuAnchorEl}
                         open={detailMenuOpen}
                         onClose={closeDetailMenu}
-                        PaperProps={{ className: 'appMenuPaper' }}
                       >
-                        <MenuItem className="appMenuItem" onClick={openCopyCreateFromDetail}>
+                        <MenuItem onClick={openCopyCreateFromDetail}>
                           {t('common.copy_this_tournament')}
                         </MenuItem>
                         {debugModeEnabled ? (
-                          <MenuItem className="appMenuItem" onClick={openDetailTechnicalDialog}>
+                          <MenuItem onClick={openDetailTechnicalDialog}>
                             {t('common.technical_info')}
                           </MenuItem>
                         ) : null}
                         <MenuItem
-                          className="appMenuItem"
                           disabled={deleteTournamentBusy}
                           onClick={openDeleteTournamentDialog}
                         >
@@ -2592,12 +2588,10 @@ export function App({ webLockAcquired = false }: AppProps = {}): JSX.Element {
                 onClose={closeHomeSortMenu}
                 anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
                 transformOrigin={{ vertical: 'top', horizontal: 'right' }}
-                PaperProps={{ className: 'appMenuPaper' }}
               >
                 {HOME_SORT_OPTIONS.map((option) => (
                   <MenuItem
                     key={option.value}
-                    className="appMenuItem"
                     selected={homeQuery.sort === option.value}
                     onClick={() => {
                       setHomeSort(option.value);

--- a/packages/web-app/src/components/ImportQrScannerDialog.tsx
+++ b/packages/web-app/src/components/ImportQrScannerDialog.tsx
@@ -195,28 +195,9 @@ export function ImportQrScannerDialog(props: ImportQrScannerDialogProps): JSX.El
       onClose={props.onClose}
       fullWidth
       maxWidth="xs"
-      PaperProps={{
-        sx: {
-          backgroundColor: 'var(--surface)',
-          color: 'var(--text)',
-          border: '1px solid var(--border)',
-          boxShadow: 'var(--shadow)',
-          '& .MuiTypography-root': {
-            color: 'var(--text)',
-          },
-          '& .hintText': {
-            color: 'var(--text-subtle)',
-          },
-        },
-      }}
     >
       <DialogTitle>{t('common.import_qr_dialog.title')}</DialogTitle>
-      <DialogContent
-        dividers
-        sx={{
-          borderColor: 'var(--border)',
-        }}
-      >
+      <DialogContent dividers>
         {!showFallback ? (
           <>
             <Typography variant="body2" className="hintText">
@@ -293,7 +274,7 @@ export function ImportQrScannerDialog(props: ImportQrScannerDialogProps): JSX.El
         ) : null}
         <canvas ref={canvasRef} className="importQrScannerCanvas" />
       </DialogContent>
-      <DialogActions sx={{ borderTop: '1px solid var(--border)' }}>
+      <DialogActions>
         <Button onClick={props.onClose}>{t('common.close')}</Button>
       </DialogActions>
     </Dialog>

--- a/packages/web-app/src/main.tsx
+++ b/packages/web-app/src/main.tsx
@@ -2,12 +2,14 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { acquireSingleTabLock, checkRuntimeCapabilities } from '@iidx/db';
 import type { TournamentPayload } from '@iidx/shared';
+import { ThemeProvider } from '@mui/material/styles';
 import { useTranslation } from 'react-i18next';
 
 import { App, AppFallbackUnsupported } from './App';
 import i18n, { APP_LANGUAGE_SETTING_KEY, ensureI18n, normalizeLanguage } from './i18n';
 import { createAppServices } from './services/app-services';
 import { AppServicesProvider } from './services/context';
+import { muiTheme } from './theme/mui-theme';
 import { resolveImportPayloadFromLocation } from './utils/import-confirm';
 import {
   IMPORT_DELEGATION_BROADCAST_ACK_TIMEOUT_MS,
@@ -57,6 +59,14 @@ interface ImportDelegationScreenProps {
 interface InvalidImportLinkScreenProps {
   code: string;
   message: string;
+}
+
+function renderWithMuiTheme(root: ReturnType<typeof ReactDOM.createRoot>, content: React.ReactNode): void {
+  root.render(
+    <React.StrictMode>
+      <ThemeProvider theme={muiTheme}>{content}</ThemeProvider>
+    </React.StrictMode>,
+  );
 }
 
 function safeSetLocalStorage(key: string, value: string): boolean {
@@ -546,11 +556,7 @@ async function waitForLocalConsent(root: ReturnType<typeof ReactDOM.createRoot>)
       resolve();
     };
 
-    root.render(
-      <React.StrictMode>
-        <LocalConsentScreen onStart={handleStart} />
-      </React.StrictMode>,
-    );
+    renderWithMuiTheme(root, <LocalConsentScreen onStart={handleStart} />);
   });
 }
 
@@ -573,20 +579,12 @@ async function bootstrap(): Promise<void> {
 
   await waitForLocalConsent(root);
 
-  root.render(
-    <React.StrictMode>
-      <SetupLoadingScreen />
-    </React.StrictMode>,
-  );
+  renderWithMuiTheme(root, <SetupLoadingScreen />);
 
   if (!import.meta.env.DEV) {
     const swSetupResult = await ensureServiceWorkerController(swUrl, swWarmupAttempt);
     if (swSetupResult.status === 'failed') {
-      root.render(
-        <React.StrictMode>
-          <ServiceWorkerFailureScreen reason={swSetupResult.reason} errorMessage={swSetupResult.errorMessage} />
-        </React.StrictMode>,
-      );
+      renderWithMuiTheme(root, <ServiceWorkerFailureScreen reason={swSetupResult.reason} errorMessage={swSetupResult.errorMessage} />);
       return;
     }
 
@@ -599,15 +597,14 @@ async function bootstrap(): Promise<void> {
         });
       }
 
-      root.render(
-        <React.StrictMode>
-          <AppFallbackUnsupported
-            reasons={[
-              'Cross-Origin-Isolation (COOP/COEP)',
-              i18n.t('common.bootstrap.cross_origin_isolated_unavailable_after_setup'),
-            ]}
-          />
-        </React.StrictMode>,
+      renderWithMuiTheme(
+        root,
+        <AppFallbackUnsupported
+          reasons={[
+            'Cross-Origin-Isolation (COOP/COEP)',
+            i18n.t('common.bootstrap.cross_origin_isolated_unavailable_after_setup'),
+          ]}
+        />,
       );
       return;
     }
@@ -632,11 +629,7 @@ async function bootstrap(): Promise<void> {
   }
 
   if (reasons.length > 0) {
-    root.render(
-      <React.StrictMode>
-        <AppFallbackUnsupported reasons={reasons} />
-      </React.StrictMode>,
-    );
+    renderWithMuiTheme(root, <AppFallbackUnsupported reasons={reasons} />);
     return;
   }
 
@@ -645,29 +638,20 @@ async function bootstrap(): Promise<void> {
     releaseLock = await acquireSingleTabLock('iidx-score-attack-web-lock');
   } catch {
     if (importPayloadResult.status === 'invalid') {
-      root.render(
-        <React.StrictMode>
-          <InvalidImportLinkScreen code={importPayloadResult.error.code} message={importPayloadResult.error.message} />
-        </React.StrictMode>,
-      );
+      renderWithMuiTheme(root, <InvalidImportLinkScreen code={importPayloadResult.error.code} message={importPayloadResult.error.message} />);
       return;
     }
     if (importPayloadResult.status === 'ready') {
-      root.render(
-        <React.StrictMode>
-          <ImportDelegationScreen
-            rawPayloadParam={importPayloadResult.rawPayloadParam}
-            payloadPreview={importPayloadResult.payload}
-          />
-        </React.StrictMode>,
+      renderWithMuiTheme(
+        root,
+        <ImportDelegationScreen
+          rawPayloadParam={importPayloadResult.rawPayloadParam}
+          payloadPreview={importPayloadResult.payload}
+        />,
       );
       return;
     }
-    root.render(
-      <React.StrictMode>
-        <AppFallbackUnsupported reasons={[i18n.t('common.bootstrap.already_running_in_other_tab')]} />
-      </React.StrictMode>,
-    );
+    renderWithMuiTheme(root, <AppFallbackUnsupported reasons={[i18n.t('common.bootstrap.already_running_in_other_tab')]} />);
     return;
   }
 
@@ -689,12 +673,11 @@ async function bootstrap(): Promise<void> {
       void services.appDb.dispose();
     });
 
-    root.render(
-      <React.StrictMode>
-        <AppServicesProvider services={services}>
-          <App webLockAcquired />
-        </AppServicesProvider>
-      </React.StrictMode>,
+    renderWithMuiTheme(
+      root,
+      <AppServicesProvider services={services}>
+        <App webLockAcquired />
+      </AppServicesProvider>,
     );
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
@@ -702,11 +685,7 @@ async function bootstrap(): Promise<void> {
       ? i18n.t('common.bootstrap.opfs_vfs_init_failed')
       : i18n.t('common.bootstrap.initialization_error', { message });
 
-    root.render(
-      <React.StrictMode>
-        <AppFallbackUnsupported reasons={[reason]} />
-      </React.StrictMode>,
-    );
+    renderWithMuiTheme(root, <AppFallbackUnsupported reasons={[reason]} />);
   }
 }
 

--- a/packages/web-app/src/pages/SettingsPage.tsx
+++ b/packages/web-app/src/pages/SettingsPage.tsx
@@ -147,78 +147,12 @@ const cardSx = {
   color: 'var(--text)',
   display: 'grid',
   gap: 2,
-  '& .MuiTypography-root.MuiTypography-colorTextSecondary': {
-    color: 'var(--text-subtle) !important',
-  },
-  '& .MuiDivider-root': {
-    borderColor: 'var(--border)',
-  },
-  '& .MuiInputBase-root': {
-    color: 'var(--text)',
-    backgroundColor: 'var(--surface-2)',
-  },
-  '& .MuiInputLabel-root': {
-    color: 'var(--text-subtle)',
-  },
-  '& .MuiSelect-icon': {
-    color: 'var(--text-subtle)',
-  },
-  '& .MuiFormHelperText-root': {
-    color: 'var(--text-subtle) !important',
-  },
-  '& .MuiChip-root.MuiChip-colorDefault': {
-    backgroundColor: 'var(--surface-3)',
-    color: 'var(--text-muted)',
-    border: '1px solid var(--border)',
-  },
-  '& .MuiChip-root.MuiChip-colorDefault .MuiChip-icon, & .MuiChip-root.MuiChip-colorDefault .MuiChip-deleteIcon': {
-    color: 'var(--text-subtle)',
-  },
-  '& .MuiOutlinedInput-notchedOutline': {
-    borderColor: 'var(--border)',
-  },
-  '& .MuiOutlinedInput-root:hover .MuiOutlinedInput-notchedOutline': {
-    borderColor: 'var(--border-strong)',
-  },
-  '& .MuiOutlinedInput-root.Mui-focused .MuiOutlinedInput-notchedOutline': {
-    borderColor: 'var(--focus)',
-  },
-  '& .MuiFormControlLabel-label': {
-    color: 'var(--text)',
-  },
-  '& .MuiInputLabel-root.Mui-disabled': {
-    color: 'var(--text-faint) !important',
-  },
-  '& .MuiInputBase-input.Mui-disabled': {
-    color: 'var(--text-muted) !important',
-    WebkitTextFillColor: 'var(--text-muted) !important',
-  },
-  '& .MuiInputBase-root.Mui-disabled': {
-    backgroundColor: 'var(--surface-3)',
-  },
-  '& .MuiSwitch-track': {
-    backgroundColor: 'var(--surface-muted)',
-    opacity: '1 !important',
-  },
-  '& .MuiSwitch-thumb': {
-    backgroundColor: 'var(--surface)',
-  },
-  '& .MuiSwitch-switchBase.Mui-checked': {
-    color: 'var(--surface)',
-  },
-  '& .MuiSwitch-switchBase.Mui-checked + .MuiSwitch-track': {
-    backgroundColor: 'var(--accent-strong)',
-    opacity: '1 !important',
-  },
 } as const;
 const accordionSx = {
   border: '1px solid var(--border)',
   borderRadius: 2,
   backgroundColor: 'transparent',
   color: 'var(--text)',
-  '& .MuiAccordionSummary-expandIconWrapper': {
-    color: 'var(--text-subtle)',
-  },
 } as const;
 
 function clampDays(v: number): number {

--- a/packages/web-app/src/pages/TournamentDetailPage.tsx
+++ b/packages/web-app/src/pages/TournamentDetailPage.tsx
@@ -1086,7 +1086,6 @@ export function TournamentDetailPage(props: TournamentDetailPageProps): JSX.Elem
         fullWidth
         maxWidth="sm"
         data-testid="tournament-detail-share-dialog"
-        PaperProps={{ className: 'detailShareDialogPaper' }}
       >
         <DialogTitle sx={{ pr: 6 }}>
           {t('tournament_detail.action.share_tournament')}
@@ -1098,7 +1097,7 @@ export function TournamentDetailPage(props: TournamentDetailPageProps): JSX.Elem
             <CloseIcon />
           </IconButton>
         </DialogTitle>
-        <DialogContent dividers sx={{ display: 'grid', gap: 2, borderColor: 'var(--border)' }}>
+        <DialogContent dividers sx={{ display: 'grid', gap: 2 }}>
           <Box>
             <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 1 }}>
               <Typography variant="subtitle2" sx={{ fontWeight: 700 }}>
@@ -1219,7 +1218,7 @@ export function TournamentDetailPage(props: TournamentDetailPageProps): JSX.Elem
 
           {shareNotice ? <Alert severity={shareNotice.severity}>{shareNotice.text}</Alert> : null}
         </DialogContent>
-        <DialogActions sx={{ borderTop: '1px solid var(--border)' }}>
+        <DialogActions>
           <Button onClick={closeShareDialog}>{t('common.close')}</Button>
         </DialogActions>
       </Dialog>
@@ -1247,10 +1246,9 @@ export function TournamentDetailPage(props: TournamentDetailPageProps): JSX.Elem
         fullWidth
         maxWidth="sm"
         data-testid="tournament-detail-submit-dialog"
-        PaperProps={{ className: 'detailSubmitDialogPaper' }}
       >
         <DialogTitle>{t('tournament_detail.submit_dialog.title')}</DialogTitle>
-        <DialogContent dividers sx={{ borderColor: 'var(--border)' }}>
+        <DialogContent dividers>
           <Typography variant="body1" data-testid="tournament-detail-submit-confirm-text">
             {submitDialogConfirmText}
           </Typography>
@@ -1260,7 +1258,7 @@ export function TournamentDetailPage(props: TournamentDetailPageProps): JSX.Elem
             </Typography>
           ) : null}
         </DialogContent>
-        <DialogActions sx={{ borderTop: '1px solid var(--border)' }}>
+        <DialogActions>
           <Button onClick={() => setSubmitDialogOpen(false)} disabled={submitBusy}>
             {t('common.cancel')}
           </Button>

--- a/packages/web-app/src/styles.css
+++ b/packages/web-app/src/styles.css
@@ -86,12 +86,6 @@
   --difficulty-pill-active-text: #ffffff;
   --difficulty-pill-disabled-bg: var(--surface-2);
   --difficulty-pill-disabled-text: var(--text-faint);
-  --menu-surface: var(--surface);
-  --menu-text: var(--text);
-  --menu-border: var(--border);
-  --menu-hover: var(--surface-3);
-  --menu-selected: var(--surface-3);
-  --menu-disabled: var(--text-faint);
   --progress-track: #e2e8f0;
   --progress-unregistered: #cfd8e3;
   --progress-unshared: #f2d3a2;
@@ -213,12 +207,6 @@
     --difficulty-pill-active-text: #0f172a;
     --difficulty-pill-disabled-bg: #364052;
     --difficulty-pill-disabled-text: #94a3b8;
-    --menu-surface: #1f2937;
-    --menu-text: #e5e7eb;
-    --menu-border: rgba(255, 255, 255, 0.12);
-    --menu-hover: rgba(255, 255, 255, 0.08);
-    --menu-selected: #334155;
-    --menu-disabled: #9ca3af;
     --progress-track: #455266;
     --progress-unregistered: #7788a2;
     --progress-unshared: #b8915f;
@@ -249,7 +237,7 @@ textarea {
   font: inherit;
 }
 
-button {
+:where(button):not(:where(.MuiButtonBase-root)) {
   border: 1px solid var(--border-strong);
   border-radius: 10px;
   background: var(--surface);
@@ -258,16 +246,16 @@ button {
   cursor: pointer;
 }
 
-button:hover:not(:disabled) {
+:where(button):not(:where(.MuiButtonBase-root)):hover:not(:disabled) {
   background: var(--surface-hover);
 }
 
-button:disabled {
+:where(button):not(:where(.MuiButtonBase-root)):disabled {
   opacity: 0.5;
   cursor: not-allowed;
 }
 
-button:focus-visible {
+:where(button):not(:where(.MuiButtonBase-root)):focus-visible {
   outline: 2px solid var(--focus);
   outline-offset: 2px;
 }
@@ -535,34 +523,6 @@ label {
 .homeAppliedChip-type.MuiChip-root.MuiChip-deletable .MuiChip-deleteIcon:hover {
   color: var(--home-chip-outline-text) !important;
   opacity: 1 !important;
-}
-
-.appMenuPaper.MuiPaper-root {
-  background: var(--menu-surface);
-  color: var(--menu-text);
-  border: 1px solid var(--menu-border);
-  box-shadow: var(--shadow);
-}
-
-.appMenuItem.MuiMenuItem-root {
-  color: var(--menu-text);
-}
-
-.appMenuItem.MuiMenuItem-root:hover {
-  background: var(--menu-hover);
-}
-
-.appMenuItem.MuiMenuItem-root.Mui-selected {
-  background: var(--menu-selected);
-}
-
-.appMenuItem.MuiMenuItem-root.Mui-selected:hover {
-  background: var(--menu-selected);
-}
-
-.appMenuItem.MuiMenuItem-root.Mui-disabled {
-  color: var(--menu-disabled);
-  opacity: 1;
 }
 
 .homeSubheaderRow {
@@ -1634,6 +1594,16 @@ label {
   padding: 10px 16px;
 }
 
+.primaryActionButton:hover:not(:disabled) {
+  border-color: var(--accent-strong);
+  background: var(--accent-strong);
+}
+
+.primaryActionButton:active:not(:disabled) {
+  border-color: var(--accent);
+  background: var(--accent);
+}
+
 .primaryActionButton:disabled {
   border-color: var(--disabled-bg);
   background: var(--disabled-bg);
@@ -1746,59 +1716,6 @@ label {
   margin: 0;
   color: var(--text-subtle);
   font-size: 12px;
-}
-
-.detailShareDialogPaper.MuiPaper-root,
-.detailSubmitDialogPaper.MuiPaper-root {
-  background: var(--surface);
-  color: var(--text);
-  border: 1px solid var(--border);
-  box-shadow: var(--shadow);
-}
-
-.detailShareDialogPaper .MuiDialogTitle-root,
-.detailShareDialogPaper .MuiDialogContent-root,
-.detailShareDialogPaper .MuiDialogActions-root,
-.detailSubmitDialogPaper .MuiDialogTitle-root,
-.detailSubmitDialogPaper .MuiDialogContent-root,
-.detailSubmitDialogPaper .MuiDialogActions-root {
-  color: var(--text);
-}
-
-.detailShareDialogPaper .MuiTypography-root.MuiTypography-colorTextSecondary,
-.detailSubmitDialogPaper .MuiTypography-root.MuiTypography-colorTextSecondary {
-  color: var(--text-subtle) !important;
-}
-
-.detailShareDialogPaper .MuiDivider-root,
-.detailSubmitDialogPaper .MuiDivider-root {
-  border-color: var(--border);
-}
-
-.detailShareDialogPaper .MuiInputBase-root,
-.detailSubmitDialogPaper .MuiInputBase-root {
-  color: var(--text);
-  background: var(--surface-2);
-}
-
-.detailShareDialogPaper .MuiInputLabel-root,
-.detailSubmitDialogPaper .MuiInputLabel-root {
-  color: var(--text-subtle);
-}
-
-.detailShareDialogPaper .MuiOutlinedInput-notchedOutline,
-.detailSubmitDialogPaper .MuiOutlinedInput-notchedOutline {
-  border-color: var(--border);
-}
-
-.detailShareDialogPaper .MuiOutlinedInput-root:hover .MuiOutlinedInput-notchedOutline,
-.detailSubmitDialogPaper .MuiOutlinedInput-root:hover .MuiOutlinedInput-notchedOutline {
-  border-color: var(--border-strong);
-}
-
-.detailShareDialogPaper .MuiOutlinedInput-root.Mui-focused .MuiOutlinedInput-notchedOutline,
-.detailSubmitDialogPaper .MuiOutlinedInput-root.Mui-focused .MuiOutlinedInput-notchedOutline {
-  border-color: var(--focus);
 }
 
 .detailLastUpdated {
@@ -2040,6 +1957,16 @@ label {
   color: var(--on-accent);
 }
 
+.chartSubmitButton-primary:hover:not(:disabled) {
+  border-color: var(--accent-strong);
+  background: var(--accent-strong);
+}
+
+.chartSubmitButton-primary:active:not(:disabled) {
+  border-color: var(--accent);
+  background: var(--accent);
+}
+
 .chartSubmitButton-secondary {
   border-color: var(--border-strong);
   background: transparent;
@@ -2094,6 +2021,16 @@ label {
   border-color: var(--accent);
   background: var(--accent);
   color: var(--on-accent);
+}
+
+.detailSubmitPrimaryButton.emphasis:hover:not(:disabled) {
+  border-color: var(--accent-strong);
+  background: var(--accent-strong);
+}
+
+.detailSubmitPrimaryButton.emphasis:active:not(:disabled) {
+  border-color: var(--accent);
+  background: var(--accent);
 }
 
 .detailSubmitSubInfo {
@@ -2167,6 +2104,11 @@ label {
   border-color: var(--accent);
   background: var(--accent-soft);
   color: var(--accent);
+}
+
+.submitPickerActionButton-capture:hover:not(:disabled) {
+  border-color: var(--accent-strong);
+  background: var(--accent-soft);
 }
 
 .submitPickerActionLabel {

--- a/packages/web-app/src/theme/mui-theme.ts
+++ b/packages/web-app/src/theme/mui-theme.ts
@@ -1,0 +1,433 @@
+import { createTheme } from '@mui/material/styles';
+
+const SURFACE_2 = 'var(--surface-2)';
+const SURFACE_3 = 'var(--surface-3)';
+const SURFACE_MUTED = 'var(--surface-muted)';
+const BACKDROP = 'var(--backdrop)';
+const SHADOW = 'var(--shadow)';
+const SHADOW_HOVER = 'var(--shadow-hover)';
+const BORDER_STRONG = 'var(--border-strong)';
+
+type ThemeWithVars = {
+  vars?: { palette?: Record<string, any> };
+  palette: Record<string, any>;
+};
+
+function paletteVars(theme: ThemeWithVars): Record<string, any> {
+  return theme.vars?.palette ?? theme.palette;
+}
+
+export const muiTheme = createTheme({
+  cssVariables: {
+    colorSchemeSelector: 'media',
+  },
+  shape: {
+    borderRadius: 10,
+  },
+  typography: {
+    button: {
+      fontWeight: 700,
+      textTransform: 'none',
+    },
+  },
+  colorSchemes: {
+    light: {
+      palette: {
+        primary: {
+          main: '#1d4ed8',
+          dark: '#1e40af',
+          light: '#2563eb',
+          contrastText: '#ffffff',
+        },
+        error: {
+          main: '#b91c1c',
+          dark: '#991b1b',
+          light: '#dc2626',
+          contrastText: '#ffffff',
+        },
+        warning: {
+          main: '#92400e',
+          dark: '#78350f',
+          light: '#b45309',
+          contrastText: '#ffffff',
+        },
+        success: {
+          main: '#166534',
+          dark: '#14532d',
+          light: '#15803d',
+          contrastText: '#ffffff',
+        },
+        background: {
+          default: '#f7f8fa',
+          paper: '#ffffff',
+        },
+        text: {
+          primary: '#111827',
+          secondary: '#475569',
+        },
+        divider: '#d0d8e8',
+        action: {
+          hover: 'rgba(15, 23, 42, 0.06)',
+          selected: '#e9edf3',
+          disabled: '#94a3b8',
+          disabledBackground: '#f1f5f9',
+        },
+      },
+    },
+    dark: {
+      palette: {
+        primary: {
+          main: '#7caeff',
+          dark: '#6ea8ff',
+          light: '#8bc3ff',
+          contrastText: '#101826',
+        },
+        error: {
+          main: '#ff9a9a',
+          dark: '#ff7f7f',
+          light: '#ffb3b3',
+          contrastText: '#101826',
+        },
+        warning: {
+          main: '#ffbd7a',
+          dark: '#ffb070',
+          light: '#ffd4a4',
+          contrastText: '#101826',
+        },
+        success: {
+          main: '#a4ddb4',
+          dark: '#7fcf97',
+          light: '#bfe8cb',
+          contrastText: '#101826',
+        },
+        background: {
+          default: '#1f242d',
+          paper: '#2a313c',
+        },
+        text: {
+          primary: '#e5ebf3',
+          secondary: '#c2ccda',
+        },
+        divider: '#9fb0c7',
+        action: {
+          hover: 'rgba(255, 255, 255, 0.08)',
+          selected: '#334155',
+          disabled: '#94a3b8',
+          disabledBackground: '#364052',
+        },
+      },
+    },
+  },
+  components: {
+    MuiAppBar: {
+      styleOverrides: {
+        colorInherit: ({ theme }) => {
+          const palette = paletteVars(theme);
+          return {
+            backgroundColor: palette.background.paper,
+            color: palette.text.primary,
+          };
+        },
+      },
+    },
+    MuiBackdrop: {
+      styleOverrides: {
+        root: {
+          backgroundColor: BACKDROP,
+        },
+      },
+    },
+    MuiPaper: {
+      styleOverrides: {
+        root: {
+          backgroundImage: 'none',
+        },
+      },
+    },
+    MuiCard: {
+      styleOverrides: {
+        root: ({ theme }) => {
+          const palette = paletteVars(theme);
+          return {
+            '&.MuiCard-outlined': {
+              borderColor: palette.divider,
+              backgroundColor: palette.background.paper,
+              color: palette.text.primary,
+              boxShadow: SHADOW,
+            },
+            '& .MuiTypography-root.MuiTypography-colorTextSecondary': {
+              color: palette.text.secondary,
+            },
+            '& .MuiDivider-root': {
+              borderColor: palette.divider,
+            },
+            '& .MuiInputBase-root': {
+              color: palette.text.primary,
+              backgroundColor: SURFACE_2,
+            },
+            '& .MuiInputLabel-root': {
+              color: palette.text.secondary,
+            },
+            '& .MuiSelect-icon': {
+              color: palette.text.secondary,
+            },
+            '& .MuiFormHelperText-root': {
+              color: palette.text.secondary,
+            },
+            '& .MuiChip-root.MuiChip-colorDefault': {
+              backgroundColor: SURFACE_3,
+              color: palette.text.secondary,
+              border: `1px solid ${palette.divider}`,
+            },
+            '& .MuiChip-root.MuiChip-colorDefault .MuiChip-icon, & .MuiChip-root.MuiChip-colorDefault .MuiChip-deleteIcon': {
+              color: palette.text.secondary,
+            },
+            '& .MuiOutlinedInput-notchedOutline': {
+              borderColor: palette.divider,
+            },
+            '& .MuiOutlinedInput-root:hover .MuiOutlinedInput-notchedOutline': {
+              borderColor: palette.text.secondary,
+            },
+            '& .MuiOutlinedInput-root.Mui-focused .MuiOutlinedInput-notchedOutline': {
+              borderColor: palette.primary.main,
+            },
+            '& .MuiFormControlLabel-label': {
+              color: palette.text.primary,
+            },
+            '& .MuiInputLabel-root.Mui-disabled': {
+              color: palette.action.disabled,
+            },
+            '& .MuiInputBase-input.Mui-disabled': {
+              color: palette.text.secondary,
+              WebkitTextFillColor: palette.text.secondary,
+            },
+            '& .MuiInputBase-root.Mui-disabled': {
+              backgroundColor: SURFACE_3,
+            },
+            '& .MuiSwitch-track': {
+              backgroundColor: SURFACE_MUTED,
+              opacity: 1,
+            },
+            '& .MuiSwitch-thumb': {
+              backgroundColor: palette.background.paper,
+            },
+            '& .MuiSwitch-switchBase.Mui-checked': {
+              color: palette.background.paper,
+            },
+            '& .MuiSwitch-switchBase.Mui-checked + .MuiSwitch-track': {
+              backgroundColor: palette.primary.light,
+              opacity: 1,
+            },
+            '& .MuiAccordionSummary-expandIconWrapper': {
+              color: palette.text.secondary,
+            },
+          };
+        },
+      },
+    },
+    MuiDialog: {
+      styleOverrides: {
+        paper: ({ theme }) => {
+          const palette = paletteVars(theme);
+          return {
+            backgroundColor: palette.background.paper,
+            color: palette.text.primary,
+            border: `1px solid ${palette.divider}`,
+            boxShadow: SHADOW,
+            '& .MuiDialogTitle-root, & .MuiDialogContent-root, & .MuiDialogActions-root': {
+              color: palette.text.primary,
+            },
+            '& .MuiDialogContentText-root, & .MuiTypography-root.MuiTypography-colorTextSecondary': {
+              color: palette.text.secondary,
+            },
+            '& .MuiDivider-root': {
+              borderColor: palette.divider,
+            },
+            '& .MuiInputBase-root': {
+              color: palette.text.primary,
+              backgroundColor: SURFACE_2,
+            },
+            '& .MuiInputLabel-root': {
+              color: palette.text.secondary,
+            },
+            '& .MuiOutlinedInput-notchedOutline': {
+              borderColor: palette.divider,
+            },
+            '& .MuiOutlinedInput-root:hover .MuiOutlinedInput-notchedOutline': {
+              borderColor: palette.text.secondary,
+            },
+            '& .MuiOutlinedInput-root.Mui-focused .MuiOutlinedInput-notchedOutline': {
+              borderColor: palette.primary.main,
+            },
+            '& .hintText': {
+              color: palette.text.secondary,
+            },
+          };
+        },
+      },
+    },
+    MuiDialogContent: {
+      styleOverrides: {
+        root: ({ theme }) => {
+          const palette = paletteVars(theme);
+          return {
+            '&.MuiDialogContent-dividers': {
+              borderTopColor: palette.divider,
+              borderBottomColor: palette.divider,
+            },
+          };
+        },
+      },
+    },
+    MuiDialogActions: {
+      styleOverrides: {
+        root: ({ theme }) => ({
+          borderTop: `1px solid ${paletteVars(theme).divider}`,
+        }),
+      },
+    },
+    MuiMenu: {
+      styleOverrides: {
+        paper: ({ theme }) => {
+          const palette = paletteVars(theme);
+          return {
+            backgroundColor: palette.background.paper,
+            color: palette.text.primary,
+            border: `1px solid ${palette.divider}`,
+            boxShadow: SHADOW,
+          };
+        },
+      },
+    },
+    MuiMenuItem: {
+      styleOverrides: {
+        root: ({ theme }) => {
+          const palette = paletteVars(theme);
+          return {
+            '&:hover': {
+              backgroundColor: palette.action.hover,
+            },
+            '&.Mui-selected, &.Mui-selected:hover': {
+              backgroundColor: palette.action.selected,
+            },
+            '&.Mui-disabled': {
+              color: palette.action.disabled,
+              opacity: 1,
+            },
+          };
+        },
+      },
+    },
+    MuiButton: {
+      styleOverrides: {
+        root: ({ theme }) => {
+          const palette = paletteVars(theme);
+          return {
+            borderRadius: 10,
+            '&.Mui-disabled': {
+              borderColor: palette.divider,
+              color: palette.action.disabled,
+              backgroundColor: palette.action.disabledBackground,
+            },
+          };
+        },
+        contained: {
+          boxShadow: SHADOW,
+          '&:hover': {
+            boxShadow: SHADOW_HOVER,
+          },
+        },
+        containedPrimary: ({ theme }) => {
+          const palette = paletteVars(theme);
+          return {
+            backgroundColor: palette.primary.main,
+            color: palette.primary.contrastText,
+            '&:hover': {
+              backgroundColor: palette.primary.dark,
+            },
+          };
+        },
+        containedError: ({ theme }) => {
+          const palette = paletteVars(theme);
+          return {
+            backgroundColor: palette.error.main,
+            color: palette.error.contrastText,
+            '&:hover': {
+              backgroundColor: palette.error.dark,
+            },
+          };
+        },
+        containedWarning: ({ theme }) => {
+          const palette = paletteVars(theme);
+          return {
+            backgroundColor: palette.warning.main,
+            color: palette.warning.contrastText,
+            '&:hover': {
+              backgroundColor: palette.warning.dark,
+            },
+          };
+        },
+        containedSuccess: ({ theme }) => {
+          const palette = paletteVars(theme);
+          return {
+            backgroundColor: palette.success.main,
+            color: palette.success.contrastText,
+            '&:hover': {
+              backgroundColor: palette.success.dark,
+            },
+          };
+        },
+        outlined: ({ theme }) => {
+          const palette = paletteVars(theme);
+          return {
+            borderColor: palette.divider,
+            '&:hover': {
+              borderColor: palette.text.secondary,
+              backgroundColor: palette.action.hover,
+            },
+          };
+        },
+      },
+    },
+    MuiFab: {
+      styleOverrides: {
+        root: {
+          boxShadow: SHADOW,
+          '&:hover': {
+            boxShadow: SHADOW_HOVER,
+          },
+        },
+      },
+    },
+    MuiOutlinedInput: {
+      styleOverrides: {
+        root: ({ theme }) => {
+          const palette = paletteVars(theme);
+          return {
+            '& .MuiOutlinedInput-notchedOutline': {
+              borderColor: palette.divider,
+            },
+            '&:hover .MuiOutlinedInput-notchedOutline': {
+              borderColor: palette.text.secondary,
+            },
+          };
+        },
+      },
+    },
+    MuiToggleButton: {
+      styleOverrides: {
+        root: ({ theme }) => {
+          const palette = paletteVars(theme);
+          return {
+            color: palette.text.secondary,
+            borderColor: BORDER_STRONG,
+            '&.Mui-selected, &.Mui-selected:hover': {
+              backgroundColor: palette.action.selected,
+              color: palette.text.primary,
+            },
+          };
+        },
+      },
+    },
+  },
+});

--- a/tasks/feat-mui-theme-phase1.md
+++ b/tasks/feat-mui-theme-phase1.md
@@ -1,0 +1,99 @@
+# Plan: feat/mui-theme-phase1
+
+## 目的
+
+- MUIコンポーネント配色を、MUI公式の `colorSchemes` ベースへ先行移行する。
+- OSダークモード追従をMUIテーマ側で成立させる。
+- 既存機能や画面導線は変更せず、色定義の配置のみを整理する。
+
+## 非目的
+
+- 非MUI要素（素のHTML/CSS）配色の全面置換。
+- レイアウト変更やUI構造変更。
+- ダークモードON/OFFトグルUI追加。
+- Service Worker / Web Locks / import-export / データ永続化仕様の変更。
+- 依存関係更新。
+
+## 変更点
+
+- `packages/web-app/src/theme/mui-theme.ts` を新規作成し、`createTheme` + `colorSchemes`（light/dark）を定義する。
+- 同ファイルでMUI主要コンポーネントの色系 `styleOverrides`（Button/Menu/MenuItem/Dialog など）を集約する。
+- `packages/web-app/src/main.tsx` に `ThemeProvider` を導入し、全レンダー経路で共通テーマを適用する。
+- `CssBaseline` は本フェーズでは導入せず、既存CSSとの競合を最小化する。
+- MUIテーマ化により不要となったメニュー配色CSS（`appMenuPaper` / `appMenuItem` と関連トークン）を削除する。
+- `App.tsx` の `Menu` / `MenuItem` から、不要になった `className` 参照を削除する。
+- 高優先のTheme移管として、詳細/提出ダイアログのクラス依存配色を `mui-theme.ts` の `MuiDialog` 系overrideへ集約する。
+- `SettingsPage.tsx` の `cardSx` 内に残る `.Mui*` 配色指定をテーマ側へ移管し、ローカル `sx` を最小化する。
+- `ImportQrScannerDialog.tsx` の `Dialog` 色指定 `sx` をテーマ側へ移管し、重複指定を削減する。
+- グローバル `button` ルールの対象を非MUI要素へ限定し、MUI Button/FAB の hover 白飛びを解消する（一覧ソート等の非MUIボタン見た目は維持）。
+- MUI dark未適用箇所（3点リーダーメニュー/プルダウン/ダイアログ群）を `theme.vars` ベースへ統一し、OSダーク時にMUI配色がライト固定化しないよう是正する。
+
+## 影響範囲
+
+- ユーザー影響:
+  - MUIコンポーネントの配色はテーマ定義を基準に切り替わる。
+  - OSダークモード時のMUI配色整合性が向上する。
+- データ影響:
+  - なし。
+- 互換性:
+  - 既存挙動（機能・遷移・保存）は維持。
+
+## 実装方針（対象ファイル単位）
+
+- `packages/web-app/src/theme/mui-theme.ts`（新規）
+  - `colorSchemes.light` / `colorSchemes.dark` の `palette` を定義。
+  - `components` にMUI配色overrideを定義し、現在のトークン意図を踏襲する。
+  - `theme.palette` 固定参照ではなく `theme.vars.palette`（必要に応じて CSSトークン）を使い、ダークモード時の `Menu/Select/Dialog` 配色反映を保証する。
+- `packages/web-app/src/main.tsx`
+  - テーマ適用ヘルパーを追加し、`root.render` の全経路で `ThemeProvider` を適用する。
+- `packages/web-app/src/styles.css`
+  - MUIテーマに置き換わった `appMenuPaper` / `appMenuItem` 関連スタイルと専用トークンを削除する。
+  - `detailShareDialogPaper` / `detailSubmitDialogPaper` のMUI配色ブロックを削除する。
+  - `button` のグローバル配色ルールを非MUIへ限定し、MUI hover競合を解消する。
+- `packages/web-app/src/App.tsx`
+  - 上記CSS削除に合わせて、`Menu` / `MenuItem` の `className` 依存を除去する。
+- `packages/web-app/src/pages/TournamentDetailPage.tsx`
+  - ダイアログ `PaperProps.className` 依存を削除し、テーマ配色へ統合する。
+- `packages/web-app/src/pages/SettingsPage.tsx`
+  - `cardSx` に残るMUI配色指定を削減し、テーマ定義へ寄せる。
+- `packages/web-app/src/components/ImportQrScannerDialog.tsx`
+  - Dialogの `PaperProps.sx` / `DialogContent.sx` の配色指定を削除し、テーマ定義へ寄せる。
+
+## テスト観点
+
+- Light:
+  - MUI Button/Menu/Dialog の背景・文字色・hoverが破綻しない。
+- Dark:
+  - OSダーク時にMUIコンポーネントがライト配色のまま残らない。
+- CSS整理:
+  - 削除対象のMUI配色CSSが未参照になっていること。
+  - 詳細/提出ダイアログ、設定画面Card内要素、QR取込ダイアログで色崩れがないこと。
+- 回帰:
+  - 既存テストが通過し、挙動変更がない。
+
+## ロールバック方針
+
+- 配色不整合が出た場合:
+  - `main.tsx` の ThemeProvider 導入差分をrevertして即時復旧。
+  - 必要に応じて `mui-theme.ts` を全revert。
+
+## Commit Plan
+
+1. `mui-theme.ts` の追加（colorSchemes + components override）。
+2. `main.tsx` へ ThemeProvider 導入（全render経路適用）。
+3. `styles.css` / `App.tsx` の不要MUIメニュー配色定義を削除。
+4. ダイアログ/設定/QR取込のMUI配色をテーマへ移管し、重複CSS/`sx` を削減。
+5. lint/test/build 実施と差分スコープ確認。
+
+## Scope Declaration
+
+- 変更対象を以下に固定する。
+  - `tasks/feat-mui-theme-phase1.md`
+  - `packages/web-app/src/theme/mui-theme.ts`
+  - `packages/web-app/src/main.tsx`
+  - `packages/web-app/src/styles.css`
+  - `packages/web-app/src/App.tsx`
+  - `packages/web-app/src/pages/TournamentDetailPage.tsx`
+  - `packages/web-app/src/pages/SettingsPage.tsx`
+  - `packages/web-app/src/components/ImportQrScannerDialog.tsx`
+- 上記以外の変更は禁止。必要が生じた場合は本tasksを更新してから実施する。

--- a/tasks/feat-mui-theme-phase1.md
+++ b/tasks/feat-mui-theme-phase1.md
@@ -85,6 +85,11 @@
 4. ダイアログ/設定/QR取込のMUI配色をテーマへ移管し、重複CSS/`sx` を削減。
 5. lint/test/build 実施と差分スコープ確認。
 
+### Commit Plan 実施結果
+
+- 上記1-5は密結合のため、途中段階で配色崩れを残さないことを優先し、単一コミットに集約して実施した。
+- 変更対象ファイルは Scope Declaration 内に限定し、検証（lint/test/build）完了後にコミットした。
+
 ## Scope Declaration
 
 - 変更対象を以下に固定する。


### PR DESCRIPTION
## 目的
- MUIコンポーネント配色を `colorSchemes` ベースへ先行移行し、OSダークモード追従を安定化する。
- ライトモード回帰（ボタン白飛び）を抑えつつ、MUI領域のテーマ適用漏れを是正する。

## 変更点
- `packages/web-app/src/theme/mui-theme.ts` を追加し、MUIテーマを一元定義。
- `packages/web-app/src/main.tsx` で全render経路を `ThemeProvider` でラップ。
- メニュー/ダイアログ/フォーム系のMUI配色をテーマoverrideへ移管。
- `App.tsx` の `Menu` / `MenuItem` から不要class依存を削除。
- `SettingsPage.tsx` の `cardSx` 内 `.Mui*` 配色指定を削減し、テーマ側へ移管。
- `TournamentDetailPage.tsx` / `ImportQrScannerDialog.tsx` のDialog配色依存 (`PaperProps` / `sx`) を削減。
- `styles.css` の不要MUI配色ブロックを削除し、グローバルbutton競合を調整。
- `tasks/feat-mui-theme-phase1.md` を作成・更新（実施結果含む）。

## 非変更点
- 非MUI要素の全面テーマ移行（Phase 2で実施）。
- レイアウト/UX構造の変更。
- Service Worker / Web Locks / import-export / データ永続化仕様の変更。
- 依存関係の更新。

## 影響範囲
- ユーザー影響:
  - MUIコンポーネント（Menu / Select / Dialog / Button / Fab / Card）のライト/ダーク配色整合性が向上。
- データ影響:
  - なし。
- 互換性:
  - 既存機能・導線・保存仕様は維持。

## テスト内容
- `pnpm lint`
- `pnpm test`
- `pnpm build`

## 回帰確認項目
- 3点リーダーメニューがダーク時にライト配色へ固定されないこと。
- プルダウン（設定画面、一覧ソートのMenu）がダーク配色で表示されること。
- ダイアログ（コピー/削除/提出/共有）がダーク配色で表示されること。
- ライトモードでMUIボタン/FABのhover白飛びが発生しないこと。