### PR TITLE
refactor(web-app): phase2 migrate remaining mui class-based styles

### DIFF
--- a/packages/web-app/src/App.tsx
+++ b/packages/web-app/src/App.tsx
@@ -354,6 +354,70 @@ const EMPTY_HOME_TOURNAMENT_BUCKETS: HomeTournamentBuckets = {
 
 const HOME_FILTER_ATTR_VALUES: readonly HomeFilterAttr[] = ['send-waiting', 'imported', 'created'];
 const HOME_APPLIED_CHIP_MAX_VISIBLE = 3;
+const homeAppliedChipBaseSx = {
+  maxWidth: '100%',
+  '& .MuiChip-label': {
+    fontWeight: 600,
+  },
+} as const;
+const homeAppliedChipTonalSx = {
+  backgroundColor: 'var(--home-chip-tonal-bg)',
+  color: 'var(--home-chip-tonal-text)',
+  '&:hover': {
+    backgroundColor: 'var(--home-chip-hover)',
+  },
+  '& .MuiChip-label': {
+    color: 'var(--home-chip-tonal-text)',
+  },
+  '& .MuiChip-deleteIcon': {
+    color: 'var(--home-chip-delete)',
+    opacity: 1,
+  },
+  '& .MuiChip-deleteIcon:hover': {
+    color: 'var(--home-chip-tonal-text)',
+    opacity: 1,
+  },
+} as const;
+const homeAppliedChipOutlineSx = {
+  borderColor: 'var(--home-chip-outline-border)',
+  color: 'var(--home-chip-outline-text)',
+  backgroundColor: 'var(--home-chip-outline-bg)',
+  '& .MuiChip-label': {
+    color: 'var(--home-chip-outline-text)',
+  },
+  '& .MuiChip-deleteIcon': {
+    color: 'var(--home-chip-delete)',
+    opacity: 1,
+  },
+  '& .MuiChip-deleteIcon:hover': {
+    color: 'var(--home-chip-outline-text)',
+    opacity: 1,
+  },
+} as const;
+const homeFilterToggleButtonGroupSx = {
+  '& .MuiToggleButtonGroup-grouped': {
+    backgroundColor: 'transparent',
+    border: '1px solid var(--home-filter-sheet-segment-border)',
+    color: 'var(--home-filter-sheet-segment-text)',
+  },
+  '& .MuiToggleButtonGroup-grouped.Mui-selected': {
+    backgroundColor: 'var(--home-filter-sheet-segment-selected-bg)',
+    borderColor: 'var(--home-filter-sheet-segment-selected-border)',
+    color: 'var(--home-filter-sheet-segment-selected-text)',
+  },
+  '& .MuiToggleButtonGroup-grouped.Mui-selected:hover': {
+    backgroundColor: 'var(--home-filter-sheet-segment-selected-bg)',
+  },
+  '& .MuiToggleButtonGroup-grouped:hover': {
+    backgroundColor: 'var(--home-filter-sheet-hover)',
+  },
+} as const;
+const homeFilterDividerSx = {
+  borderColor: 'var(--home-filter-sheet-divider)',
+} as const;
+const homeFilterCheckboxSx = {
+  color: 'var(--home-filter-checkbox-unchecked)',
+} as const;
 
 function normalizeAsciiLowercase(value: string): string {
   return value.replace(/[A-Z]/g, (char) => char.toLowerCase());
@@ -2545,6 +2609,11 @@ export function App({ webLockAcquired = false }: AppProps = {}): JSX.Element {
                       ]
                         .filter((className) => className.length > 0)
                         .join(' ')}
+                      sx={[
+                        homeAppliedChipBaseSx,
+                        chip.variant === 'tonal' && homeAppliedChipTonalSx,
+                        chip.category === 'type' && homeAppliedChipOutlineSx,
+                      ]}
                       label={chip.label}
                       onClick={chip.onClick}
                       {...(chip.onRemove ? { onDelete: chip.onRemove } : {})}
@@ -2556,6 +2625,7 @@ export function App({ webLockAcquired = false }: AppProps = {}): JSX.Element {
                       clickable
                       variant="outlined"
                       className="homeAppliedChip homeAppliedChip-overflow"
+                      sx={[homeAppliedChipBaseSx, homeAppliedChipOutlineSx]}
                       label={`+${homeHiddenAppliedChipCount}`}
                       onClick={() => openHomeFilterSheet()}
                     />
@@ -2758,6 +2828,7 @@ export function App({ webLockAcquired = false }: AppProps = {}): JSX.Element {
                   exclusive
                   size="small"
                   fullWidth
+                  sx={homeFilterToggleButtonGroupSx}
                   onChange={(_event, value: TournamentTab | null) => {
                     if (!value) {
                       return;
@@ -2773,7 +2844,7 @@ export function App({ webLockAcquired = false }: AppProps = {}): JSX.Element {
                   <ToggleButton value="ended">{t('common.home_filter.state.ended')}</ToggleButton>
                 </ToggleButtonGroup>
               </div>
-              <Divider />
+              <Divider sx={homeFilterDividerSx} />
             </div>
             <Box className="homeFilterSheetBody">
               <div className="homeFilterSection" ref={homeCategorySectionRef}>
@@ -2785,6 +2856,7 @@ export function App({ webLockAcquired = false }: AppProps = {}): JSX.Element {
                   exclusive
                   size="small"
                   fullWidth
+                  sx={homeFilterToggleButtonGroupSx}
                   onChange={(_event, value: HomeFilterCategory | null) => {
                     setHomeQuery((previous) => ({
                       ...previous,
@@ -2796,7 +2868,7 @@ export function App({ webLockAcquired = false }: AppProps = {}): JSX.Element {
                   <ToggleButton value="completed">{t('common.home_filter.category.completed')}</ToggleButton>
                 </ToggleButtonGroup>
               </div>
-              <Divider />
+              <Divider sx={homeFilterDividerSx} />
               <div className="homeFilterSection" ref={homeTypeSectionRef}>
                 <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 1 }}>
                   {t('common.home_filter.section.type')}
@@ -2806,6 +2878,7 @@ export function App({ webLockAcquired = false }: AppProps = {}): JSX.Element {
                   exclusive
                   size="small"
                   fullWidth
+                  sx={homeFilterToggleButtonGroupSx}
                   onChange={(_event, value: 'imported' | 'created' | null) => {
                     setHomeQuery((previous) => {
                       const attrsWithoutType = previous.attrs.filter((entry) => entry !== 'imported' && entry !== 'created');
@@ -2820,7 +2893,7 @@ export function App({ webLockAcquired = false }: AppProps = {}): JSX.Element {
                   <ToggleButton value="created">{t('common.home_filter.type.created')}</ToggleButton>
                 </ToggleButtonGroup>
               </div>
-              <Divider />
+              <Divider sx={homeFilterDividerSx} />
               <div className="homeFilterSection" ref={homeAttrsSectionRef}>
                 <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 1 }}>
                   {t('common.home_filter.section.attr')}
@@ -2829,6 +2902,7 @@ export function App({ webLockAcquired = false }: AppProps = {}): JSX.Element {
                   <FormControlLabel
                     control={
                       <Checkbox
+                        sx={homeFilterCheckboxSx}
                         checked={homeQuery.attrs.includes('send-waiting')}
                         onChange={(event) => {
                           setHomeQuery((previous) => ({

--- a/packages/web-app/src/pages/CreateTournamentPage.tsx
+++ b/packages/web-app/src/pages/CreateTournamentPage.tsx
@@ -64,51 +64,6 @@ const DATE_PICKER_TEXT_FIELD_SX = {
     color: 'var(--text-subtle)',
   },
 } as const;
-const SONG_AUTOCOMPLETE_SX = {
-  width: '100%',
-  maxWidth: '100%',
-  '& .MuiInputBase-root': {
-    minHeight: 44,
-  },
-  '& .MuiOutlinedInput-root': {
-    backgroundColor: 'var(--surface)',
-    color: 'var(--text)',
-  },
-  '& .MuiInputBase-input::placeholder': {
-    color: 'var(--text-faint)',
-    opacity: 1,
-  },
-  '& .MuiAutocomplete-popupIndicator': {
-    color: 'var(--create-song-popup-icon)',
-  },
-  '& .MuiAutocomplete-clearIndicator': {
-    color: 'var(--text-subtle)',
-  },
-} as const;
-const SONG_AUTOCOMPLETE_POPPER_SX = {
-  '& .MuiPaper-root': {
-    background: 'var(--create-song-dropdown-bg)',
-    color: 'var(--text)',
-    border: '1px solid var(--create-song-dropdown-border)',
-    boxShadow: 'var(--shadow)',
-  },
-  '& .MuiAutocomplete-listbox': {
-    background: 'var(--create-song-dropdown-bg)',
-    color: 'var(--text)',
-  },
-  '& .MuiAutocomplete-option': {
-    color: 'var(--text)',
-  },
-  '& .MuiAutocomplete-option:hover, & .MuiAutocomplete-option.Mui-focused': {
-    background: 'var(--create-song-dropdown-hover)',
-  },
-  "& .MuiAutocomplete-option[aria-selected='true']": {
-    background: 'var(--create-song-dropdown-selected)',
-  },
-  "& .MuiAutocomplete-option[aria-selected='true'].Mui-focused": {
-    background: 'var(--create-song-dropdown-selected)',
-  },
-} as const;
 const DATE_PICKER_LOCALE_TEXT_BY_LANGUAGE = {
   ja: jaJP.components.MuiLocalizationProvider.defaultProps.localeText as any,
   en: enUS.components.MuiLocalizationProvider.defaultProps.localeText as any,
@@ -696,92 +651,85 @@ export function CreateTournamentPage(props: CreateTournamentPageProps): JSX.Elem
 
                   <div className="createField">
                     <span className="createFieldLabel">{t('create_tournament.field.song.label')}</span>
-                    <Box sx={SONG_AUTOCOMPLETE_SX}>
-                      <Autocomplete<SongSummary, false, false, false>
-                        className="createSongAutocompleteRoot"
-                        fullWidth
-                        openOnFocus
-                        options={row.options}
-                        slotProps={{
-                          popper: {
-                            sx: SONG_AUTOCOMPLETE_POPPER_SX,
-                          },
-                        }}
-                        filterOptions={(options) => options}
-                        value={row.selectedSong}
-                        inputValue={row.query}
-                        loading={row.loading}
-                        onOpen={() => {
-                          if (row.options.length === 0 && row.query.trim().length > 0) {
-                            void handleSearch(row.key, row.query);
-                          }
-                        }}
-                        noOptionsText={
-                          row.query.trim().length === 0
-                            ? t('create_tournament.field.song.no_options_empty_query')
-                            : t('create_tournament.field.song.no_options_not_found')
+                    <Autocomplete<SongSummary, false, false, false>
+                      className="createSongAutocompleteRoot"
+                      fullWidth
+                      openOnFocus
+                      options={row.options}
+                      filterOptions={(options) => options}
+                      value={row.selectedSong}
+                      inputValue={row.query}
+                      loading={row.loading}
+                      onOpen={() => {
+                        if (row.options.length === 0 && row.query.trim().length > 0) {
+                          void handleSearch(row.key, row.query);
                         }
-                        loadingText={t('create_tournament.field.song.loading')}
-                        isOptionEqualToValue={(option, value) => option.musicId === value.musicId}
-                        getOptionLabel={(option) => option.title}
-                        onInputChange={(_, value, reason) => {
-                          if (reason === 'input' || reason === 'clear') {
-                            void handleSearch(row.key, value);
-                            return;
-                          }
-                          updateRow(row.key, (current) => ({
-                            ...current,
-                            query: value,
-                          }));
-                        }}
-                        onChange={(_, selectedSong) => {
-                          updateRow(row.key, (current) => ({
-                            ...current,
-                            selectedSong,
-                            query: selectedSong?.title ?? '',
-                            chartOptions: [],
-                            selectedChartId: null,
-                          }));
-                          if (selectedSong) {
-                            void loadCharts(row.key, selectedSong.musicId, row.playStyle);
-                          }
-                        }}
-                        renderInput={(params) => (
-                          <TextField
-                            {...(params as any)}
-                            placeholder={t('create_tournament.field.song.placeholder')}
-                            InputProps={{
-                              ...params.InputProps,
-                              endAdornment: (
-                                <>
-                                  {row.loading ? <CircularProgress color="inherit" size={16} /> : null}
-                                  {params.InputProps.endAdornment}
-                                </>
-                              ),
-                            }}
-                          />
-                        )}
-                        renderOption={(optionProps, option) => {
-                          const { key: optionKey, ...liProps } = optionProps as Record<string, unknown> & { key?: React.Key };
-                          return (
-                            <Box
-                              component="li"
-                              key={option.musicId > 0 ? `music-${option.musicId}` : String(optionKey ?? option.title)}
-                              {...liProps}
-                            >
-                              <Box sx={{ display: 'grid', gap: 0.5 }}>
-                                <Typography variant="caption" className="createSongAutocompleteOptionVersion">
-                                  [{versionLabel(option.version)}]
-                                </Typography>
-                                <Typography variant="body2" sx={{ whiteSpace: 'normal', wordBreak: 'break-word' }}>
-                                  {option.title}
-                                </Typography>
-                              </Box>
+                      }}
+                      noOptionsText={
+                        row.query.trim().length === 0
+                          ? t('create_tournament.field.song.no_options_empty_query')
+                          : t('create_tournament.field.song.no_options_not_found')
+                      }
+                      loadingText={t('create_tournament.field.song.loading')}
+                      isOptionEqualToValue={(option, value) => option.musicId === value.musicId}
+                      getOptionLabel={(option) => option.title}
+                      onInputChange={(_, value, reason) => {
+                        if (reason === 'input' || reason === 'clear') {
+                          void handleSearch(row.key, value);
+                          return;
+                        }
+                        updateRow(row.key, (current) => ({
+                          ...current,
+                          query: value,
+                        }));
+                      }}
+                      onChange={(_, selectedSong) => {
+                        updateRow(row.key, (current) => ({
+                          ...current,
+                          selectedSong,
+                          query: selectedSong?.title ?? '',
+                          chartOptions: [],
+                          selectedChartId: null,
+                        }));
+                        if (selectedSong) {
+                          void loadCharts(row.key, selectedSong.musicId, row.playStyle);
+                        }
+                      }}
+                      renderInput={(params) => (
+                        <TextField
+                          {...(params as any)}
+                          placeholder={t('create_tournament.field.song.placeholder')}
+                          InputProps={{
+                            ...params.InputProps,
+                            endAdornment: (
+                              <>
+                                {row.loading ? <CircularProgress color="inherit" size={16} /> : null}
+                                {params.InputProps.endAdornment}
+                              </>
+                            ),
+                          }}
+                        />
+                      )}
+                      renderOption={(optionProps, option) => {
+                        const { key: optionKey, ...liProps } = optionProps as Record<string, unknown> & { key?: React.Key };
+                        return (
+                          <Box
+                            component="li"
+                            key={option.musicId > 0 ? `music-${option.musicId}` : String(optionKey ?? option.title)}
+                            {...liProps}
+                          >
+                            <Box sx={{ display: 'grid', gap: 0.5 }}>
+                              <Typography variant="caption" className="createSongAutocompleteOptionVersion">
+                                [{versionLabel(option.version)}]
+                              </Typography>
+                              <Typography variant="body2" sx={{ whiteSpace: 'normal', wordBreak: 'break-word' }}>
+                                {option.title}
+                              </Typography>
                             </Box>
-                          );
-                        }}
-                      />
-                    </Box>
+                          </Box>
+                        );
+                      }}
+                    />
                     {rowSongMissing ? (
                       <p className="errorText createInlineError createInlineErrorCompact">
                         {t('create_tournament.validation.chart_song_required')}

--- a/packages/web-app/src/pages/CreateTournamentPage.tsx
+++ b/packages/web-app/src/pages/CreateTournamentPage.tsx
@@ -46,24 +46,6 @@ type AppLanguage = 'ja' | 'en' | 'ko';
 
 const SONG_SEARCH_DEBUG_STORAGE_KEY = 'iidx:debug:song-search';
 const CREATE_WIZARD_DEBUG_STORAGE_KEY = 'iidx:debug:create-wizard';
-const DATE_PICKER_TEXT_FIELD_SX = {
-  '& .MuiOutlinedInput-root, & .MuiInputBase-root, & .MuiPickersInputBase-root, & .MuiPickersOutlinedInput-root': {
-    backgroundColor: 'var(--surface)',
-    color: 'var(--text)',
-    minHeight: 44,
-  },
-  '& .MuiInputBase-input, & .MuiPickersInputBase-input, & .MuiPickersSectionList-root, & .MuiPickersSectionList-section': {
-    color: 'var(--text) !important',
-    WebkitTextFillColor: 'var(--text)',
-  },
-  '& .MuiInputBase-input::placeholder': {
-    color: 'var(--text-faint)',
-    opacity: 1,
-  },
-  '& .MuiIconButton-root, & .MuiSvgIcon-root': {
-    color: 'var(--text-subtle)',
-  },
-} as const;
 const DATE_PICKER_LOCALE_TEXT_BY_LANGUAGE = {
   ja: jaJP.components.MuiLocalizationProvider.defaultProps.localeText as any,
   en: enUS.components.MuiLocalizationProvider.defaultProps.localeText as any,
@@ -533,7 +515,7 @@ export function CreateTournamentPage(props: CreateTournamentPageProps): JSX.Elem
                             placeholder: t('create_tournament.field.period.start_placeholder'),
                             fullWidth: true,
                             size: 'small',
-                            sx: DATE_PICKER_TEXT_FIELD_SX,
+                            className: 'createPeriodDatePickerTextField',
                           },
                         }}
                       />
@@ -558,7 +540,7 @@ export function CreateTournamentPage(props: CreateTournamentPageProps): JSX.Elem
                             placeholder: t('create_tournament.field.period.end_placeholder'),
                             fullWidth: true,
                             size: 'small',
-                            sx: DATE_PICKER_TEXT_FIELD_SX,
+                            className: 'createPeriodDatePickerTextField',
                           },
                         }}
                       />

--- a/packages/web-app/src/pages/CreateTournamentPage.tsx
+++ b/packages/web-app/src/pages/CreateTournamentPage.tsx
@@ -46,9 +46,30 @@ type AppLanguage = 'ja' | 'en' | 'ko';
 
 const SONG_SEARCH_DEBUG_STORAGE_KEY = 'iidx:debug:song-search';
 const CREATE_WIZARD_DEBUG_STORAGE_KEY = 'iidx:debug:create-wizard';
+const DATE_PICKER_TEXT_FIELD_SX = {
+  '& .MuiOutlinedInput-root, & .MuiInputBase-root, & .MuiPickersInputBase-root, & .MuiPickersOutlinedInput-root': {
+    backgroundColor: 'var(--surface)',
+    color: 'var(--text)',
+    minHeight: 44,
+  },
+  '& .MuiInputBase-input, & .MuiPickersInputBase-input, & .MuiPickersSectionList-root, & .MuiPickersSectionList-section': {
+    color: 'var(--text) !important',
+    WebkitTextFillColor: 'var(--text)',
+  },
+  '& .MuiInputBase-input::placeholder': {
+    color: 'var(--text-faint)',
+    opacity: 1,
+  },
+  '& .MuiIconButton-root, & .MuiSvgIcon-root': {
+    color: 'var(--text-subtle)',
+  },
+} as const;
 const SONG_AUTOCOMPLETE_SX = {
   width: '100%',
   maxWidth: '100%',
+  '& .MuiInputBase-root': {
+    minHeight: 44,
+  },
   '& .MuiOutlinedInput-root': {
     backgroundColor: 'var(--surface)',
     color: 'var(--text)',
@@ -62,6 +83,30 @@ const SONG_AUTOCOMPLETE_SX = {
   },
   '& .MuiAutocomplete-clearIndicator': {
     color: 'var(--text-subtle)',
+  },
+} as const;
+const SONG_AUTOCOMPLETE_POPPER_SX = {
+  '& .MuiPaper-root': {
+    background: 'var(--create-song-dropdown-bg)',
+    color: 'var(--text)',
+    border: '1px solid var(--create-song-dropdown-border)',
+    boxShadow: 'var(--shadow)',
+  },
+  '& .MuiAutocomplete-listbox': {
+    background: 'var(--create-song-dropdown-bg)',
+    color: 'var(--text)',
+  },
+  '& .MuiAutocomplete-option': {
+    color: 'var(--text)',
+  },
+  '& .MuiAutocomplete-option:hover, & .MuiAutocomplete-option.Mui-focused': {
+    background: 'var(--create-song-dropdown-hover)',
+  },
+  "& .MuiAutocomplete-option[aria-selected='true']": {
+    background: 'var(--create-song-dropdown-selected)',
+  },
+  "& .MuiAutocomplete-option[aria-selected='true'].Mui-focused": {
+    background: 'var(--create-song-dropdown-selected)',
   },
 } as const;
 const DATE_PICKER_LOCALE_TEXT_BY_LANGUAGE = {
@@ -528,7 +573,14 @@ export function CreateTournamentPage(props: CreateTournamentPageProps): JSX.Elem
                           }));
                         }}
                         format="yyyy/MM/dd"
-                        slotProps={{ textField: { placeholder: t('create_tournament.field.period.start_placeholder'), fullWidth: true, size: 'small' } }}
+                        slotProps={{
+                          textField: {
+                            placeholder: t('create_tournament.field.period.start_placeholder'),
+                            fullWidth: true,
+                            size: 'small',
+                            sx: DATE_PICKER_TEXT_FIELD_SX,
+                          },
+                        }}
                       />
                     </LocalizationProvider>
                     {validation.startDateError ? <p className="errorText createInlineError">{t(validation.startDateError)}</p> : null}
@@ -546,7 +598,14 @@ export function CreateTournamentPage(props: CreateTournamentPageProps): JSX.Elem
                           }));
                         }}
                         format="yyyy/MM/dd"
-                        slotProps={{ textField: { placeholder: t('create_tournament.field.period.end_placeholder'), fullWidth: true, size: 'small' } }}
+                        slotProps={{
+                          textField: {
+                            placeholder: t('create_tournament.field.period.end_placeholder'),
+                            fullWidth: true,
+                            size: 'small',
+                            sx: DATE_PICKER_TEXT_FIELD_SX,
+                          },
+                        }}
                       />
                     </LocalizationProvider>
                     {validation.endDateError ? <p className="errorText createInlineError">{t(validation.endDateError)}</p> : null}
@@ -645,7 +704,7 @@ export function CreateTournamentPage(props: CreateTournamentPageProps): JSX.Elem
                         options={row.options}
                         slotProps={{
                           popper: {
-                            className: 'createSongAutocompletePopper',
+                            sx: SONG_AUTOCOMPLETE_POPPER_SX,
                           },
                         }}
                         filterOptions={(options) => options}

--- a/packages/web-app/src/styles.css
+++ b/packages/web-app/src/styles.css
@@ -982,8 +982,7 @@ label {
   padding-bottom: 120px;
 }
 
-.createTournamentPage input,
-.createTournamentPage .MuiInputBase-root {
+.createTournamentPage input {
   min-height: 44px;
 }
 
@@ -1154,39 +1153,9 @@ label {
   align-self: center;
 }
 
-.periodRangeInputs .MuiFormControl-root {
-  width: 100%;
-}
-
 .periodDateField {
   display: grid;
   gap: 6px;
-}
-
-.periodDateField .MuiOutlinedInput-root,
-.periodDateField .MuiInputBase-root,
-.periodDateField .MuiPickersInputBase-root,
-.periodDateField .MuiPickersOutlinedInput-root {
-  background-color: var(--surface);
-  color: var(--text);
-}
-
-.periodDateField .MuiInputBase-input,
-.periodDateField .MuiPickersInputBase-input,
-.periodDateField .MuiPickersSectionList-root,
-.periodDateField .MuiPickersSectionList-section {
-  color: var(--text) !important;
-  -webkit-text-fill-color: var(--text);
-}
-
-.periodDateField .MuiInputBase-input::placeholder {
-  color: var(--text-faint);
-  opacity: 1;
-}
-
-.periodDateField .MuiIconButton-root,
-.periodDateField .MuiSvgIcon-root {
-  color: var(--text-subtle);
 }
 
 .periodSummaryText {
@@ -1319,35 +1288,6 @@ label {
   display: flex;
   gap: 4px;
   align-items: center;
-}
-
-.createSongAutocompletePopper .MuiPaper-root {
-  background: var(--create-song-dropdown-bg);
-  color: var(--text);
-  border: 1px solid var(--create-song-dropdown-border);
-  box-shadow: var(--shadow);
-}
-
-.createSongAutocompletePopper .MuiAutocomplete-listbox {
-  background: var(--create-song-dropdown-bg);
-  color: var(--text);
-}
-
-.createSongAutocompletePopper .MuiAutocomplete-option {
-  color: var(--text);
-}
-
-.createSongAutocompletePopper .MuiAutocomplete-option:hover,
-.createSongAutocompletePopper .MuiAutocomplete-option.Mui-focused {
-  background: var(--create-song-dropdown-hover);
-}
-
-.createSongAutocompletePopper .MuiAutocomplete-option[aria-selected='true'] {
-  background: var(--create-song-dropdown-selected);
-}
-
-.createSongAutocompletePopper .MuiAutocomplete-option[aria-selected='true'].Mui-focused {
-  background: var(--create-song-dropdown-selected);
 }
 
 .createSongAutocompleteOptionVersion {

--- a/packages/web-app/src/styles.css
+++ b/packages/web-app/src/styles.css
@@ -237,7 +237,7 @@ textarea {
   font: inherit;
 }
 
-:where(button):not(:where(.MuiButtonBase-root)) {
+:where(button) {
   border: 1px solid var(--border-strong);
   border-radius: 10px;
   background: var(--surface);
@@ -246,16 +246,16 @@ textarea {
   cursor: pointer;
 }
 
-:where(button):not(:where(.MuiButtonBase-root)):hover:not(:disabled) {
+:where(button:hover:not(:disabled)) {
   background: var(--surface-hover);
 }
 
-:where(button):not(:where(.MuiButtonBase-root)):disabled {
+:where(button:disabled) {
   opacity: 0.5;
   cursor: not-allowed;
 }
 
-:where(button):not(:where(.MuiButtonBase-root)):focus-visible {
+:where(button:focus-visible) {
   outline: 2px solid var(--focus);
   outline-offset: 2px;
 }

--- a/packages/web-app/src/styles.css
+++ b/packages/web-app/src/styles.css
@@ -476,55 +476,6 @@ label {
   max-width: 100%;
 }
 
-.homeAppliedChip .MuiChip-label {
-  font-weight: 600;
-}
-
-.homeAppliedChip-tonal.MuiChip-root {
-  background: var(--home-chip-tonal-bg);
-  color: var(--home-chip-tonal-text);
-}
-
-.homeAppliedChip-tonal.MuiChip-root:hover {
-  background: var(--home-chip-hover);
-}
-
-.homeAppliedChip-tonal .MuiChip-label {
-  color: var(--home-chip-tonal-text);
-}
-
-.homeAppliedChip-tonal.MuiChip-root.MuiChip-deletable .MuiChip-deleteIcon {
-  color: var(--home-chip-delete) !important;
-  opacity: 1 !important;
-}
-
-.homeAppliedChip-tonal.MuiChip-root.MuiChip-deletable .MuiChip-deleteIcon:hover {
-  color: var(--home-chip-tonal-text) !important;
-  opacity: 1 !important;
-}
-
-.homeAppliedChip-type.MuiChip-root,
-.homeAppliedChip-overflow.MuiChip-root {
-  border-color: var(--home-chip-outline-border);
-  color: var(--home-chip-outline-text);
-  background: var(--home-chip-outline-bg);
-}
-
-.homeAppliedChip-type .MuiChip-label,
-.homeAppliedChip-overflow .MuiChip-label {
-  color: var(--home-chip-outline-text);
-}
-
-.homeAppliedChip-type.MuiChip-root.MuiChip-deletable .MuiChip-deleteIcon {
-  color: var(--home-chip-delete) !important;
-  opacity: 1 !important;
-}
-
-.homeAppliedChip-type.MuiChip-root.MuiChip-deletable .MuiChip-deleteIcon:hover {
-  color: var(--home-chip-outline-text) !important;
-  opacity: 1 !important;
-}
-
 .homeSubheaderRow {
   position: sticky;
   top: 56px;
@@ -606,34 +557,6 @@ label {
   max-height: 70dvh;
   background: var(--home-filter-sheet-bg);
   color: var(--home-filter-sheet-text);
-}
-
-.homeFilterSheet .MuiDivider-root {
-  border-color: var(--home-filter-sheet-divider);
-}
-
-.homeFilterSheet .MuiToggleButtonGroup-grouped {
-  background: transparent;
-  border: 1px solid var(--home-filter-sheet-segment-border);
-  color: var(--home-filter-sheet-segment-text);
-}
-
-.homeFilterSheet .MuiToggleButtonGroup-grouped.Mui-selected {
-  background: var(--home-filter-sheet-segment-selected-bg);
-  border-color: var(--home-filter-sheet-segment-selected-border);
-  color: var(--home-filter-sheet-segment-selected-text);
-}
-
-.homeFilterSheet .MuiToggleButtonGroup-grouped.Mui-selected:hover {
-  background: var(--home-filter-sheet-segment-selected-bg);
-}
-
-.homeFilterSheet .MuiToggleButtonGroup-grouped:hover {
-  background: var(--home-filter-sheet-hover);
-}
-
-.homeFilterSheet .MuiCheckbox-root {
-  color: var(--home-filter-checkbox-unchecked);
 }
 
 .homeFilterSheetHandle {

--- a/packages/web-app/src/theme/mui-theme.ts
+++ b/packages/web-app/src/theme/mui-theme.ts
@@ -3,6 +3,7 @@ import { createTheme } from '@mui/material/styles';
 const SURFACE_2 = 'var(--surface-2)';
 const SURFACE_3 = 'var(--surface-3)';
 const SURFACE_MUTED = 'var(--surface-muted)';
+const SURFACE = 'var(--surface)';
 const BACKDROP = 'var(--backdrop)';
 const SHADOW = 'var(--shadow)';
 const SHADOW_HOVER = 'var(--shadow-hover)';
@@ -424,6 +425,56 @@ export const muiTheme = createTheme({
             '&.Mui-selected, &.Mui-selected:hover': {
               backgroundColor: palette.action.selected,
               color: palette.text.primary,
+            },
+          };
+        },
+      },
+    },
+    MuiAutocomplete: {
+      styleOverrides: {
+        root: ({ theme }) => {
+          const palette = paletteVars(theme);
+          return {
+            '& .MuiInputBase-root': {
+              minHeight: 44,
+            },
+            '& .MuiOutlinedInput-root': {
+              backgroundColor: SURFACE,
+              color: palette.text.primary,
+            },
+            '& .MuiInputBase-input::placeholder': {
+              color: 'var(--text-faint)',
+              opacity: 1,
+            },
+            '& .MuiAutocomplete-popupIndicator': {
+              color: 'var(--create-song-popup-icon)',
+            },
+            '& .MuiAutocomplete-clearIndicator': {
+              color: 'var(--text-subtle)',
+            },
+          };
+        },
+        popper: ({ theme }) => {
+          const palette = paletteVars(theme);
+          return {
+            '& .MuiPaper-root': {
+              background: 'var(--create-song-dropdown-bg)',
+              color: palette.text.primary,
+              border: `1px solid var(--create-song-dropdown-border)`,
+              boxShadow: SHADOW,
+            },
+            '& .MuiAutocomplete-listbox': {
+              background: 'var(--create-song-dropdown-bg)',
+              color: palette.text.primary,
+            },
+            '& .MuiAutocomplete-option': {
+              color: palette.text.primary,
+              '&:hover, &.Mui-focused': {
+                background: 'var(--create-song-dropdown-hover)',
+              },
+              "&[aria-selected='true'], &[aria-selected='true'].Mui-focused": {
+                background: 'var(--create-song-dropdown-selected)',
+              },
             },
           };
         },

--- a/packages/web-app/src/theme/mui-theme.ts
+++ b/packages/web-app/src/theme/mui-theme.ts
@@ -1,4 +1,5 @@
 import { createTheme } from '@mui/material/styles';
+import type {} from '@mui/x-date-pickers/themeAugmentation';
 
 const SURFACE_2 = 'var(--surface-2)';
 const SURFACE_3 = 'var(--surface-3)';
@@ -475,6 +476,33 @@ export const muiTheme = createTheme({
               "&[aria-selected='true'], &[aria-selected='true'].Mui-focused": {
                 background: 'var(--create-song-dropdown-selected)',
               },
+            },
+          };
+        },
+      },
+    },
+    MuiPickersTextField: {
+      styleOverrides: {
+        root: ({ theme }) => {
+          const palette = paletteVars(theme);
+          return {
+            '&.createPeriodDatePickerTextField .MuiOutlinedInput-root, &.createPeriodDatePickerTextField .MuiInputBase-root, &.createPeriodDatePickerTextField .MuiPickersInputBase-root, &.createPeriodDatePickerTextField .MuiPickersOutlinedInput-root':
+              {
+                backgroundColor: SURFACE,
+                color: palette.text.primary,
+                minHeight: 44,
+              },
+            '&.createPeriodDatePickerTextField .MuiInputBase-input, &.createPeriodDatePickerTextField .MuiPickersInputBase-input, &.createPeriodDatePickerTextField .MuiPickersSectionList-root, &.createPeriodDatePickerTextField .MuiPickersSectionList-section':
+              {
+                color: `${palette.text.primary} !important`,
+                WebkitTextFillColor: palette.text.primary,
+              },
+            '&.createPeriodDatePickerTextField .MuiInputBase-input::placeholder': {
+              color: 'var(--text-faint)',
+              opacity: 1,
+            },
+            '&.createPeriodDatePickerTextField .MuiIconButton-root, &.createPeriodDatePickerTextField .MuiSvgIcon-root': {
+              color: 'var(--text-subtle)',
             },
           };
         },

--- a/tasks/feat-mui-theme-phase2.md
+++ b/tasks/feat-mui-theme-phase2.md
@@ -6,6 +6,7 @@
 - `App.tsx` 側の MUI `sx` に寄せ、MUI配色責務をコンポーネント側へ集約する。
 - Create大会画面に残っている DatePicker / Autocomplete Popper の MUI クラス依存配色を `sx` へ移管する。
 - Create大会画面で局所定義している `Autocomplete` 配色 `sx` を MUIテーマ（`mui-theme.ts`）へ移管し、画面側の配色責務をさらに削減する。
+- Create大会画面で局所定義している DatePicker の `slotProps.textField.sx` を MUIテーマ（`mui-theme.ts`）へ移管し、画面側の配色責務をさらに削減する。
 - 見た目・挙動を変えず、テーマ移管の後続作業（Phase2）として差分を最小化する。
 
 ## 非目的
@@ -24,6 +25,7 @@
 - Create大会画面の曲名 `Autocomplete` 候補ポップアップ配色を `slotProps.popper.sx` に移管。
 - 上記移管により不要になった `styles.css` の `.periodDateField .Mui*` / `.createSongAutocompletePopper .Mui*` ルールを削除。
 - Create大会画面に残る `SONG_AUTOCOMPLETE_SX` / `SONG_AUTOCOMPLETE_POPPER_SX` を削除し、同等配色を `mui-theme.ts` の `MuiAutocomplete` overrideに統合する。
+- Create大会画面に残る `DATE_PICKER_TEXT_FIELD_SX` を削除し、同等配色を `mui-theme.ts` の `MuiPickersTextField` overrideへ統合する。
 
 ## 影響範囲
 
@@ -49,6 +51,10 @@
   - `MuiAutocomplete` の `styleOverrides` を追加し、Create画面で使用している入力/アイコン/候補ポップアップ配色をテーマへ移管する。
 - `packages/web-app/src/pages/CreateTournamentPage.tsx`
   - テーマ移管した `Autocomplete` 配色ローカル `sx` 定義/適用を削除する。
+- `packages/web-app/src/theme/mui-theme.ts`
+  - `MuiPickersTextField` の `styleOverrides` を追加し、Create画面DatePicker入力の配色をテーマへ移管する。
+- `packages/web-app/src/pages/CreateTournamentPage.tsx`
+  - テーマ移管した `DATE_PICKER_TEXT_FIELD_SX` 定義と `slotProps.textField.sx` 適用を削除し、`className` でテーマ適用対象を指定する。
 - `packages/web-app/src/styles.css`
   - `periodDateField` と `createSongAutocompletePopper` 配下の `.Mui*` 依存ルールを削除する。
 
@@ -80,6 +86,8 @@
 6. `lint/test/build` 実行と差分確認。
 7. `mui-theme.ts` に `MuiAutocomplete` override を追加し、Create画面のローカルAutocomplete配色 `sx` を削除。
 8. `lint/test/build` 実行と差分確認。
+9. `mui-theme.ts` に `MuiPickersTextField` override を追加し、Create画面のローカルDatePicker配色 `sx` を削除。
+10. `lint/test/build` 実行と差分確認。
 
 ## Scope Declaration
 

--- a/tasks/feat-mui-theme-phase2.md
+++ b/tasks/feat-mui-theme-phase2.md
@@ -7,6 +7,7 @@
 - Create大会画面に残っている DatePicker / Autocomplete Popper の MUI クラス依存配色を `sx` へ移管する。
 - Create大会画面で局所定義している `Autocomplete` 配色 `sx` を MUIテーマ（`mui-theme.ts`）へ移管し、画面側の配色責務をさらに削減する。
 - Create大会画面で局所定義している DatePicker の `slotProps.textField.sx` を MUIテーマ（`mui-theme.ts`）へ移管し、画面側の配色責務をさらに削減する。
+- 全画面確認のうえ `styles.css` に残存する MUIクラス依存セレクタ（`button` グローバルの `.MuiButtonBase-root` 除外）を削減する。
 - 見た目・挙動を変えず、テーマ移管の後続作業（Phase2）として差分を最小化する。
 
 ## 非目的
@@ -26,6 +27,7 @@
 - 上記移管により不要になった `styles.css` の `.periodDateField .Mui*` / `.createSongAutocompletePopper .Mui*` ルールを削除。
 - Create大会画面に残る `SONG_AUTOCOMPLETE_SX` / `SONG_AUTOCOMPLETE_POPPER_SX` を削除し、同等配色を `mui-theme.ts` の `MuiAutocomplete` overrideに統合する。
 - Create大会画面に残る `DATE_PICKER_TEXT_FIELD_SX` を削除し、同等配色を `mui-theme.ts` の `MuiPickersTextField` overrideへ統合する。
+- `styles.css` の `button` グローバル配色を低特異性 `:where(...)` へ置換し、`.MuiButtonBase-root` 依存を除去する。
 
 ## 影響範囲
 
@@ -56,6 +58,8 @@
 - `packages/web-app/src/pages/CreateTournamentPage.tsx`
   - テーマ移管した `DATE_PICKER_TEXT_FIELD_SX` 定義と `slotProps.textField.sx` 適用を削除し、`className` でテーマ適用対象を指定する。
 - `packages/web-app/src/styles.css`
+  - `button` グローバルルールの `.MuiButtonBase-root` 除外依存を撤去し、低特異性セレクタへ置換する。
+- `packages/web-app/src/styles.css`
   - `periodDateField` と `createSongAutocompletePopper` 配下の `.Mui*` 依存ルールを削除する。
 
 ## テスト観点
@@ -66,6 +70,8 @@
   - Create大会画面の期間DatePicker入力（背景/文字/placeholder/アイコン）配色が従来と一致する。
   - Create大会画面の曲候補ポップアップ（paper/listbox/option hover/selected）配色が従来と一致する。
   - Create大会画面の曲名入力（背景/placeholder/右側アイコン色）が従来と一致する。
+  - 全画面で `styles.css` に `.Mui*` セレクタが残存しないこと。
+  - Light時に主要ボタン（赤/青/FAB含む）のhover白飛びが再発しないこと。
 - 回帰:
   - フィルタ選択・解除、検索チップ削除、ソート変更の挙動が不変。
   - Create大会画面の期間入力、曲検索候補表示、曲選択の挙動が不変。
@@ -88,6 +94,8 @@
 8. `lint/test/build` 実行と差分確認。
 9. `mui-theme.ts` に `MuiPickersTextField` override を追加し、Create画面のローカルDatePicker配色 `sx` を削除。
 10. `lint/test/build` 実行と差分確認。
+11. `styles.css` の残存MUIクラス依存セレクタを低特異性 `:where(...)` へ置換。
+12. `lint/test/build` 実行と差分確認。
 
 ## Scope Declaration
 

--- a/tasks/feat-mui-theme-phase2.md
+++ b/tasks/feat-mui-theme-phase2.md
@@ -5,6 +5,7 @@
 - Phase1 後に `styles.css` に残っているホーム画面フィルタ周辺の MUI クラス依存配色を削減する。
 - `App.tsx` 側の MUI `sx` に寄せ、MUI配色責務をコンポーネント側へ集約する。
 - Create大会画面に残っている DatePicker / Autocomplete Popper の MUI クラス依存配色を `sx` へ移管する。
+- Create大会画面で局所定義している `Autocomplete` 配色 `sx` を MUIテーマ（`mui-theme.ts`）へ移管し、画面側の配色責務をさらに削減する。
 - 見た目・挙動を変えず、テーマ移管の後続作業（Phase2）として差分を最小化する。
 
 ## 非目的
@@ -22,6 +23,7 @@
 - Create大会画面の DatePicker 入力配色（背景/文字/placeholder/アイコン）を `DatePicker` の `slotProps.textField.sx` に移管。
 - Create大会画面の曲名 `Autocomplete` 候補ポップアップ配色を `slotProps.popper.sx` に移管。
 - 上記移管により不要になった `styles.css` の `.periodDateField .Mui*` / `.createSongAutocompletePopper .Mui*` ルールを削除。
+- Create大会画面に残る `SONG_AUTOCOMPLETE_SX` / `SONG_AUTOCOMPLETE_POPPER_SX` を削除し、同等配色を `mui-theme.ts` の `MuiAutocomplete` overrideに統合する。
 
 ## 影響範囲
 
@@ -43,6 +45,10 @@
 - `packages/web-app/src/pages/CreateTournamentPage.tsx`
   - DatePicker の `slotProps.textField.sx` を共通化し、既存CSSのMUI配色ルールを移管する。
   - `Autocomplete` の `slotProps.popper.sx` を追加し、候補ポップアップの配色を移管する。
+- `packages/web-app/src/theme/mui-theme.ts`
+  - `MuiAutocomplete` の `styleOverrides` を追加し、Create画面で使用している入力/アイコン/候補ポップアップ配色をテーマへ移管する。
+- `packages/web-app/src/pages/CreateTournamentPage.tsx`
+  - テーマ移管した `Autocomplete` 配色ローカル `sx` 定義/適用を削除する。
 - `packages/web-app/src/styles.css`
   - `periodDateField` と `createSongAutocompletePopper` 配下の `.Mui*` 依存ルールを削除する。
 
@@ -53,6 +59,7 @@
   - BottomSheet のセグメント（selected/hover）、divider、checkbox 未選択色が従来と一致する。
   - Create大会画面の期間DatePicker入力（背景/文字/placeholder/アイコン）配色が従来と一致する。
   - Create大会画面の曲候補ポップアップ（paper/listbox/option hover/selected）配色が従来と一致する。
+  - Create大会画面の曲名入力（背景/placeholder/右側アイコン色）が従来と一致する。
 - 回帰:
   - フィルタ選択・解除、検索チップ削除、ソート変更の挙動が不変。
   - Create大会画面の期間入力、曲検索候補表示、曲選択の挙動が不変。
@@ -71,6 +78,8 @@
 4. `CreateTournamentPage.tsx` に DatePicker / Autocomplete Popper の MUI `sx` を追加。
 5. `styles.css` の Create画面向け不要 `.Mui*` 依存ルールを削除。
 6. `lint/test/build` 実行と差分確認。
+7. `mui-theme.ts` に `MuiAutocomplete` override を追加し、Create画面のローカルAutocomplete配色 `sx` を削除。
+8. `lint/test/build` 実行と差分確認。
 
 ## Scope Declaration
 
@@ -78,5 +87,6 @@
   - `tasks/feat-mui-theme-phase2.md`
   - `packages/web-app/src/App.tsx`
   - `packages/web-app/src/pages/CreateTournamentPage.tsx`
+  - `packages/web-app/src/theme/mui-theme.ts`
   - `packages/web-app/src/styles.css`
 - 上記以外の変更は禁止。必要が出た場合は本tasksを更新してから実施する。

--- a/tasks/feat-mui-theme-phase2.md
+++ b/tasks/feat-mui-theme-phase2.md
@@ -4,6 +4,7 @@
 
 - Phase1 後に `styles.css` に残っているホーム画面フィルタ周辺の MUI クラス依存配色を削減する。
 - `App.tsx` 側の MUI `sx` に寄せ、MUI配色責務をコンポーネント側へ集約する。
+- Create大会画面に残っている DatePicker / Autocomplete Popper の MUI クラス依存配色を `sx` へ移管する。
 - 見た目・挙動を変えず、テーマ移管の後続作業（Phase2）として差分を最小化する。
 
 ## 非目的
@@ -18,6 +19,9 @@
 - ホーム適用チップ (`Chip`) の MUI サブ要素配色（label/deleteIcon/hover）を `App.tsx` の `sx` に移管。
 - ホームフィルタBottomSheet内の MUI要素配色（`ToggleButtonGroup` / `Divider` / `Checkbox`）を `sx` に移管。
 - 上記移管により不要になった `styles.css` の `.homeAppliedChip* .Mui*` / `.homeFilterSheet .Mui*` ルールを削除。
+- Create大会画面の DatePicker 入力配色（背景/文字/placeholder/アイコン）を `DatePicker` の `slotProps.textField.sx` に移管。
+- Create大会画面の曲名 `Autocomplete` 候補ポップアップ配色を `slotProps.popper.sx` に移管。
+- 上記移管により不要になった `styles.css` の `.periodDateField .Mui*` / `.createSongAutocompletePopper .Mui*` ルールを削除。
 
 ## 影響範囲
 
@@ -36,14 +40,22 @@
   - BottomSheet 内 `ToggleButtonGroup` / `Divider` / `Checkbox` へ `sx` を追加する。
 - `packages/web-app/src/styles.css`
   - `homeAppliedChip` と `homeFilterSheet` 配下の `.Mui*` 依存ルールを削除し、レイアウト系クラスのみ残す。
+- `packages/web-app/src/pages/CreateTournamentPage.tsx`
+  - DatePicker の `slotProps.textField.sx` を共通化し、既存CSSのMUI配色ルールを移管する。
+  - `Autocomplete` の `slotProps.popper.sx` を追加し、候補ポップアップの配色を移管する。
+- `packages/web-app/src/styles.css`
+  - `periodDateField` と `createSongAutocompletePopper` 配下の `.Mui*` 依存ルールを削除する。
 
 ## テスト観点
 
 - 見た目:
   - ホーム適用チップ（status/condition/type/overflow）の背景・文字・削除アイコン色が従来と一致する。
   - BottomSheet のセグメント（selected/hover）、divider、checkbox 未選択色が従来と一致する。
+  - Create大会画面の期間DatePicker入力（背景/文字/placeholder/アイコン）配色が従来と一致する。
+  - Create大会画面の曲候補ポップアップ（paper/listbox/option hover/selected）配色が従来と一致する。
 - 回帰:
   - フィルタ選択・解除、検索チップ削除、ソート変更の挙動が不変。
+  - Create大会画面の期間入力、曲検索候補表示、曲選択の挙動が不変。
   - `pnpm lint` / `pnpm test` / `pnpm build` が通過する。
 
 ## ロールバック方針
@@ -56,11 +68,15 @@
 1. `App.tsx` にホームフィルタ周辺の MUI `sx` を追加。
 2. `styles.css` の不要 `.Mui*` 依存ルールを削除。
 3. `lint/test/build` 実行と差分確認。
+4. `CreateTournamentPage.tsx` に DatePicker / Autocomplete Popper の MUI `sx` を追加。
+5. `styles.css` の Create画面向け不要 `.Mui*` 依存ルールを削除。
+6. `lint/test/build` 実行と差分確認。
 
 ## Scope Declaration
 
 - 変更対象を以下に固定する。
   - `tasks/feat-mui-theme-phase2.md`
   - `packages/web-app/src/App.tsx`
+  - `packages/web-app/src/pages/CreateTournamentPage.tsx`
   - `packages/web-app/src/styles.css`
 - 上記以外の変更は禁止。必要が出た場合は本tasksを更新してから実施する。

--- a/tasks/feat-mui-theme-phase2.md
+++ b/tasks/feat-mui-theme-phase2.md
@@ -1,0 +1,66 @@
+# Plan: feat/mui-theme-phase2
+
+## 目的
+
+- Phase1 後に `styles.css` に残っているホーム画面フィルタ周辺の MUI クラス依存配色を削減する。
+- `App.tsx` 側の MUI `sx` に寄せ、MUI配色責務をコンポーネント側へ集約する。
+- 見た目・挙動を変えず、テーマ移管の後続作業（Phase2）として差分を最小化する。
+
+## 非目的
+
+- 非MUI要素（素の `button` / `div` など）の全面リデザイン。
+- ルーティング、状態管理、フィルタロジック、ソートロジックの変更。
+- Service Worker / Web Locks / import-export / データ永続化仕様の変更。
+- 依存関係更新。
+
+## 変更点
+
+- ホーム適用チップ (`Chip`) の MUI サブ要素配色（label/deleteIcon/hover）を `App.tsx` の `sx` に移管。
+- ホームフィルタBottomSheet内の MUI要素配色（`ToggleButtonGroup` / `Divider` / `Checkbox`）を `sx` に移管。
+- 上記移管により不要になった `styles.css` の `.homeAppliedChip* .Mui*` / `.homeFilterSheet .Mui*` ルールを削除。
+
+## 影響範囲
+
+- ユーザー影響:
+  - ホーム画面のフィルタUI（適用チップ・BottomSheet）の見た目は維持される。
+  - 配色責務が `sx` に寄るため、MUIテーマ追従性が向上する。
+- データ影響:
+  - なし。
+- 互換性:
+  - フィルタ条件・ソート・検索・遷移の挙動は不変。
+
+## 実装方針（対象ファイル単位）
+
+- `packages/web-app/src/App.tsx`
+  - ホーム適用チップの `sx` を追加し、トーナル/アウトライン系の配色・hover・deleteIcon色を定義する。
+  - BottomSheet 内 `ToggleButtonGroup` / `Divider` / `Checkbox` へ `sx` を追加する。
+- `packages/web-app/src/styles.css`
+  - `homeAppliedChip` と `homeFilterSheet` 配下の `.Mui*` 依存ルールを削除し、レイアウト系クラスのみ残す。
+
+## テスト観点
+
+- 見た目:
+  - ホーム適用チップ（status/condition/type/overflow）の背景・文字・削除アイコン色が従来と一致する。
+  - BottomSheet のセグメント（selected/hover）、divider、checkbox 未選択色が従来と一致する。
+- 回帰:
+  - フィルタ選択・解除、検索チップ削除、ソート変更の挙動が不変。
+  - `pnpm lint` / `pnpm test` / `pnpm build` が通過する。
+
+## ロールバック方針
+
+- 配色崩れが出た場合:
+  - `App.tsx` の `sx` 追加差分を revert し、`styles.css` の削除差分を戻して復旧する。
+
+## Commit Plan
+
+1. `App.tsx` にホームフィルタ周辺の MUI `sx` を追加。
+2. `styles.css` の不要 `.Mui*` 依存ルールを削除。
+3. `lint/test/build` 実行と差分確認。
+
+## Scope Declaration
+
+- 変更対象を以下に固定する。
+  - `tasks/feat-mui-theme-phase2.md`
+  - `packages/web-app/src/App.tsx`
+  - `packages/web-app/src/styles.css`
+- 上記以外の変更は禁止。必要が出た場合は本tasksを更新してから実施する。


### PR DESCRIPTION
## 目的
- Phase1後に残っていた MUI クラス依存配色を Phase2で削減し、配色責務を `sx` / MUI Theme へ集約する。
- 見た目整合性を維持したまま、`styles.css` の `.Mui*` 依存を除去する。

## 変更点
- Home（一覧）フィルタ周辺の MUI 配色を `App.tsx` の `sx` へ移管。
  - 適用チップ（label/deleteIcon/hover）
  - BottomSheet内 `ToggleButtonGroup` / `Divider` / `Checkbox`
- Create（作成）画面の MUI 配色移管。
  - DatePicker 入力配色を `slotProps.textField.sx` → `MuiPickersTextField` override へ移管
  - Song Autocomplete 入力/候補ポップアップ配色を `MuiAutocomplete` override へ移管
- `mui-theme.ts` を拡張。
  - `MuiAutocomplete` / `MuiPickersTextField` の `styleOverrides` を追加
  - `@mui/x-date-pickers/themeAugmentation` を導入（型拡張）
- `styles.css` クリーンアップ。
  - Home/Create向け `.Mui*` 依存ルールを削除
  - 残存していた `button` グローバルの `.MuiButtonBase-root` 除外依存を低特異性 `:where(...)` へ置換
- 計画更新。
  - `tasks/feat-mui-theme-phase2.md` を実装内容に合わせて更新

## 非変更点
- 画面レイアウトやUX構造の変更
- ルーティング、状態管理、データ仕様、Service Worker / Web Locks 周辺
- 依存関係更新

## 影響範囲
- ユーザー影響: 画面挙動は不変で、MUI配色のテーマ追従性が向上。
- データ影響: なし。
- 互換性: 既存操作フローへの影響なし。

## テスト内容
- `pnpm lint`
- `pnpm test`
- `pnpm build`

すべて成功。

## 回帰確認項目
- Light: 主要ボタン（赤/青/FAB）の hover 白飛びが再発しないこと
- Home: フィルタチップ / BottomSheet 配色と挙動が維持されること
- Create: DatePicker / Song Autocomplete の入力・候補ポップアップ配色が維持されること
- `styles.css` 上で `.Mui*` セレクタが残存しないこと