### PR TITLE
feat(web-app): add home list microinteractions

### DIFF
--- a/packages/web-app/src/App.tsx
+++ b/packages/web-app/src/App.tsx
@@ -29,6 +29,7 @@ import {
   Tooltip,
   Typography,
 } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
 import AddIcon from '@mui/icons-material/Add';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import CloseIcon from '@mui/icons-material/Close';
@@ -43,7 +44,7 @@ import { APP_LANGUAGE_SETTING_KEY, ensureI18n, normalizeLanguage, type AppLangua
 import { ImportQrScannerDialog } from './components/ImportQrScannerDialog';
 import { UnsupportedScreen } from './components/UnsupportedScreen';
 import { CreateTournamentPage } from './pages/CreateTournamentPage';
-import { HomePage, sortForActiveTab } from './pages/HomePage';
+import { HomePage, sortForActiveTab, type HomeListAnimationMode } from './pages/HomePage';
 import { ImportConfirmPage } from './pages/ImportConfirmPage';
 import { ImportTournamentPage } from './pages/ImportTournamentPage';
 import { SettingsPage, type AppInfoCardData, type AppSwStatus } from './pages/SettingsPage';
@@ -106,6 +107,95 @@ function formatByteSize(rawBytes: number | null, unknownLabel: string): string {
   return `${bytes} bytes`;
 }
 
+function usePrefersReducedMotion(): boolean {
+  const [prefersReducedMotion, setPrefersReducedMotion] = React.useState(false);
+
+  React.useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      setPrefersReducedMotion(false);
+      return;
+    }
+    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const apply = () => {
+      setPrefersReducedMotion(mediaQuery.matches);
+    };
+    apply();
+    if (typeof mediaQuery.addEventListener === 'function') {
+      mediaQuery.addEventListener('change', apply);
+      return () => {
+        mediaQuery.removeEventListener('change', apply);
+      };
+    }
+    mediaQuery.addListener(apply);
+    return () => {
+      mediaQuery.removeListener(apply);
+    };
+  }, []);
+
+  return prefersReducedMotion;
+}
+
+function useAnimatedCount(target: number, durationMs: number, disabled: boolean): number {
+  const [value, setValue] = React.useState(target);
+  const valueRef = React.useRef(target);
+
+  React.useEffect(() => {
+    if (disabled) {
+      valueRef.current = target;
+      setValue(target);
+      return;
+    }
+    const startValue = valueRef.current;
+    if (startValue === target) {
+      setValue(target);
+      return;
+    }
+    const startTime = performance.now();
+    let frameId = 0;
+    const animate = (now: number) => {
+      const progress = Math.min(1, (now - startTime) / durationMs);
+      const eased = 1 - (1 - progress) ** 3;
+      const nextValue = Math.round(startValue + (target - startValue) * eased);
+      valueRef.current = nextValue;
+      setValue(nextValue);
+      if (progress < 1) {
+        frameId = window.requestAnimationFrame(animate);
+        return;
+      }
+      valueRef.current = target;
+      setValue(target);
+    };
+    frameId = window.requestAnimationFrame(animate);
+    return () => {
+      window.cancelAnimationFrame(frameId);
+    };
+  }, [disabled, durationMs, target]);
+
+  return value;
+}
+
+interface CountTemplateParts {
+  prefix: string;
+  suffix: string;
+  hasPlaceholder: boolean;
+}
+
+function splitCountTemplate(template: string, token: string): CountTemplateParts {
+  const tokenIndex = template.indexOf(token);
+  if (tokenIndex < 0) {
+    return {
+      prefix: template,
+      suffix: '',
+      hasPlaceholder: false,
+    };
+  }
+  return {
+    prefix: template.slice(0, tokenIndex),
+    suffix: template.slice(tokenIndex + token.length),
+    hasPlaceholder: true,
+  };
+}
+
 type RouteState =
   | { name: 'home' }
   | { name: 'import' }
@@ -157,6 +247,8 @@ const BUILD_TIME =
   typeof __BUILD_TIME__ === 'string' && __BUILD_TIME__.trim().length > 0 ? __BUILD_TIME__ : '-';
 const SW_VERSION_REQUEST_TIMEOUT_MS = 1500;
 const DEBUG_MODE_STORAGE_KEY = 'iidx:debug:mode';
+const HOME_RESULT_COUNT_MARKER = 908172635;
+const HOME_RESULT_COUNT_ANIMATION_DURATION_MS = 200;
 
 type CreateDraftDialogState =
   | { kind: 'none' }
@@ -769,6 +861,22 @@ function isHomeFilterDefault(query: HomeQueryState): boolean {
   );
 }
 
+function hasSameHomeQueryExceptSort(previous: HomeQueryState, next: HomeQueryState): boolean {
+  if (previous.state !== next.state) {
+    return false;
+  }
+  if (normalizeHomeSearchForFilter(previous.searchText) !== normalizeHomeSearchForFilter(next.searchText)) {
+    return false;
+  }
+  if (previous.category !== next.category) {
+    return false;
+  }
+  if (previous.attrs.length !== next.attrs.length) {
+    return false;
+  }
+  return previous.attrs.every((value, index) => value === next.attrs[index]);
+}
+
 interface AppProps {
   webLockAcquired?: boolean;
 }
@@ -921,6 +1029,25 @@ async function resolveOpfsStatus(): Promise<AppInfoCardData['opfsStatus']> {
 export function App({ webLockAcquired = false }: AppProps = {}): JSX.Element {
   const { appDb, opfs, songMasterService } = useAppServices();
   const { t } = useTranslation();
+  const theme = useTheme();
+  const prefersReducedMotion = usePrefersReducedMotion();
+  const homeResultCountTransition = React.useMemo(
+    () =>
+      theme.transitions.create('opacity', {
+        duration: prefersReducedMotion ? 0 : 150,
+        easing: theme.transitions.easing.easeOut,
+        delay: prefersReducedMotion ? 0 : 50,
+      }),
+    [prefersReducedMotion, theme],
+  );
+  const homeFabIconTransition = React.useMemo(
+    () =>
+      theme.transitions.create('transform', {
+        duration: prefersReducedMotion ? 0 : 190,
+        easing: theme.transitions.easing.easeInOut,
+      }),
+    [prefersReducedMotion, theme],
+  );
 
   const [routeStack, setRouteStack] = React.useState<RouteState[]>(() => createInitialRouteStack());
   const [homeQuery, setHomeQuery] = React.useState<HomeQueryState>(() => createDefaultHomeQueryState());
@@ -980,6 +1107,7 @@ export function App({ webLockAcquired = false }: AppProps = {}): JSX.Element {
   const [whatsNewDialogOpen, setWhatsNewDialogOpen] = React.useState(false);
   const appTabIdRef = React.useRef<string>(crypto.randomUUID());
   const handledDelegationRequestIdsRef = React.useRef<Set<string>>(new Set());
+  const previousHomeQueryRef = React.useRef<HomeQueryState>(homeQuery);
   const homeSearchInputRef = React.useRef<HTMLInputElement | null>(null);
   const homeStateSectionRef = React.useRef<HTMLDivElement | null>(null);
   const homeCategorySectionRef = React.useRef<HTMLDivElement | null>(null);
@@ -1073,7 +1201,26 @@ export function App({ webLockAcquired = false }: AppProps = {}): JSX.Element {
     () => applyHomeQueryState(homeTournamentBuckets, homeQuery),
     [homeQuery, homeTournamentBuckets],
   );
+  const homeListAnimationMode = React.useMemo<HomeListAnimationMode>(() => {
+    const previous = previousHomeQueryRef.current;
+    const sortChanged = previous.sort !== homeQuery.sort;
+    if (sortChanged && hasSameHomeQueryExceptSort(previous, homeQuery)) {
+      return 'sort';
+    }
+    return 'filter';
+  }, [homeQuery]);
   const homeResultCount = homeVisibleItems.length;
+  const animatedHomeResultCount = useAnimatedCount(
+    homeResultCount,
+    HOME_RESULT_COUNT_ANIMATION_DURATION_MS,
+    prefersReducedMotion,
+  );
+  const [homeResultCountAnimationTick, setHomeResultCountAnimationTick] = React.useState(0);
+  const homeResultCountTemplate = t('common.home_filter.result_count', { count: HOME_RESULT_COUNT_MARKER });
+  const homeResultCountParts = React.useMemo(
+    () => splitCountTemplate(homeResultCountTemplate, String(HOME_RESULT_COUNT_MARKER)),
+    [homeResultCountTemplate],
+  );
   const homeHasNonDefaultFilter = !isHomeFilterDefault(homeQuery);
   const homeNormalizedSearch = normalizeHomeSearchForFilter(homeQuery.searchText);
   const homeHasSearchQuery = homeNormalizedSearch.length > 0;
@@ -1083,6 +1230,14 @@ export function App({ webLockAcquired = false }: AppProps = {}): JSX.Element {
   const rawWhatsNewItems = t('whats_new.items', { returnObjects: true }) as unknown;
   const whatsNewItems =
     Array.isArray(rawWhatsNewItems) ? rawWhatsNewItems.filter((value): value is string => typeof value === 'string') : [];
+
+  React.useEffect(() => {
+    setHomeResultCountAnimationTick((current) => current + 1);
+  }, [homeResultCount]);
+
+  React.useEffect(() => {
+    previousHomeQueryRef.current = homeQuery;
+  }, [homeQuery]);
 
   const openHomeFilterSheet = React.useCallback(
     (focusSection: HomeFilterSheetFocusSection = null) => {
@@ -2677,6 +2832,8 @@ export function App({ webLockAcquired = false }: AppProps = {}): JSX.Element {
               todayDate={todayDate}
               state={homeQuery.state}
               items={homeVisibleItems}
+              prefersReducedMotion={prefersReducedMotion}
+              animationMode={homeListAnimationMode}
               onOpenFilterInEmpty={() => openHomeFilterSheet()}
               onOpenDetail={async (tournamentUuid) => {
                 const loaded = await reloadDetail(tournamentUuid);
@@ -2808,7 +2965,25 @@ export function App({ webLockAcquired = false }: AppProps = {}): JSX.Element {
             <div className="homeFilterSheetFixed">
               <div className="homeFilterSheetTopRow">
                 <Typography variant="body2" className="homeFilterResultCount">
-                  {t('common.home_filter.result_count', { count: homeResultCount })}
+                  {homeResultCountParts.hasPlaceholder ? (
+                    <>
+                      <span>{homeResultCountParts.prefix}</span>
+                      <span
+                        key={homeResultCountAnimationTick}
+                        className={
+                          prefersReducedMotion
+                            ? 'homeFilterResultCountValue'
+                            : 'homeFilterResultCountValue homeFilterResultCountValue-animated'
+                        }
+                        style={{ transition: homeResultCountTransition }}
+                      >
+                        {animatedHomeResultCount}
+                      </span>
+                      <span>{homeResultCountParts.suffix}</span>
+                    </>
+                  ) : (
+                    t('common.home_filter.result_count', { count: animatedHomeResultCount })
+                  )}
                 </Typography>
                 <button
                   type="button"
@@ -2935,7 +3110,15 @@ export function App({ webLockAcquired = false }: AppProps = {}): JSX.Element {
             <Box sx={{ position: 'fixed', right: 24, bottom: 24, zIndex: 30 }} onClick={closeCreateFabTooltip}>
               <SpeedDial
                 ariaLabel={t('common.tournament.actions')}
-                icon={<AddIcon />}
+                icon={(
+                  <AddIcon
+                    className={speedDialOpen ? 'homeFabPlusIcon homeFabPlusIcon-open' : 'homeFabPlusIcon'}
+                    sx={{
+                      transformOrigin: 'center',
+                      transition: homeFabIconTransition,
+                    }}
+                  />
+                )}
                 direction="up"
                 open={speedDialOpen}
                 onOpen={() => {

--- a/packages/web-app/src/components/TournamentSummaryCard.tsx
+++ b/packages/web-app/src/components/TournamentSummaryCard.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { daysUntilStart } from '@iidx/shared';
+import { useTheme } from '@mui/material/styles';
 import { useTranslation } from 'react-i18next';
 
 import type { TournamentStatus } from '../utils/tournament-status';
@@ -21,6 +22,7 @@ interface TournamentSummaryCardProps {
   cardClassName?: string;
   onOpenDetail?: (() => void) | undefined;
   shareAction?: React.ReactNode;
+  prefersReducedMotion?: boolean;
 }
 
 function joinClasses(...values: Array<string | undefined | null | false>): string {
@@ -49,6 +51,25 @@ function resolveRelativeTone(status: TournamentStatus): RelativeTone {
 
 export function TournamentSummaryCard(props: TournamentSummaryCardProps): JSX.Element {
   const { t } = useTranslation();
+  const theme = useTheme();
+  const prefersReducedMotion = props.prefersReducedMotion ?? false;
+  const progressBarTransition = React.useMemo(
+    () =>
+      theme.transitions.create('width', {
+        duration: prefersReducedMotion ? 0 : 280,
+        easing: theme.transitions.easing.easeOut,
+      }),
+    [prefersReducedMotion, theme],
+  );
+  const progressValueTransition = React.useMemo(
+    () =>
+      theme.transitions.create('opacity', {
+        duration: prefersReducedMotion ? 0 : 150,
+        easing: theme.transitions.easing.easeOut,
+        delay: prefersReducedMotion ? 0 : 50,
+      }),
+    [prefersReducedMotion, theme],
+  );
   const statusInfo = React.useMemo(
     () => resolveTournamentCardStatus(props.startDate, props.endDate, props.todayDate),
     [props.endDate, props.startDate, props.todayDate],
@@ -72,8 +93,56 @@ export function TournamentSummaryCard(props: TournamentSummaryCardProps): JSX.El
   const showPeriod = props.variant !== 'list';
   const showIncompleteLabels = (props.variant === 'list' || props.variant === 'detail') && (safeUnregisteredCount > 0 || safeUnsharedCount > 0);
   const showProgress = props.variant === 'list' || props.variant === 'detail';
+  const shouldAnimateProgress = props.variant === 'list' && !prefersReducedMotion;
+  const submittedCount = safeSharedCount + safeUnsharedCount;
+  const progressValueText = `${submittedCount}/${totalCount}`;
   const showDetailLink = props.variant === 'list';
   const showShareAction = props.variant === 'detail' && Boolean(props.shareAction);
+  const [displayedProgress, setDisplayedProgress] = React.useState(() => ({
+    shared: shouldAnimateProgress ? 0 : sharedPercent,
+    unshared: shouldAnimateProgress ? 0 : unsharedPercent,
+    unregistered: shouldAnimateProgress ? 0 : unregisteredPercent,
+  }));
+  const [progressValueVisible, setProgressValueVisible] = React.useState(() => !showProgress || !shouldAnimateProgress);
+
+  React.useEffect(() => {
+    if (!shouldAnimateProgress) {
+      setDisplayedProgress({
+        shared: sharedPercent,
+        unshared: unsharedPercent,
+        unregistered: unregisteredPercent,
+      });
+      return;
+    }
+    const frameId = window.requestAnimationFrame(() => {
+      setDisplayedProgress({
+        shared: sharedPercent,
+        unshared: unsharedPercent,
+        unregistered: unregisteredPercent,
+      });
+    });
+    return () => {
+      window.cancelAnimationFrame(frameId);
+    };
+  }, [sharedPercent, shouldAnimateProgress, unsharedPercent, unregisteredPercent]);
+
+  React.useEffect(() => {
+    if (!showProgress) {
+      setProgressValueVisible(false);
+      return;
+    }
+    if (!shouldAnimateProgress) {
+      setProgressValueVisible(true);
+      return;
+    }
+    setProgressValueVisible(false);
+    const timeoutId = window.setTimeout(() => {
+      setProgressValueVisible(true);
+    }, 50);
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [showProgress, shouldAnimateProgress, submittedCount, totalCount]);
   const baseClassName =
     props.variant === 'list'
       ? 'tournamentCard tournamentSummaryCard tournamentSummaryCard-list'
@@ -114,15 +183,24 @@ export function TournamentSummaryCard(props: TournamentSummaryCardProps): JSX.El
           </div>
         ) : null}
         {showProgress ? (
-          <div className="progressBar stateDistributionBar tournamentSummaryProgress" aria-hidden>
-            <div className="progressBarSegment-shared" style={{ width: `${sharedPercent}%` }} />
-            <div className="progressBarSegment-sendWaiting" style={{ width: `${unsharedPercent}%` }} />
-            <div className="progressBarSegment-unregistered" style={{ width: `${unregisteredPercent}%` }} />
+          <div className="tournamentSummaryProgressWrap">
+            <div className="progressBar stateDistributionBar tournamentSummaryProgress" aria-hidden>
+              <div className="progressBarSegment-shared" style={{ width: `${displayedProgress.shared}%`, transition: progressBarTransition }} />
+              <div className="progressBarSegment-sendWaiting" style={{ width: `${displayedProgress.unshared}%`, transition: progressBarTransition }} />
+              <div className="progressBarSegment-unregistered" style={{ width: `${displayedProgress.unregistered}%`, transition: progressBarTransition }} />
+            </div>
+            <span
+              className={joinClasses('tournamentProgressValue', progressValueVisible && 'tournamentProgressValue-visible')}
+              style={{ transition: progressValueTransition }}
+              aria-hidden
+            >
+              {progressValueText}
+            </span>
           </div>
         ) : null}
         {showDetailLink ? (
           <div className="cardNavigationHint">
-            <span>{t('home.action.view_detail')}</span>
+            <span className="cardNavigationHintLabel">{t('home.action.view_detail')}</span>
             <span className="cardArrow" aria-hidden>
               →
             </span>

--- a/packages/web-app/src/pages/HomePage.test.tsx
+++ b/packages/web-app/src/pages/HomePage.test.tsx
@@ -11,6 +11,7 @@ describe('HomePage', () => {
       <HomePage
         todayDate="2026-02-10"
         state="active"
+        prefersReducedMotion
         items={[
           {
             tournamentUuid: 't1',
@@ -76,6 +77,7 @@ describe('HomePage', () => {
       <HomePage
         todayDate="2026-02-10"
         state="upcoming"
+        prefersReducedMotion
         items={[upcomingItem]}
         onOpenDetail={() => undefined}
       />,
@@ -90,6 +92,7 @@ describe('HomePage', () => {
       <HomePage
         todayDate="2026-02-10"
         state="ended"
+        prefersReducedMotion
         items={[endedItem]}
         onOpenDetail={() => undefined}
       />,
@@ -107,6 +110,7 @@ describe('HomePage', () => {
       <HomePage
         todayDate="2026-02-10"
         state="active"
+        prefersReducedMotion
         items={[
           {
             tournamentUuid: 't1',
@@ -138,6 +142,7 @@ describe('HomePage', () => {
       <HomePage
         todayDate="2026-02-08"
         state="active"
+        prefersReducedMotion
         items={[]}
         onOpenFilterInEmpty={onOpenFilterInEmpty}
         onOpenDetail={() => undefined}

--- a/packages/web-app/src/pages/HomePage.tsx
+++ b/packages/web-app/src/pages/HomePage.tsx
@@ -1,8 +1,14 @@
 import React from 'react';
+import { useTheme } from '@mui/material/styles';
 import type { TournamentListItem, TournamentTab } from '@iidx/db';
 import { useTranslation } from 'react-i18next';
 
 import { TournamentSummaryCard } from '../components/TournamentSummaryCard';
+
+const HOME_CARD_ENTER_EXIT_DURATION_MS = 200;
+const HOME_CARD_FLIP_DURATION_MS = 200;
+
+export type HomeListAnimationMode = 'filter' | 'sort';
 
 interface HomePageProps {
   todayDate: string;
@@ -10,12 +16,22 @@ interface HomePageProps {
   items: TournamentListItem[];
   onOpenDetail: (tournamentUuid: string) => void;
   onOpenFilterInEmpty?: () => void;
+  prefersReducedMotion?: boolean;
+  animationMode?: HomeListAnimationMode;
 }
 
 interface ProgressDistribution {
   sharedCount: number;
   sendWaitingCount: number;
   unregisteredCount: number;
+}
+
+type HomeCardAnimationPhase = 'entering' | 'stable' | 'exiting';
+
+interface HomeCardEntry {
+  key: string;
+  item: TournamentListItem;
+  phase: HomeCardAnimationPhase;
 }
 
 function resolveProgressDistribution(item: TournamentListItem): ProgressDistribution {
@@ -73,12 +89,227 @@ export function sortForActiveTab(a: TournamentListItem, b: TournamentListItem): 
   return a.tournamentUuid.localeCompare(b.tournamentUuid);
 }
 
+function createStableCardEntries(items: TournamentListItem[]): HomeCardEntry[] {
+  return items.map((item) => ({
+    key: item.tournamentUuid,
+    item,
+    phase: 'stable',
+  }));
+}
+
+function mergeCardEntries(previous: HomeCardEntry[], nextItems: TournamentListItem[]): HomeCardEntry[] {
+  const nextIds = new Set(nextItems.map((item) => item.tournamentUuid));
+  const previousById = new Map(previous.map((entry) => [entry.key, entry] as const));
+  const previousIndexById = new Map(previous.map((entry, index) => [entry.key, index] as const));
+  const nextEntries: HomeCardEntry[] = nextItems.map((item) => {
+    const existing = previousById.get(item.tournamentUuid);
+    if (!existing) {
+      return {
+        key: item.tournamentUuid,
+        item,
+        phase: 'entering',
+      };
+    }
+    return {
+      key: existing.key,
+      item,
+      phase: existing.phase === 'exiting' ? 'stable' : existing.phase,
+    };
+  });
+  const exitingEntries = previous
+    .filter((entry) => !nextIds.has(entry.key))
+    .map((entry) =>
+      entry.phase === 'exiting'
+        ? entry
+        : {
+            ...entry,
+            phase: 'exiting' as const,
+          },
+    );
+  if (exitingEntries.length === 0) {
+    return nextEntries;
+  }
+  const merged = [...nextEntries];
+  const sortedExiting = [...exitingEntries].sort(
+    (a, b) => (previousIndexById.get(a.key) ?? 0) - (previousIndexById.get(b.key) ?? 0),
+  );
+  let insertedCount = 0;
+  for (const exiting of sortedExiting) {
+    const previousIndex = previousIndexById.get(exiting.key) ?? merged.length;
+    const insertIndex = Math.max(0, Math.min(merged.length, previousIndex + insertedCount));
+    merged.splice(insertIndex, 0, exiting);
+    insertedCount += 1;
+  }
+  return merged;
+}
+
 export function HomePage(props: HomePageProps): JSX.Element {
   const { t } = useTranslation();
+  const theme = useTheme();
+  const prefersReducedMotion = props.prefersReducedMotion ?? false;
+  const animationMode = props.animationMode ?? 'filter';
+  const flipEnabled = !prefersReducedMotion && animationMode === 'sort';
+  const cardEnterExitDuration = prefersReducedMotion ? 0 : HOME_CARD_ENTER_EXIT_DURATION_MS;
+  const cardEnterExitTransition = React.useMemo(
+    () =>
+      theme.transitions.create('opacity', {
+        duration: cardEnterExitDuration,
+        easing: theme.transitions.easing.easeOut,
+      }),
+    [cardEnterExitDuration, theme],
+  );
+  const cardFlipTransition = React.useMemo(
+    () =>
+      theme.transitions.create('transform', {
+        duration: prefersReducedMotion ? 0 : HOME_CARD_FLIP_DURATION_MS,
+        easing: theme.transitions.easing.easeOut,
+      }),
+    [prefersReducedMotion, theme],
+  );
+  const [cardEntries, setCardEntries] = React.useState<HomeCardEntry[]>(() => createStableCardEntries(props.items));
+  const cardItemRefs = React.useRef<Map<string, HTMLLIElement>>(new Map());
+  const previousRectsRef = React.useRef<Map<string, DOMRect>>(new Map());
+  const exitTimersRef = React.useRef<Map<string, number>>(new Map());
+  const enterFrameRef = React.useRef<number | null>(null);
+  const flipFrameIdsRef = React.useRef<number[]>([]);
+
+  const setCardItemRef = React.useCallback((key: string, node: HTMLLIElement | null) => {
+    if (node) {
+      cardItemRefs.current.set(key, node);
+      return;
+    }
+    cardItemRefs.current.delete(key);
+  }, []);
+
+  React.useEffect(() => {
+    if (prefersReducedMotion) {
+      setCardEntries(createStableCardEntries(props.items));
+      return;
+    }
+    setCardEntries((previous) => mergeCardEntries(previous, props.items));
+  }, [prefersReducedMotion, props.items]);
+
+  React.useEffect(() => {
+    if (prefersReducedMotion) {
+      return;
+    }
+    if (!cardEntries.some((entry) => entry.phase === 'entering')) {
+      return;
+    }
+    if (enterFrameRef.current !== null) {
+      window.cancelAnimationFrame(enterFrameRef.current);
+    }
+    enterFrameRef.current = window.requestAnimationFrame(() => {
+      setCardEntries((current) =>
+        current.map((entry) =>
+          entry.phase === 'entering'
+            ? {
+                ...entry,
+                phase: 'stable',
+              }
+            : entry,
+        ),
+      );
+      enterFrameRef.current = null;
+    });
+    return () => {
+      if (enterFrameRef.current !== null) {
+        window.cancelAnimationFrame(enterFrameRef.current);
+        enterFrameRef.current = null;
+      }
+    };
+  }, [cardEntries, prefersReducedMotion]);
+
+  React.useEffect(() => {
+    if (prefersReducedMotion) {
+      exitTimersRef.current.forEach((timerId) => window.clearTimeout(timerId));
+      exitTimersRef.current.clear();
+      previousRectsRef.current.clear();
+    }
+  }, [prefersReducedMotion]);
+
+  React.useEffect(() => {
+    if (prefersReducedMotion) {
+      return;
+    }
+    const exitingKeys = new Set(cardEntries.filter((entry) => entry.phase === 'exiting').map((entry) => entry.key));
+    exitTimersRef.current.forEach((timerId, key) => {
+      if (!exitingKeys.has(key)) {
+        window.clearTimeout(timerId);
+        exitTimersRef.current.delete(key);
+      }
+    });
+    for (const key of exitingKeys) {
+      if (exitTimersRef.current.has(key)) {
+        continue;
+      }
+      const timerId = window.setTimeout(() => {
+        exitTimersRef.current.delete(key);
+        setCardEntries((current) => current.filter((entry) => entry.key !== key));
+      }, HOME_CARD_ENTER_EXIT_DURATION_MS);
+      exitTimersRef.current.set(key, timerId);
+    }
+  }, [cardEntries, prefersReducedMotion]);
+
+  React.useLayoutEffect(() => {
+    const nextRects = new Map<string, DOMRect>();
+    cardItemRefs.current.forEach((node, key) => {
+      nextRects.set(key, node.getBoundingClientRect());
+    });
+    if (flipEnabled) {
+      for (const frameId of flipFrameIdsRef.current) {
+        window.cancelAnimationFrame(frameId);
+      }
+      flipFrameIdsRef.current = [];
+      const stableKeys = new Set(cardEntries.filter((entry) => entry.phase === 'stable').map((entry) => entry.key));
+      nextRects.forEach((nextRect, key) => {
+        if (!stableKeys.has(key)) {
+          return;
+        }
+        const previousRect = previousRectsRef.current.get(key);
+        if (!previousRect) {
+          return;
+        }
+        const deltaX = previousRect.left - nextRect.left;
+        const deltaY = previousRect.top - nextRect.top;
+        if (Math.abs(deltaX) < 0.5 && Math.abs(deltaY) < 0.5) {
+          return;
+        }
+        const node = cardItemRefs.current.get(key);
+        if (!node) {
+          return;
+        }
+        node.style.transition = 'none';
+        node.style.transform = `translate(${deltaX}px, ${deltaY}px)`;
+        const frameId = window.requestAnimationFrame(() => {
+          node.style.transition = cardFlipTransition;
+          node.style.transform = '';
+        });
+        flipFrameIdsRef.current.push(frameId);
+      });
+    }
+    previousRectsRef.current = nextRects;
+  }, [cardEntries, cardFlipTransition, flipEnabled]);
+
+  React.useEffect(
+    () => () => {
+      if (enterFrameRef.current !== null) {
+        window.cancelAnimationFrame(enterFrameRef.current);
+        enterFrameRef.current = null;
+      }
+      for (const frameId of flipFrameIdsRef.current) {
+        window.cancelAnimationFrame(frameId);
+      }
+      flipFrameIdsRef.current = [];
+      exitTimersRef.current.forEach((timerId) => window.clearTimeout(timerId));
+      exitTimersRef.current.clear();
+    },
+    [],
+  );
 
   return (
     <div className="page tournamentListPage">
-      {props.items.length === 0 ? (
+      {cardEntries.length === 0 ? (
         <div className="emptyState">
           <p className="emptyText">{t('home.empty.text')}</p>
           {props.onOpenFilterInEmpty ? (
@@ -89,22 +320,32 @@ export function HomePage(props: HomePageProps): JSX.Element {
         </div>
       ) : (
         <ul className="cardList">
-          {props.items.map((item) => {
-            const progress = resolveProgressDistribution(item);
+          {cardEntries.map((entry) => {
+            const progress = resolveProgressDistribution(entry.item);
 
             return (
-              <li key={item.tournamentUuid}>
-                <TournamentSummaryCard
-                  variant="list"
-                  title={item.tournamentName}
-                  startDate={item.startDate}
-                  endDate={item.endDate}
-                  todayDate={props.todayDate}
-                  sharedCount={progress.sharedCount}
-                  unsharedCount={progress.sendWaitingCount}
-                  unregisteredCount={progress.unregisteredCount}
-                  onOpenDetail={() => props.onOpenDetail(item.tournamentUuid)}
-                />
+              <li key={entry.key} className="homeCardListItem" ref={(node) => setCardItemRef(entry.key, node)}>
+                <div
+                  className={`homeCardPresence homeCardPresence-${entry.phase}`}
+                  style={{
+                    transition: cardEnterExitTransition,
+                  }}
+                >
+                  <div className="homeCardPresenceContent">
+                    <TournamentSummaryCard
+                      variant="list"
+                      title={entry.item.tournamentName}
+                      startDate={entry.item.startDate}
+                      endDate={entry.item.endDate}
+                      todayDate={props.todayDate}
+                      sharedCount={progress.sharedCount}
+                      unsharedCount={progress.sendWaitingCount}
+                      unregisteredCount={progress.unregisteredCount}
+                      prefersReducedMotion={prefersReducedMotion}
+                      onOpenDetail={() => props.onOpenDetail(entry.item.tournamentUuid)}
+                    />
+                  </div>
+                </div>
               </li>
             );
           })}

--- a/packages/web-app/src/styles.css
+++ b/packages/web-app/src/styles.css
@@ -596,6 +596,28 @@ label {
   margin: 0;
   font-weight: 600;
   color: var(--home-filter-sheet-muted);
+  display: inline-flex;
+  align-items: baseline;
+}
+
+.homeFilterResultCountValue {
+  display: inline-block;
+  min-width: 2ch;
+  text-align: right;
+}
+
+.homeFilterResultCountValue-animated {
+  animation: homeFilterResultCountFade 150ms ease 50ms both;
+}
+
+@keyframes homeFilterResultCountFade {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
 }
 
 .homeFilterResetLink {
@@ -647,6 +669,29 @@ label {
   gap: 16px;
 }
 
+.homeCardListItem {
+  list-style: none;
+  will-change: transform;
+}
+
+.homeCardPresence {
+  opacity: 1;
+  transition: opacity 200ms ease;
+}
+
+.homeCardPresenceContent {
+  overflow: hidden;
+}
+
+.homeCardPresence-entering {
+  opacity: 0;
+}
+
+.homeCardPresence-exiting {
+  opacity: 0;
+  pointer-events: none;
+}
+
 .tournamentCard {
   width: 100%;
   text-align: left;
@@ -657,11 +702,20 @@ label {
   display: grid;
   gap: 10px;
   box-shadow: var(--shadow);
+  cursor: pointer;
+  transform: scale(1);
+  transform-origin: center;
+  transition: transform 150ms ease, background-color 150ms ease, box-shadow 150ms ease;
 }
 
 .tournamentCard:hover {
   background: var(--surface-2);
   box-shadow: var(--shadow);
+}
+
+.tournamentCard:active {
+  transform: scale(0.98);
+  transition-duration: 120ms;
 }
 
 .tournamentCard:focus-visible {
@@ -935,6 +989,8 @@ label {
 .stateDistributionBar > .progressBarSegment-sendWaiting,
 .stateDistributionBar > .progressBarSegment-unregistered {
   height: 100%;
+  width: 0;
+  transition: width 280ms ease-out;
 }
 
 .stateDistributionBar > .progressBarSegment-shared {
@@ -955,6 +1011,24 @@ label {
   background: linear-gradient(90deg, var(--accent-strong), var(--progress-gradient-end));
 }
 
+.tournamentSummaryProgressWrap {
+  display: grid;
+  gap: 4px;
+}
+
+.tournamentProgressValue {
+  justify-self: end;
+  color: var(--text-faint);
+  font-size: 11px;
+  font-weight: 600;
+  opacity: 0;
+  transition: opacity 150ms ease 50ms;
+}
+
+.tournamentProgressValue-visible {
+  opacity: 1;
+}
+
 .cardNavigationHint {
   display: inline-flex;
   justify-self: end;
@@ -965,10 +1039,28 @@ label {
   font-weight: 700;
 }
 
+.cardNavigationHintLabel {
+  text-decoration: none;
+  text-underline-offset: 2px;
+  text-decoration-thickness: 1px;
+}
+
 .cardArrow {
   color: var(--accent);
   font-size: 17px;
   line-height: 1;
+  transform: translateX(0);
+  transition: transform 130ms ease;
+}
+
+.tournamentCard:hover .cardNavigationHintLabel,
+.tournamentCard:focus-visible .cardNavigationHintLabel {
+  text-decoration: underline;
+}
+
+.tournamentCard:hover .cardArrow,
+.tournamentCard:focus-visible .cardArrow {
+  transform: translateX(4px);
 }
 
 .formGrid {
@@ -2207,6 +2299,37 @@ label {
 .settingsGrid dd {
   margin: 0;
   overflow-wrap: anywhere;
+}
+
+.homeFabPlusIcon-open {
+  transform: rotate(45deg);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .homeCardPresence,
+  .homeCardListItem,
+  .tournamentCard,
+  .stateDistributionBar > .progressBarSegment-shared,
+  .stateDistributionBar > .progressBarSegment-sendWaiting,
+  .stateDistributionBar > .progressBarSegment-unregistered,
+  .tournamentProgressValue,
+  .cardArrow,
+  .homeFilterResultCountValue-animated,
+  .homeFabPlusIcon {
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 1ms !important;
+    transition-delay: 0ms !important;
+  }
+
+  .homeCardPresence-entering,
+  .homeCardPresence-exiting {
+    opacity: 1;
+  }
+
+  .tournamentCard:active {
+    transform: scale(1);
+  }
 }
 
 @media (max-width: 720px) {

--- a/tasks/feat-home-microinteractions.md
+++ b/tasks/feat-home-microinteractions.md
@@ -1,0 +1,98 @@
+# Plan: feat/home-microinteractions
+
+## 目的
+
+- スコアタ一覧の状態変化（フィルタ差分・カード操作・FAB展開）を短時間で理解できるようにし、操作の説明性を上げる。
+- 演出過多を避け、既存UI/意味体系を維持したまま最小差分でマイクロインタラクションを追加する。
+- `prefers-reduced-motion` 利用時に動きを無効化または短縮し、アクセシビリティを担保する。
+
+## 非目的
+
+- データモデル・DB・永続化形式の変更。
+- Service Worker / Web Locks / import-export 経路の変更。
+- 依存追加（新規ライブラリ導入）やテーマ全面刷新。
+
+## 変更点
+
+- 一覧カードに hover/press フィードバックを追加。
+  - press時 `scale(0.98)`（短時間）を適用。
+  - 「詳細を見る」の hover underline と矢印の右移動を追加。
+- 既存アニメーションの安定性改善として、可能な箇所は MUI `theme.transitions` ベースへ寄せる。
+  - duration / easing を MUI transitions 由来の値で統一
+  - FAB回転・一覧差分・進捗/件数の遷移指定を MUI transitions と同期
+- フィルタ/検索/ソート反映時の一覧差分アニメを追加。
+  - フィルタ/検索時:
+    - FLIPなし
+    - 追加/削除は opacity のみ（200ms）
+    - collapse（高さアニメ）は行わない
+  - 並び替え時:
+    - FLIPあり
+    - transform は FLIP のみ（追加 translate は行わない）
+    - duration 200ms / easing ease-out
+- 進捗バー表示時の短時間アニメを追加。
+  - バー描画の視認性向上（短時間収束）
+  - 数値表示の遅延フェードイン
+- 「現在の結果: N件」の N のみを短時間で更新するアニメーションを追加。
+- FAB展開状態に同期した `+` アイコンの 45 度回転（`×` 見え）を追加。
+
+## 影響範囲（ユーザー / データ / 互換性）
+
+- ユーザー:
+  - ホーム一覧の操作時フィードバックが増える。
+  - フィルタ結果変化・FAB展開状態が視覚的に追いやすくなる。
+- データ:
+  - 影響なし（読み取り/UI表示のみ）。
+- 互換性:
+  - API / payload / DB schema 変更なし。
+  - `prefers-reduced-motion` に対応し、動きが苦手な環境でも破綻しない。
+
+## 実装方針（対象ファイル単位）
+
+- `packages/web-app/src/pages/HomePage.tsx`
+  - 一覧差分アニメ管理（enter/exit/FLIP）を実装。
+  - `animationMode`（filter/search or sort）で挙動分岐し、要件どおりに motion を切り替える。
+- `packages/web-app/src/components/TournamentSummaryCard.tsx`
+  - カード内導線と進捗表示のマイクロインタラクション用DOM/classを追加。
+  - 進捗バー・数値フェードの transition 指定を MUI transitions 化。
+- `packages/web-app/src/App.tsx`
+  - 結果件数の数値アニメーション、およびFABアイコン回転を実装。
+  - FABアイコン回転の transition 指定を MUI transitions 化。
+- `packages/web-app/src/styles.css`
+  - カード hover/press、リンク矢印遷移、一覧差分、進捗バー、件数、FAB回転のスタイルを追加。
+  - reduced-motion向けの短縮/無効化を追加。
+- `packages/web-app/src/pages/HomePage.test.tsx`
+  - DOM構造変更に伴う既存テスト調整と、追加要素の回帰確認を補強。
+
+### 変更スコープ固定
+
+- 上記5ファイル + 本 tasks ファイルのみ変更。
+
+## テスト観点
+
+- Home 一覧:
+  - カード押下で `onOpenDetail` が従来通り呼ばれる。
+  - フィルタ変更で追加/削除/並び替え時に要素が消失せず描画される（回帰なし）。
+- 進捗:
+  - 既存の進捗セグメント比率（width値）が維持される。
+- 件数表示:
+  - 表示文言は維持しつつ数値のみ更新される。
+- FAB:
+  - 開閉状態とアイコン回転クラスが同期する。
+- 全体:
+  - `pnpm --filter @iidx/web-app test -- --run src/pages/HomePage.test.tsx`
+  - `pnpm --filter @iidx/web-app lint`
+  - 必要最小限で web-app テスト実行
+
+## ロールバック方針
+
+- UIアニメ関連の変更をコミット単位で revert する。
+- FLIP/件数/FAB回転は別コミット化し、問題箇所のみ戻せるように分離する。
+
+## Commit Plan（コミット分割計画）
+
+1. 一覧差分（FLIP + enter/exit）実装と HomePage テスト調整。
+2. カード hover/press・進捗・詳細リンクのマイクロインタラクション追加。
+3. 件数アニメーションと FAB 回転、reduced-motion 調整。
+
+Commit execution note:
+- 実装後の検証で「フィルタ/検索時のガタつき抑制」「MUI transitions への統一」「FLIP適用条件の分離」が同一箇所にまたがり、差分が強く結合したため、最終的に単一コミットへ集約する。


### PR DESCRIPTION
## 目的
- 一覧画面の状態変化（フィルタ/検索/並び替え、カード操作、FAB展開）の説明性を上げる。
- フィルタ/検索時のガタつきを抑え、並び替え時のみFLIPを使う挙動に分離する。

## 変更点
- 一覧カードのマイクロインタラクション
  - hover/pressフィードバック（press: scale 0.98）
  - 「詳細を見る」hover underline + 矢印移動
- 一覧差分アニメーション
  - フィルタ/検索: FLIPなし、追加/削除は opacity のみ（200ms）
  - 並び替え: FLIPあり、transform は FLIP のみ（200ms, ease-out）
- 進捗バーと進捗値の短時間アニメーション追加
- 「現在の結果: N件」の N のみアニメーション更新
- FAB 展開時の + アイコン 45deg 回転（MUI transitions ベース）
- reduced-motion 時の短縮/無効化
- Planファイル追加: tasks/feat-home-microinteractions.md

## 非変更点
- DB schema / 永続化形式 / payload 仕様
- Service Worker / Web Locks / single-tab invariant
- 依存関係追加

## 影響範囲
- ユーザー: ホーム一覧画面の視覚フィードバック改善
- データ/互換性: 変更なし

## テスト内容
- pnpm --filter @iidx/web-app lint
- pnpm --filter @iidx/web-app test -- --run src/pages/HomePage.test.tsx
  - package scriptの都合でweb-appテスト一式が実行され、全件pass

## 回帰確認項目
- フィルタ/検索時にガタつきなくフェードのみで追加/削除される
- 並び替え時のみFLIPで位置遷移する
- カードクリック導線、進捗表示、FAB回転が同期する
- prefers-reduced-motion で過剰な動きが抑制される