### PR TITLE
feat(web-app): add detail page microinteractions

### DIFF
--- a/packages/web-app/src/App.tsx
+++ b/packages/web-app/src/App.tsx
@@ -49,7 +49,7 @@ import { ImportConfirmPage } from './pages/ImportConfirmPage';
 import { ImportTournamentPage } from './pages/ImportTournamentPage';
 import { SettingsPage, type AppInfoCardData, type AppSwStatus } from './pages/SettingsPage';
 import { SubmitEvidencePage } from './pages/SubmitEvidencePage';
-import { TournamentDetailPage } from './pages/TournamentDetailPage';
+import { TournamentDetailPage, type TournamentDetailReturnSignal } from './pages/TournamentDetailPage';
 import {
   buildCreateTournamentInput,
   CREATE_TOURNAMENT_DRAFT_STORAGE_KEY,
@@ -202,8 +202,37 @@ type RouteState =
   | { name: 'import-confirm' }
   | { name: 'create' }
   | { name: 'detail'; tournamentUuid: string }
-  | { name: 'submit'; tournamentUuid: string; chartId: number }
+  | { name: 'submit'; tournamentUuid: string; chartId: number; progressSnapshot: DetailProgressSnapshot }
   | { name: 'settings' };
+
+interface DetailProgressSnapshot {
+  shared: number;
+  unshared: number;
+  unregistered: number;
+}
+
+function resolveDetailProgressSnapshot(detail: TournamentDetailItem): DetailProgressSnapshot {
+  let shared = 0;
+  let unshared = 0;
+  let unregistered = 0;
+  detail.charts.forEach((chart) => {
+    const localSaved = chart.updateSeq > 0 && !chart.fileDeleted;
+    if (!localSaved) {
+      unregistered += 1;
+      return;
+    }
+    if (chart.needsSend) {
+      unshared += 1;
+      return;
+    }
+    shared += 1;
+  });
+  return { shared, unshared, unregistered };
+}
+
+function hasDetailProgressChanged(previous: DetailProgressSnapshot, next: DetailProgressSnapshot): boolean {
+  return previous.shared !== next.shared || previous.unshared !== next.unshared || previous.unregistered !== next.unregistered;
+}
 
 function normalizePathname(pathname: string): string {
   if (pathname.length > 1 && pathname.endsWith('/')) {
@@ -1057,6 +1086,7 @@ export function App({ webLockAcquired = false }: AppProps = {}): JSX.Element {
   const [homeFilterFocusSection, setHomeFilterFocusSection] = React.useState<HomeFilterSheetFocusSection>(null);
   const [homeQueryReady, setHomeQueryReady] = React.useState(false);
   const [detail, setDetail] = React.useState<TournamentDetailItem | null>(null);
+  const [detailReturnSignal, setDetailReturnSignal] = React.useState<TournamentDetailReturnSignal | null>(null);
   const [busy, setBusy] = React.useState(false);
   const [songMasterReady, setSongMasterReady] = React.useState(false);
   const [songMasterMeta, setSongMasterMeta] = React.useState<Record<string, string | null>>(INITIAL_SONG_MASTER_META);
@@ -1521,6 +1551,28 @@ export function App({ webLockAcquired = false }: AppProps = {}): JSX.Element {
       return previous.slice(0, -1);
     });
   }, []);
+
+  const publishDetailReturnSignal = React.useCallback((next: Omit<TournamentDetailReturnSignal, 'token'>) => {
+    setDetailReturnSignal({
+      ...next,
+      token: crypto.randomUUID(),
+    });
+  }, []);
+
+  const consumeDetailReturnSignal = React.useCallback((token: string) => {
+    setDetailReturnSignal((current) => (current && current.token === token ? null : current));
+  }, []);
+
+  const goBack = React.useCallback(() => {
+    if (route.name === 'submit') {
+      publishDetailReturnSignal({
+        tournamentUuid: route.tournamentUuid,
+        returnReason: 'back',
+        progressChanged: false,
+      });
+    }
+    popRoute();
+  }, [popRoute, publishDetailReturnSignal, route]);
 
   const resetRoute = React.useCallback((next: RouteState) => {
     setRouteStack([next]);
@@ -2060,6 +2112,7 @@ export function App({ webLockAcquired = false }: AppProps = {}): JSX.Element {
         resetRoute({ name: 'home' });
         return;
       }
+      setDetailReturnSignal(null);
       replaceRoute({ name: 'detail', tournamentUuid: result.tournamentUuid });
     },
     [appDb, pushToast, refreshTournamentList, reloadDetail, replaceRoute, resetRoute, t],
@@ -2261,9 +2314,10 @@ export function App({ webLockAcquired = false }: AppProps = {}): JSX.Element {
     [appDb, appendRuntimeLog, pushToast, refreshSettingsSnapshot, refreshTournamentList, t],
   );
 
+  const submitRoute = route.name === 'submit' ? route : null;
   const submitChart =
-    route.name === 'submit' && detail
-      ? detail.charts.find((chart) => chart.chartId === route.chartId) ?? null
+    submitRoute && detail
+      ? detail.charts.find((chart) => chart.chartId === submitRoute.chartId) ?? null
       : null;
 
   const pageTitle = React.useMemo(() => {
@@ -2674,7 +2728,7 @@ export function App({ webLockAcquired = false }: AppProps = {}): JSX.Element {
                 >
                   <Box sx={{ minWidth: 40, display: 'flex', justifyContent: 'flex-start' }}>
                     {canGoBack ? (
-                      <IconButton edge="start" color="inherit" aria-label="back" onClick={popRoute}>
+                      <IconButton edge="start" color="inherit" aria-label="back" onClick={goBack}>
                         <ArrowBackIcon />
                       </IconButton>
                     ) : null}
@@ -2687,7 +2741,7 @@ export function App({ webLockAcquired = false }: AppProps = {}): JSX.Element {
               ) : (
                 <>
                   {canGoBack ? (
-                    <IconButton edge="start" color="inherit" aria-label="back" onClick={popRoute} sx={{ mr: 1 }}>
+                    <IconButton edge="start" color="inherit" aria-label="back" onClick={goBack} sx={{ mr: 1 }}>
                       <ArrowBackIcon />
                     </IconButton>
                   ) : null}
@@ -2840,6 +2894,7 @@ export function App({ webLockAcquired = false }: AppProps = {}): JSX.Element {
                 if (!loaded) {
                   return;
                 }
+                setDetailReturnSignal(null);
                 pushRoute({ name: 'detail', tournamentUuid });
               }}
             />
@@ -2888,7 +2943,12 @@ export function App({ webLockAcquired = false }: AppProps = {}): JSX.Element {
             detail={detail}
             todayDate={todayDate}
             onOpenSubmit={(chartId) => {
-              pushRoute({ name: 'submit', tournamentUuid: detail.tournamentUuid, chartId });
+              pushRoute({
+                name: 'submit',
+                tournamentUuid: detail.tournamentUuid,
+                chartId,
+                progressSnapshot: resolveDetailProgressSnapshot(detail),
+              });
             }}
             onUpdated={async () => {
               await reloadDetail(detail.tournamentUuid);
@@ -2898,17 +2958,29 @@ export function App({ webLockAcquired = false }: AppProps = {}): JSX.Element {
             debugModeEnabled={debugModeEnabled}
             debugLastError={detailTechnicalInfo?.last_error ?? null}
             onReportDebugError={setDetailDebugLastError}
+            returnSignal={detailReturnSignal && detailReturnSignal.tournamentUuid === detail.tournamentUuid ? detailReturnSignal : null}
+            onConsumeReturnSignal={consumeDetailReturnSignal}
+            prefersReducedMotion={prefersReducedMotion}
           />
         )}
 
-        {route.name === 'submit' && detail && submitChart && (
+        {submitRoute && detail && submitChart && (
           <SubmitEvidencePage
             detail={detail}
             chart={submitChart}
             onSaved={async (reason) => {
-              await reloadDetail(detail.tournamentUuid);
+              const nextDetail = await reloadDetail(detail.tournamentUuid);
               await refreshTournamentList();
-              if (reason === 'submit') {
+              if (reason === 'saved' || reason === 'replaced') {
+                const nextSnapshot = nextDetail ? resolveDetailProgressSnapshot(nextDetail) : submitRoute.progressSnapshot;
+                publishDetailReturnSignal({
+                  tournamentUuid: detail.tournamentUuid,
+                  returnReason: reason,
+                  changedChartId: String(submitRoute.chartId),
+                  progressChanged: hasDetailProgressChanged(submitRoute.progressSnapshot, nextSnapshot),
+                });
+              }
+              if (nextDetail) {
                 popRoute();
               }
             }}

--- a/packages/web-app/src/components/ChartCard.tsx
+++ b/packages/web-app/src/components/ChartCard.tsx
@@ -22,6 +22,7 @@ interface ChartCardProps {
   statusTestId?: string | undefined;
   metaTestId?: string | undefined;
   variant?: ChartCardVariant | undefined;
+  statusAnimationToken?: number | undefined;
 }
 
 function joinClasses(...values: Array<string | undefined | null | false>): string {
@@ -102,6 +103,10 @@ export function ChartCard(props: ChartCardProps): JSX.Element {
 
   const showSubmitMetaStatus = variant === 'submit' && badgeStatus !== undefined && !hideSubmitBadge;
   const showLeftStatus = variant === 'detail' && badgeStatus !== undefined;
+  const detailStatusBadgeKey =
+    showLeftStatus && props.statusAnimationToken !== undefined
+      ? `detail-status-${badgeStatus}-${props.statusAnimationToken}`
+      : `detail-status-${badgeStatus}`;
   const hasActions = props.actions !== null && props.actions !== undefined;
   const useDetailMobileLayout = variant === 'detail' && isMobileViewport;
   const showInlineDetailAction = useDetailMobileLayout && hasActions;
@@ -147,7 +152,12 @@ export function ChartCard(props: ChartCardProps): JSX.Element {
           <div className={joinClasses('chartLeftStatusRow', showInlineDetailAction && 'chartLeftStatusRow-mobile')}>
             {showLeftStatus ? (
               <span
-                className={`chartStateBadge chartStateBadge-${badgeStatus}`}
+                key={detailStatusBadgeKey}
+                className={joinClasses(
+                  `chartStateBadge chartStateBadge-${badgeStatus}`,
+                  'chartStateBadge-detail',
+                  props.statusAnimationToken !== undefined && 'chartStateBadge-fade',
+                )}
                 data-testid={props.statusTestId}
                 data-chart-state={badgeStatus}
               >

--- a/packages/web-app/src/components/TournamentSummaryCard.tsx
+++ b/packages/web-app/src/components/TournamentSummaryCard.tsx
@@ -23,6 +23,7 @@ interface TournamentSummaryCardProps {
   onOpenDetail?: (() => void) | undefined;
   shareAction?: React.ReactNode;
   prefersReducedMotion?: boolean;
+  animateProgress?: boolean;
 }
 
 function joinClasses(...values: Array<string | undefined | null | false>): string {
@@ -56,7 +57,7 @@ export function TournamentSummaryCard(props: TournamentSummaryCardProps): JSX.El
   const progressBarTransition = React.useMemo(
     () =>
       theme.transitions.create('width', {
-        duration: prefersReducedMotion ? 0 : 280,
+        duration: prefersReducedMotion ? 0 : 200,
         easing: theme.transitions.easing.easeOut,
       }),
     [prefersReducedMotion, theme],
@@ -64,9 +65,8 @@ export function TournamentSummaryCard(props: TournamentSummaryCardProps): JSX.El
   const progressValueTransition = React.useMemo(
     () =>
       theme.transitions.create('opacity', {
-        duration: prefersReducedMotion ? 0 : 150,
+        duration: prefersReducedMotion ? 0 : 200,
         easing: theme.transitions.easing.easeOut,
-        delay: prefersReducedMotion ? 0 : 50,
       }),
     [prefersReducedMotion, theme],
   );
@@ -93,7 +93,7 @@ export function TournamentSummaryCard(props: TournamentSummaryCardProps): JSX.El
   const showPeriod = props.variant !== 'list';
   const showIncompleteLabels = (props.variant === 'list' || props.variant === 'detail') && (safeUnregisteredCount > 0 || safeUnsharedCount > 0);
   const showProgress = props.variant === 'list' || props.variant === 'detail';
-  const shouldAnimateProgress = props.variant === 'list' && !prefersReducedMotion;
+  const shouldAnimateProgress = Boolean(props.animateProgress ?? (props.variant === 'list')) && !prefersReducedMotion;
   const submittedCount = safeSharedCount + safeUnsharedCount;
   const progressValueText = `${submittedCount}/${totalCount}`;
   const showDetailLink = props.variant === 'list';

--- a/packages/web-app/src/pages/SubmitEvidencePage.tsx
+++ b/packages/web-app/src/pages/SubmitEvidencePage.tsx
@@ -10,7 +10,7 @@ import { reencodeImageToJpeg, toSafeArrayBuffer } from '../utils/image';
 interface SubmitEvidencePageProps {
   detail: TournamentDetailItem;
   chart: TournamentDetailChart;
-  onSaved: (reason: 'submit' | 'delete') => Promise<void> | void;
+  onSaved: (reason: 'saved' | 'replaced') => Promise<void> | void;
 }
 
 enum SubmitState {
@@ -168,6 +168,7 @@ export function SubmitEvidencePage(props: SubmitEvidencePageProps): JSX.Element 
       if (submitState === SubmitState.PROCESSING) {
         return;
       }
+      const saveReason: 'saved' | 'replaced' = localSaved ? 'replaced' : 'saved';
       manualSelectionRef.current = true;
       setSubmitState(SubmitState.PROCESSING);
       setErrorReasonKey(null);
@@ -202,13 +203,13 @@ export function SubmitEvidencePage(props: SubmitEvidencePageProps): JSX.Element 
         setPreviewFromBlob(encoded.blob);
         setSubmitState(SubmitState.IDLE);
 
-        await Promise.resolve(props.onSaved('submit'));
+        await Promise.resolve(props.onSaved(saveReason));
       } catch (error) {
         setSubmitState(SubmitState.ERROR);
         setErrorReasonKey(resolveFailureReasonKey(error));
       }
     },
-    [appDb, opfs, props, setPreviewFromBlob, submitState],
+    [appDb, localSaved, opfs, props, setPreviewFromBlob, submitState],
   );
 
   const onSelectFile = React.useCallback(

--- a/packages/web-app/src/pages/TournamentDetailPage.test.tsx
+++ b/packages/web-app/src/pages/TournamentDetailPage.test.tsx
@@ -4,7 +4,7 @@ import { cleanup, render, screen, waitFor, within } from '@testing-library/react
 import userEvent from '@testing-library/user-event';
 import type { TournamentDetailItem } from '@iidx/db';
 
-import { TournamentDetailPage } from './TournamentDetailPage';
+import { TournamentDetailPage, type TournamentDetailReturnSignal } from './TournamentDetailPage';
 
 vi.mock('qrcode', () => ({
   default: {
@@ -104,18 +104,27 @@ function buildDetail(overrides: Partial<TournamentDetailItem> = {}): TournamentD
 function renderPage(
   overrides: Partial<TournamentDetailItem> = {},
   todayDate = '2026-02-10',
-  options: { debugModeEnabled?: boolean } = {},
+  options: {
+    debugModeEnabled?: boolean;
+    onOpenSubmit?: (chartId: number) => void;
+    returnSignal?: TournamentDetailReturnSignal | null;
+    onConsumeReturnSignal?: (token: string) => void;
+    prefersReducedMotion?: boolean;
+  } = {},
 ): void {
   render(
     <TournamentDetailPage
       detail={buildDetail(overrides)}
       todayDate={todayDate}
-      onOpenSubmit={() => undefined}
+      onOpenSubmit={options.onOpenSubmit ?? (() => undefined)}
       onUpdated={() => undefined}
       onOpenSettings={() => undefined}
       debugModeEnabled={options.debugModeEnabled ?? false}
       debugLastError={null}
       onReportDebugError={() => undefined}
+      returnSignal={options.returnSignal ?? null}
+      {...(options.onConsumeReturnSignal ? { onConsumeReturnSignal: options.onConsumeReturnSignal } : {})}
+      {...(options.prefersReducedMotion !== undefined ? { prefersReducedMotion: options.prefersReducedMotion } : {})}
     />,
   );
 }
@@ -301,6 +310,7 @@ describe('TournamentDetailPage', () => {
         value: undefined,
       });
     }
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
@@ -348,6 +358,59 @@ describe('TournamentDetailPage', () => {
     expect(actionButtons[2]?.textContent).toContain('差し替え');
     expect(actionButtons[2]?.getAttribute('data-chart-action-tone')).toBe('secondary');
     expect(actionButtons[2]?.className).toContain('chartSubmitButton-secondary');
+  });
+
+  it('locks chart submit buttons for 200ms to prevent double taps', async () => {
+    const onOpenSubmit = vi.fn();
+    renderPage({}, '2026-02-10', { onOpenSubmit });
+
+    const actionButtons = screen.getAllByTestId('tournament-detail-chart-submit-button');
+    await userEvent.click(actionButtons[0] as HTMLElement);
+    await userEvent.click(actionButtons[0] as HTMLElement);
+    expect(onOpenSubmit).toHaveBeenCalledTimes(1);
+
+    await new Promise((resolve) => {
+      window.setTimeout(resolve, 210);
+    });
+    await userEvent.click(actionButtons[0] as HTMLElement);
+    expect(onOpenSubmit).toHaveBeenCalledTimes(2);
+  });
+
+  it('highlights changed chart on saved return signal and consumes the signal token', async () => {
+    const onConsumeReturnSignal = vi.fn();
+    renderPage({}, '2026-02-10', {
+      returnSignal: {
+        token: 'signal-token-1',
+        tournamentUuid: detail.tournamentUuid,
+        returnReason: 'saved',
+        changedChartId: '101',
+        progressChanged: true,
+      },
+      onConsumeReturnSignal,
+    });
+
+    await waitFor(() => {
+      expect(onConsumeReturnSignal).toHaveBeenCalledWith('signal-token-1');
+    });
+    await waitFor(() => {
+      const row = document.querySelector('li[data-chart-id="101"]');
+      expect(row?.className).toContain('detailChartListRow-highlighted');
+    });
+  });
+
+  it('does not highlight chart rows when return reason is back', async () => {
+    renderPage({}, '2026-02-10', {
+      returnSignal: {
+        token: 'signal-token-back',
+        tournamentUuid: detail.tournamentUuid,
+        returnReason: 'back',
+        progressChanged: false,
+      },
+    });
+
+    await waitFor(() => {
+      expect(document.querySelector('.detailChartListRow-highlighted')).toBeNull();
+    });
   });
 
   it('renders chart attributes as one line text and removes attribute badges', () => {

--- a/packages/web-app/src/pages/TournamentDetailPage.tsx
+++ b/packages/web-app/src/pages/TournamentDetailPage.tsx
@@ -5,6 +5,7 @@ import QRCode from 'qrcode';
 import { useTranslation } from 'react-i18next';
 import CloseIcon from '@mui/icons-material/Close';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import { useTheme } from '@mui/material/styles';
 import {
   Accordion,
   AccordionDetails,
@@ -24,6 +25,7 @@ import {
   TextField,
   Typography,
 } from '@mui/material';
+import useMediaQuery from '@mui/material/useMediaQuery';
 
 import { useAppServices } from '../services/context';
 import { ChartCard } from '../components/ChartCard';
@@ -32,6 +34,17 @@ import { buildImportUrl } from '../utils/payload-url';
 import { difficultyColorHex } from '../utils/iidx';
 import { resolveTournamentCardStatus } from '../utils/tournament-status';
 import { TournamentSummaryCard } from '../components/TournamentSummaryCard';
+
+export type TournamentDetailReturnReason = 'back' | 'saved' | 'replaced' | 'shared';
+
+export interface TournamentDetailReturnSignal {
+  token: string;
+  tournamentUuid: string;
+  returnReason: TournamentDetailReturnReason;
+  changedChartId?: string;
+  changedCount?: number;
+  progressChanged?: boolean;
+}
 
 interface TournamentDetailPageProps {
   detail: TournamentDetailItem;
@@ -42,6 +55,9 @@ interface TournamentDetailPageProps {
   debugModeEnabled: boolean;
   debugLastError: string | null;
   onReportDebugError: (errorMessage: string | null) => void;
+  returnSignal?: TournamentDetailReturnSignal | null;
+  onConsumeReturnSignal?: (token: string) => void;
+  prefersReducedMotion?: boolean;
 }
 
 const SHARE_IMAGE_WIDTH = 1080;
@@ -66,7 +82,16 @@ type SharePosterChart = {
 };
 
 type ChartShareState = 'unregistered' | 'unshared' | 'shared';
+type ChartStateCounts = { shared: number; unshared: number; unregistered: number };
 type TranslationFn = (...args: any[]) => any;
+
+function hasChartStateCountChanged(previous: ChartStateCounts, next: ChartStateCounts): boolean {
+  return (
+    previous.shared !== next.shared ||
+    previous.unshared !== next.unshared ||
+    previous.unregistered !== next.unregistered
+  );
+}
 
 function optionalHashtag(value: string): string | null {
   const formatted = formatHashtagForDisplay(value);
@@ -539,6 +564,11 @@ async function buildShareImage(detail: TournamentDetailItem, shareUrl: string, t
 export function TournamentDetailPage(props: TournamentDetailPageProps): JSX.Element {
   const { appDb, opfs } = useAppServices();
   const { t } = useTranslation();
+  const theme = useTheme();
+  const prefersReducedMotion = props.prefersReducedMotion ?? useMediaQuery('(prefers-reduced-motion: reduce)');
+  const incomingReturnSignal =
+    props.returnSignal && props.returnSignal.tournamentUuid === props.detail.tournamentUuid ? props.returnSignal : null;
+  const initialReturnSignal = incomingReturnSignal;
   const [shareDialogOpen, setShareDialogOpen] = React.useState(false);
   const [shareImageStatus, setShareImageStatus] = React.useState<'idle' | 'loading' | 'ready' | 'error'>('idle');
   const [shareImageBlob, setShareImageBlob] = React.useState<Blob | null>(null);
@@ -552,6 +582,31 @@ export function TournamentDetailPage(props: TournamentDetailPageProps): JSX.Elem
   const [submitToast, setSubmitToast] = React.useState<SubmitToast | null>(null);
   const [submitToastOpen, setSubmitToastOpen] = React.useState(false);
   const [needsSendOverrides, setNeedsSendOverrides] = React.useState<Record<number, boolean>>({});
+  const [chartSubmitLocked, setChartSubmitLocked] = React.useState(false);
+  const [footerSubmitLocked, setFooterSubmitLocked] = React.useState(false);
+  const [highlightedChartId, setHighlightedChartId] = React.useState<number | null>(null);
+  const [statusFadeTokens, setStatusFadeTokens] = React.useState<Record<number, number>>({});
+  const [activeReturnSignal, setActiveReturnSignal] = React.useState<TournamentDetailReturnSignal | null>(initialReturnSignal);
+  const [summaryProgressAnimationEnabled, setSummaryProgressAnimationEnabled] = React.useState(() => {
+    if (prefersReducedMotion) {
+      return false;
+    }
+    if (!initialReturnSignal) {
+      return true;
+    }
+    if (initialReturnSignal.returnReason === 'back') {
+      return false;
+    }
+    if (typeof initialReturnSignal.progressChanged === 'boolean') {
+      return initialReturnSignal.progressChanged;
+    }
+    return initialReturnSignal.returnReason !== 'shared' || (initialReturnSignal.changedCount ?? 0) > 0;
+  });
+  const chartSubmitLockTimerRef = React.useRef<number | null>(null);
+  const footerSubmitLockTimerRef = React.useRef<number | null>(null);
+  const chartListItemRefs = React.useRef<Record<number, HTMLLIElement | null>>({});
+  const previousChartStateRef = React.useRef<Record<number, ChartShareState> | null>(null);
+  const previousChartStateCountsRef = React.useRef<ChartStateCounts | null>(null);
 
   const payload = React.useMemo(() => {
     const normalizedPayloadHashtag = normalizeHashtag(props.detail.hashtag) || 'IIDX';
@@ -612,15 +667,21 @@ export function TournamentDetailPage(props: TournamentDetailPageProps): JSX.Elem
     }
     setSubmitToastOpen(false);
   }, []);
-  const chartStateCounts = React.useMemo(() => {
-    let shared = 0;
-    let unshared = 0;
-    let unregistered = 0;
+  const chartShareStateById = React.useMemo(() => {
+    const stateMap: Record<number, ChartShareState> = {};
     props.detail.charts.forEach((chart) => {
       const chartNeedsSend = resolveNeedsSend(chart);
       const localSaved = resolveChartLocalSaved(chart);
       const submitted = resolveChartSubmitted(localSaved, chartNeedsSend);
-      const state = resolveChartShareState(localSaved, submitted);
+      stateMap[chart.chartId] = resolveChartShareState(localSaved, submitted);
+    });
+    return stateMap;
+  }, [props.detail.charts, resolveNeedsSend]);
+  const chartStateCounts = React.useMemo<ChartStateCounts>(() => {
+    let shared = 0;
+    let unshared = 0;
+    let unregistered = 0;
+    Object.values(chartShareStateById).forEach((state) => {
       if (state === 'shared') {
         shared += 1;
         return;
@@ -631,12 +692,8 @@ export function TournamentDetailPage(props: TournamentDetailPageProps): JSX.Elem
       }
       unregistered += 1;
     });
-    return {
-      shared,
-      unshared,
-      unregistered,
-    };
-  }, [props.detail.charts, resolveNeedsSend]);
+    return { shared, unshared, unregistered };
+  }, [chartShareStateById]);
   const localSavedCharts = React.useMemo(
     () => props.detail.charts.filter((chart) => resolveChartLocalSaved(chart)),
     [props.detail.charts],
@@ -678,6 +735,122 @@ export function TournamentDetailPage(props: TournamentDetailPageProps): JSX.Elem
   React.useEffect(() => {
     setNeedsSendOverrides({});
   }, [props.detail]);
+
+  React.useEffect(() => {
+    if (!incomingReturnSignal) {
+      return;
+    }
+    setActiveReturnSignal(incomingReturnSignal);
+    props.onConsumeReturnSignal?.(incomingReturnSignal.token);
+  }, [incomingReturnSignal, props.onConsumeReturnSignal]);
+
+  React.useEffect(() => {
+    if (prefersReducedMotion) {
+      setSummaryProgressAnimationEnabled(false);
+      return;
+    }
+    if (!activeReturnSignal) {
+      return;
+    }
+    if (activeReturnSignal.returnReason === 'back') {
+      setSummaryProgressAnimationEnabled(false);
+      return;
+    }
+    if (typeof activeReturnSignal.progressChanged === 'boolean') {
+      setSummaryProgressAnimationEnabled(activeReturnSignal.progressChanged);
+      return;
+    }
+    if (activeReturnSignal.returnReason === 'shared') {
+      setSummaryProgressAnimationEnabled((activeReturnSignal.changedCount ?? 0) > 0);
+      return;
+    }
+    setSummaryProgressAnimationEnabled(true);
+  }, [activeReturnSignal, prefersReducedMotion]);
+
+  React.useEffect(() => {
+    const previous = previousChartStateCountsRef.current;
+    if (previous && hasChartStateCountChanged(previous, chartStateCounts) && !prefersReducedMotion) {
+      setSummaryProgressAnimationEnabled(true);
+    }
+    previousChartStateCountsRef.current = chartStateCounts;
+  }, [chartStateCounts, prefersReducedMotion]);
+
+  React.useEffect(() => {
+    const previous = previousChartStateRef.current;
+    if (!previous) {
+      previousChartStateRef.current = chartShareStateById;
+      return;
+    }
+
+    const changedChartIds: number[] = [];
+    Object.entries(chartShareStateById).forEach(([chartIdRaw, nextState]) => {
+      const chartId = Number(chartIdRaw);
+      const prevState = previous[chartId];
+      if (prevState && prevState !== nextState) {
+        changedChartIds.push(chartId);
+      }
+    });
+    previousChartStateRef.current = chartShareStateById;
+
+    if (changedChartIds.length === 0 || prefersReducedMotion) {
+      return;
+    }
+    setStatusFadeTokens((current) => {
+      const next = { ...current };
+      changedChartIds.forEach((chartId) => {
+        next[chartId] = (next[chartId] ?? 0) + 1;
+      });
+      return next;
+    });
+  }, [chartShareStateById, prefersReducedMotion]);
+
+  React.useEffect(() => {
+    if (!activeReturnSignal || (activeReturnSignal.returnReason !== 'saved' && activeReturnSignal.returnReason !== 'replaced')) {
+      return;
+    }
+    if (!activeReturnSignal.changedChartId) {
+      return;
+    }
+    const changedChartId = Number.parseInt(activeReturnSignal.changedChartId, 10);
+    if (!Number.isFinite(changedChartId)) {
+      return;
+    }
+    const target = chartListItemRefs.current[changedChartId];
+    if (!target) {
+      return;
+    }
+
+    const rect = target.getBoundingClientRect();
+    const viewportHeight = window.innerHeight || document.documentElement.clientHeight;
+    const isOutsideViewport = rect.bottom < 0 || rect.top > viewportHeight;
+    if (isOutsideViewport) {
+      target.scrollIntoView({
+        block: 'center',
+        behavior: prefersReducedMotion ? 'auto' : 'smooth',
+      });
+    }
+
+    setHighlightedChartId(changedChartId);
+    const timeoutId = window.setTimeout(() => {
+      setHighlightedChartId((current) => (current === changedChartId ? null : current));
+    }, prefersReducedMotion ? 80 : 600);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [activeReturnSignal, prefersReducedMotion]);
+
+  React.useEffect(
+    () => () => {
+      if (chartSubmitLockTimerRef.current !== null) {
+        window.clearTimeout(chartSubmitLockTimerRef.current);
+      }
+      if (footerSubmitLockTimerRef.current !== null) {
+        window.clearTimeout(footerSubmitLockTimerRef.current);
+      }
+    },
+    [],
+  );
 
   React.useEffect(() => {
     if (!shareDialogOpen) {
@@ -842,6 +1015,39 @@ export function TournamentDetailPage(props: TournamentDetailPageProps): JSX.Elem
     setPreviewZoomOpen(false);
   }, []);
 
+  const openSubmitPageWithLock = React.useCallback(
+    (chartId: number) => {
+      if (chartSubmitLocked) {
+        return;
+      }
+      setChartSubmitLocked(true);
+      if (chartSubmitLockTimerRef.current !== null) {
+        window.clearTimeout(chartSubmitLockTimerRef.current);
+      }
+      chartSubmitLockTimerRef.current = window.setTimeout(() => {
+        setChartSubmitLocked(false);
+        chartSubmitLockTimerRef.current = null;
+      }, 200);
+      props.onOpenSubmit(chartId);
+    },
+    [chartSubmitLocked, props],
+  );
+
+  const openSubmitDialogWithLock = React.useCallback(() => {
+    if (!canOpenSubmitDialog || footerSubmitLocked) {
+      return;
+    }
+    setFooterSubmitLocked(true);
+    if (footerSubmitLockTimerRef.current !== null) {
+      window.clearTimeout(footerSubmitLockTimerRef.current);
+    }
+    footerSubmitLockTimerRef.current = window.setTimeout(() => {
+      setFooterSubmitLocked(false);
+      footerSubmitLockTimerRef.current = null;
+    }, 200);
+    setSubmitDialogOpen(true);
+  }, [canOpenSubmitDialog, footerSubmitLocked]);
+
   const collectSubmissionFiles = React.useCallback(async (targetCharts: TournamentDetailChart[]): Promise<File[]> => {
     const files: File[] = [];
     for (const chart of targetCharts) {
@@ -884,7 +1090,7 @@ export function TournamentDetailPage(props: TournamentDetailPageProps): JSX.Elem
   }, []);
 
   const markChartsAsShared = React.useCallback(
-    async (chartIds: number[], options?: { allowUndo?: boolean }) => {
+    async (chartIds: number[], options?: { allowUndo?: boolean; changedCount?: number }) => {
       await appDb.markEvidenceSendCompleted(props.detail.tournamentUuid, chartIds);
       setNeedsSendOverrides((current) => {
         const next = { ...current };
@@ -898,6 +1104,14 @@ export function TournamentDetailPage(props: TournamentDetailPageProps): JSX.Elem
         severity: 'success',
         text: t('tournament_detail.submit_dialog.notice.marked_shared'),
         ...(options?.allowUndo === false ? {} : { undoChartIds: [...chartIds] }),
+      });
+      const changedCount = Math.max(0, options?.changedCount ?? chartIds.length);
+      setActiveReturnSignal({
+        token: crypto.randomUUID(),
+        tournamentUuid: props.detail.tournamentUuid,
+        returnReason: 'shared',
+        changedCount,
+        progressChanged: changedCount > 0,
       });
       props.onReportDebugError(null);
     },
@@ -944,6 +1158,7 @@ export function TournamentDetailPage(props: TournamentDetailPageProps): JSX.Elem
     setSubmitBusy(true);
     const targetCharts = [...submitTargetCharts];
     const targetChartIds = targetCharts.map((chart) => chart.chartId);
+    const changedCount = targetCharts.reduce((count, chart) => (resolveNeedsSend(chart) ? count + 1 : count), 0);
     const allowUndo = submitMode === 'submit';
     try {
       const files = await collectSubmissionFiles(targetCharts);
@@ -957,7 +1172,7 @@ export function TournamentDetailPage(props: TournamentDetailPageProps): JSX.Elem
             text: submitMessageText,
             files,
           });
-          await markChartsAsShared(targetChartIds, { allowUndo });
+          await markChartsAsShared(targetChartIds, { allowUndo, changedCount });
           return;
         } catch (error: unknown) {
           if (error instanceof DOMException && error.name === 'AbortError') {
@@ -975,7 +1190,7 @@ export function TournamentDetailPage(props: TournamentDetailPageProps): JSX.Elem
         props.onReportDebugError(message);
         return;
       }
-      await markChartsAsShared(targetChartIds, { allowUndo });
+      await markChartsAsShared(targetChartIds, { allowUndo, changedCount });
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : t('tournament_detail.submit_dialog.notice.share_images_failed');
       showSubmitToast({ severity: 'error', text: message });
@@ -995,6 +1210,7 @@ export function TournamentDetailPage(props: TournamentDetailPageProps): JSX.Elem
     submitTargetChartIds,
     submitTargetCharts,
     submitMessageText,
+    resolveNeedsSend,
     t,
   ]);
 
@@ -1010,6 +1226,8 @@ export function TournamentDetailPage(props: TournamentDetailPageProps): JSX.Elem
         sharedCount={chartStateCounts.shared}
         unsharedCount={chartStateCounts.unshared}
         unregisteredCount={chartStateCounts.unregistered}
+        prefersReducedMotion={prefersReducedMotion}
+        animateProgress={summaryProgressAnimationEnabled}
         shareAction={
           !props.detail.isImported ? (
             <div className="detailShareArea">
@@ -1046,14 +1264,30 @@ export function TournamentDetailPage(props: TournamentDetailPageProps): JSX.Elem
             const submitted = resolveChartSubmitted(localSaved, chartNeedsSend);
             const chartShareState = resolveChartShareState(localSaved, submitted);
             const chartHasIssue = Boolean(chartStatus.errorText);
+            const isReturnHighlighted = highlightedChartId === chart.chartId;
             return (
-              <li key={chart.chartId}>
+              <li
+                key={chart.chartId}
+                data-chart-id={String(chart.chartId)}
+                className={isReturnHighlighted ? 'detailChartListRow detailChartListRow-highlighted' : 'detailChartListRow'}
+                style={
+                  isReturnHighlighted
+                    ? ({
+                        '--detail-return-highlight': theme.palette.action.selected,
+                      } as React.CSSProperties)
+                    : undefined
+                }
+                ref={(node) => {
+                  chartListItemRefs.current[chart.chartId] = node;
+                }}
+              >
                 <ChartCard
                   title={chart.title}
                   playStyle={chart.playStyle}
                   difficulty={chart.difficulty}
                   level={levelText}
                   status={chartShareState}
+                  statusAnimationToken={statusFadeTokens[chart.chartId]}
                   statusTestId="tournament-detail-chart-status-label"
                   metaTestId="tournament-detail-chart-meta-line"
                   note={chartStatus.errorText}
@@ -1067,7 +1301,8 @@ export function TournamentDetailPage(props: TournamentDetailPageProps): JSX.Elem
                         className={`chartSubmitButton chartSubmitButton-${chartStatus.actionTone}`}
                         data-testid="tournament-detail-chart-submit-button"
                         data-chart-action-tone={chartStatus.actionTone}
-                        onClick={() => props.onOpenSubmit(chart.chartId)}
+                        onClick={() => openSubmitPageWithLock(chart.chartId)}
+                        disabled={chartSubmitLocked}
                       >
                         {chartStatus.actionLabel}
                       </button>
@@ -1308,13 +1543,8 @@ export function TournamentDetailPage(props: TournamentDetailPageProps): JSX.Elem
               type="button"
               className={`detailSubmitPrimaryButton ${submitMode === 'submit' && canOpenSubmitDialog ? 'emphasis' : ''}`}
               data-testid="tournament-detail-submit-open-button"
-              onClick={() => {
-                if (!canOpenSubmitDialog) {
-                  return;
-                }
-                setSubmitDialogOpen(true);
-              }}
-              disabled={!canOpenSubmitDialog}
+              onClick={openSubmitDialogWithLock}
+              disabled={!canOpenSubmitDialog || footerSubmitLocked}
             >
               {submitButtonLabel}
             </button>

--- a/packages/web-app/src/styles.css
+++ b/packages/web-app/src/styles.css
@@ -1697,6 +1697,37 @@ label {
   gap: 8px;
 }
 
+.detailChartListRow {
+  position: relative;
+}
+
+.detailChartListRow::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: 12px;
+  background: var(--detail-return-highlight, rgba(25, 118, 210, 0.18));
+  opacity: 0;
+  pointer-events: none;
+  z-index: 2;
+}
+
+.detailChartListRow-highlighted::after {
+  animation: detailCardReturnHighlight 600ms ease-out;
+}
+
+@keyframes detailCardReturnHighlight {
+  0% {
+    opacity: 0;
+  }
+  16.666% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
 .chartListItem {
   width: 100%;
   display: grid;
@@ -1837,6 +1868,23 @@ label {
   background: var(--status-shared-bg);
 }
 
+.chartStateBadge-detail {
+  min-width: 86px;
+}
+
+.chartStateBadge-fade {
+  animation: chartStateBadgeFadeIn 200ms ease-out;
+}
+
+@keyframes chartStateBadgeFadeIn {
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
 .chartStatusLine {
   display: inline-flex;
   align-items: center;
@@ -1904,6 +1952,12 @@ label {
   border-radius: 10px;
   padding: 7px 12px;
   font-weight: 700;
+  transform: scale(1);
+  transition: transform 120ms ease-out;
+}
+
+.chartSubmitButton:active:not(:disabled) {
+  transform: scale(0.98);
 }
 
 .chartSubmitButton-primary {
@@ -1970,6 +2024,12 @@ label {
   color: var(--text-muted);
   font-weight: 700;
   padding: 10px 16px;
+  transform: scale(1);
+  transition: transform 120ms ease-out;
+}
+
+.detailSubmitPrimaryButton:active:not(:disabled) {
+  transform: scale(0.98);
 }
 
 .detailSubmitPrimaryButton.emphasis {
@@ -2315,7 +2375,11 @@ label {
   .tournamentProgressValue,
   .cardArrow,
   .homeFilterResultCountValue-animated,
-  .homeFabPlusIcon {
+  .homeFabPlusIcon,
+  .chartSubmitButton,
+  .detailSubmitPrimaryButton,
+  .chartStateBadge-fade,
+  .detailChartListRow-highlighted::after {
     animation-duration: 1ms !important;
     animation-iteration-count: 1 !important;
     transition-duration: 1ms !important;
@@ -2328,6 +2392,11 @@ label {
   }
 
   .tournamentCard:active {
+    transform: scale(1);
+  }
+
+  .chartSubmitButton:active:not(:disabled),
+  .detailSubmitPrimaryButton:active:not(:disabled) {
     transform: scale(1);
   }
 }

--- a/tasks/feat-detail-microinteractions.md
+++ b/tasks/feat-detail-microinteractions.md
@@ -1,0 +1,88 @@
+# Plan: feat/detail-microinteractions
+
+## 作業宣言
+
+- worktree path: `C:\work\score_attack_manager\iidx_score_attack_manager-home-microinteractions`
+- BASE_SHA: `9609338e44cef485dd3f185ae991803805bf5b12`
+
+## 目的
+
+- スコアタ詳細画面で「登録する/差し替え」「提出する」押下時の手応えを最小演出で追加する。
+- 提出画面から詳細へ戻った際に、変更対象と変更有無を短時間で認知できるようにする。
+- 演出は 200ms 基調・`ease-out`・reduced-motion 対応で統一し、過剰なモーションを避ける。
+
+## 非目的
+
+- DB スキーマ、永続化形式、import/export、Service Worker、Web Locks の変更。
+- 共有フローのロジック全面変更や新規依存導入。
+- 詳細画面以外の大規模 UI リデザイン。
+
+## 変更点
+
+- ルート戻りシグナルを追加し、詳細復帰時の理由を判定できるようにする。
+  - `returnReason: 'back' | 'saved' | 'replaced' | 'shared'`
+  - `changedChartId` / `changedCount` を必要時に付与
+- 譜面カードの「登録する/差し替え」ボタンに press scale と 200ms 連打抑止を追加。
+- 下部固定「提出する」ボタンに press scale と 200ms 連打抑止を追加。
+- `saved/replaced` 復帰時のみ、該当カード 1 件に 600ms の背景ハイライトを追加。
+- 状態ラベルの内容変化時のみ 200ms フェードで置換し、ラベル領域の幅ブレを抑制。
+- 上部進捗バーは「初回表示」または「変化あり時」のみ 200ms で遷移し、変化なし復帰ではアニメしない。
+- 提出確認ダイアログは MUI 標準遷移のみ維持（内部追加アニメ無し）。
+
+## 影響範囲（ユーザー / データ / 互換性）
+
+- ユーザー:
+  - 押下フィードバックが明確になり、復帰時の差分把握が容易になる。
+- データ:
+  - 変更なし（UI 状態・ルーティング状態のみ）。
+- 互換性:
+  - API / payload / DB schema 変更なし。
+  - reduced-motion 環境ではアニメ無効化または短縮。
+
+## 実装方針（対象ファイル単位）
+
+- `packages/web-app/src/App.tsx`
+  - submit/detail 間の戻りシグナル状態を追加。
+  - submit 遷移時に進捗スナップショットを保持し、戻り時に変化有無を判定。
+  - submit 画面からの戻り（back/saved/replaced）でシグナルを設定。
+- `packages/web-app/src/pages/SubmitEvidencePage.tsx`
+  - 保存完了コールバックで `saved/replaced` を返せるように変更。
+- `packages/web-app/src/pages/TournamentDetailPage.tsx`
+  - 戻りシグナル受信・消費処理を実装。
+  - 譜面ボタン/下部提出ボタンの press + 連打抑止を実装。
+  - カードハイライト・条件付き `scrollIntoView` を実装。
+  - 状態ラベル置換フェード制御を実装。
+  - 進捗アニメの発火条件を制御し、`shared` の同画面更新シグナルも扱う。
+- `packages/web-app/src/components/TournamentSummaryCard.tsx`
+  - 進捗バーアニメの有効/無効を外部指定できる最小拡張を追加（200ms 基準）。
+- `packages/web-app/src/components/ChartCard.tsx`
+  - 状態ラベル置換フェード用の最小 props/class 拡張を追加。
+- `packages/web-app/src/styles.css`
+  - 詳細画面向け press scale / highlight / fade のスタイルを追加。
+  - reduced-motion 向けに対象アニメの無効化または短縮を追加。
+- `packages/web-app/src/pages/TournamentDetailPage.test.tsx`
+  - 連打抑止・戻りシグナル・ラベル差分演出の回帰確認を追加/更新。
+
+### 変更スコープ固定
+
+- 上記 7 ファイル + 本 `tasks/feat-detail-microinteractions.md` のみ変更する。
+
+## テスト観点
+
+- 「登録する/差し替え」押下時にボタンが短時間 disabled になり二重押下を抑止できる。
+- 提出画面保存完了で戻ると、理由（saved/replaced）に応じて対象カードのみハイライトされる。
+- `returnReason='back'` の戻りでは不要演出が発火しない。
+- 状態ラベル変化時のみフェードし、レイアウトが崩れない。
+- 上部進捗バーが初回表示・変化あり時のみアニメし、変化なしでは静止表示になる。
+- 提出確認ダイアログに追加アニメがない（既存 MUI 標準遷移のみ）。
+
+## ロールバック方針
+
+- ルーティングシグナル追加と UI 演出追加を分離し、問題箇所をコミット単位で `git revert` できるようにする。
+- 演出が問題の場合はスタイル/props 拡張コミットのみを切り戻し、既存フローを保持する。
+
+## Commit Plan（コミット分割計画）
+
+1. `App.tsx` / `SubmitEvidencePage.tsx` の戻りシグナル実装（back/saved/replaced 判定）。
+2. `TournamentDetailPage.tsx` / `ChartCard.tsx` / `TournamentSummaryCard.tsx` の演出制御実装。
+3. `styles.css` と `TournamentDetailPage.test.tsx` の調整、検証コマンド実行。


### PR DESCRIPTION
## 目的
- スコアタ詳細画面で押下フィードバックを追加し、操作の手応えを明確化する。
- 提出画面から戻った際の差分認知（saved/replaced/shared/back）を最小演出で提供する。
- 演出を 200ms 基調・`ease-out`・reduced-motion 対応で統一する。

## 変更点
- submit/detail 間に戻りシグナルを追加。
  - `returnReason: back | saved | replaced | shared`
  - `changedChartId`, `changedCount`, 進捗差分判定を付与
- 提出画面保存完了コールバックを `saved/replaced` へ変更。
- 詳細画面に以下を実装。
  - 「登録する/差し替え」押下: `scale(0.98)` + 200ms 連打抑止
  - 下部「提出する」押下: `scale(0.98)` + 200ms 連打抑止
  - `saved/replaced` 復帰時: 対象カード 1 件の 600ms 背景ハイライト
  - 状態ラベル変更時のみ 200ms フェード
  - 上部進捗バー: 初回表示/変化あり時のみ 200ms アニメ
- `ChartCard` / `TournamentSummaryCard` / `styles.css` を最小拡張して演出制御を追加。
- `tasks/feat-detail-microinteractions.md` を追加。
- `TournamentDetailPage.test.tsx` に連打抑止・戻りハイライト回帰テストを追加。

## 非変更点
- DB schema / 永続化形式 / payload 仕様
- Service Worker / Web Locks / import-export 経路
- 依存関係（lockfile含む）

## 影響範囲
- ユーザー: 詳細画面の操作フィードバックと戻り時差分認知が向上。
- データ: 変更なし（UI状態/ルーティング状態のみ）。
- 互換性: API/DB 互換性への影響なし。

## テスト内容
- `pnpm --filter @iidx/web-app lint`
- `pnpm --filter @iidx/web-app test -- --run src/pages/TournamentDetailPage.test.tsx`

## 回帰確認項目
- 提出確認ダイアログは MUI 標準遷移のみ（追加内部アニメなし）。
- `returnReason=back` で不要演出が発火しない。
- `saved/replaced` で対象カードのみハイライトされる。
- 進捗バーが「初回 or 変化あり」でのみ遷移する。