### PR TITLE
feat(web-app): extend single-tab aggregation to normal startup flow

### DIFF
--- a/packages/web-app/src/App.tsx
+++ b/packages/web-app/src/App.tsx
@@ -68,7 +68,9 @@ import {
   IMPORT_DELEGATION_STORAGE_REQUEST_KEY,
   buildImportAckMessage,
   isImportRequestMessage,
+  isTabFocusRequestMessage,
   parseImportRequestStorageValue,
+  parseTabFocusRequestStorageValue,
 } from './utils/import-delegation';
 import {
   CREATE_TOURNAMENT_PATH,
@@ -2163,7 +2165,7 @@ export function App({ webLockAcquired = false }: AppProps = {}): JSX.Element {
       }
     };
 
-    const processRequest = (requestId: string, rawPayloadParam: string, via: 'broadcast' | 'storage'): void => {
+    const processImportRequest = (requestId: string, rawPayloadParam: string, via: 'broadcast' | 'storage'): void => {
       if (handledRequestIds.has(requestId)) {
         return;
       }
@@ -2171,15 +2173,44 @@ export function App({ webLockAcquired = false }: AppProps = {}): JSX.Element {
       void processDelegatedImport(requestId, rawPayloadParam, via);
     };
 
+    const processFocusRequest = (requestId: string): void => {
+      if (handledRequestIds.has(requestId)) {
+        return;
+      }
+      handledRequestIds.add(requestId);
+      try {
+        window.focus();
+      } catch {
+        // ignore focus failures
+      }
+    };
+
     const channel = typeof BroadcastChannel === 'function' ? new BroadcastChannel(IMPORT_DELEGATION_CHANNEL) : null;
     const onChannelMessage = (event: MessageEvent<unknown>) => {
-      if (!isImportRequestMessage(event.data)) {
-        return;
-      }
-      if (event.data.senderTabId === tabId) {
-        return;
-      }
+      if (isImportRequestMessage(event.data)) {
+        if (event.data.senderTabId === tabId) {
+          return;
+        }
 
+        const requestId = event.data.requestId;
+        try {
+          channel?.postMessage(
+            buildImportAckMessage({
+              requestId,
+              receiverTabId: tabId,
+              via: 'broadcast',
+            }),
+          );
+        } catch {
+          // ignore broadcast failures
+        }
+
+        processImportRequest(requestId, event.data.rawPayloadParam, 'broadcast');
+        return;
+      }
+      if (!isTabFocusRequestMessage(event.data) || event.data.senderTabId === tabId) {
+        return;
+      }
       const requestId = event.data.requestId;
       try {
         channel?.postMessage(
@@ -2192,8 +2223,7 @@ export function App({ webLockAcquired = false }: AppProps = {}): JSX.Element {
       } catch {
         // ignore broadcast failures
       }
-
-      processRequest(requestId, event.data.rawPayloadParam, 'broadcast');
+      processFocusRequest(requestId);
     };
 
     channel?.addEventListener('message', onChannelMessage);
@@ -2206,13 +2236,18 @@ export function App({ webLockAcquired = false }: AppProps = {}): JSX.Element {
       ) {
         return;
       }
-      const request = parseImportRequestStorageValue(event.newValue);
-      if (!request || request.senderTabId === tabId) {
+      const importRequest = parseImportRequestStorageValue(event.newValue);
+      if (importRequest && importRequest.senderTabId !== tabId) {
+        sendStorageAck(importRequest.requestId);
+        processImportRequest(importRequest.requestId, importRequest.rawPayloadParam, 'storage');
         return;
       }
-
-      sendStorageAck(request.requestId);
-      processRequest(request.requestId, request.rawPayloadParam, 'storage');
+      const focusRequest = parseTabFocusRequestStorageValue(event.newValue);
+      if (!focusRequest || focusRequest.senderTabId === tabId) {
+        return;
+      }
+      sendStorageAck(focusRequest.requestId);
+      processFocusRequest(focusRequest.requestId);
     };
 
     window.addEventListener('storage', onStorage);

--- a/packages/web-app/src/main.tsx
+++ b/packages/web-app/src/main.tsx
@@ -18,6 +18,7 @@ import {
   IMPORT_DELEGATION_STORAGE_ACK_TIMEOUT_MS,
   IMPORT_DELEGATION_STORAGE_REQUEST_KEY,
   buildImportRequestMessage,
+  buildTabFocusRequestMessage,
   isImportAckMessage,
   parseImportAckStorageValue,
 } from './utils/import-delegation';
@@ -56,6 +57,10 @@ interface ImportDelegationScreenProps {
   payloadPreview: TournamentPayload;
 }
 
+interface ExistingTabAggregationScreenProps {
+  onPromoteCurrentTab: () => Promise<boolean>;
+}
+
 interface InvalidImportLinkScreenProps {
   code: string;
   message: string;
@@ -91,7 +96,7 @@ function tryCloseTab(): void {
 }
 
 async function sendImportRequestViaBroadcast(
-  requestMessage: ReturnType<typeof buildImportRequestMessage>,
+  requestMessage: ReturnType<typeof buildImportRequestMessage> | ReturnType<typeof buildTabFocusRequestMessage>,
 ): Promise<boolean> {
   if (typeof BroadcastChannel !== 'function') {
     return false;
@@ -134,7 +139,7 @@ async function sendImportRequestViaBroadcast(
 }
 
 async function sendImportRequestViaStorage(
-  requestMessage: ReturnType<typeof buildImportRequestMessage>,
+  requestMessage: ReturnType<typeof buildImportRequestMessage> | ReturnType<typeof buildTabFocusRequestMessage>,
 ): Promise<boolean> {
   return await new Promise<boolean>((resolve) => {
     let settled = false;
@@ -186,6 +191,31 @@ async function delegateImportToExistingTab(rawPayloadParam: string, senderTabId:
     requestId: crypto.randomUUID(),
     senderTabId,
     rawPayloadParam,
+  });
+
+  const broadcastAcked = await sendImportRequestViaBroadcast(requestMessage);
+  if (broadcastAcked) {
+    return {
+      status: 'ack',
+      via: 'broadcast',
+    };
+  }
+
+  const storageAcked = await sendImportRequestViaStorage(requestMessage);
+  if (storageAcked) {
+    return {
+      status: 'ack',
+      via: 'storage',
+    };
+  }
+
+  return { status: 'not_acknowledged' };
+}
+
+async function delegateTabFocusToExistingTab(senderTabId: string): Promise<ImportDelegationResult> {
+  const requestMessage = buildTabFocusRequestMessage({
+    requestId: crypto.randomUUID(),
+    senderTabId,
   });
 
   const broadcastAcked = await sendImportRequestViaBroadcast(requestMessage);
@@ -540,6 +570,101 @@ function ImportDelegationScreen(props: ImportDelegationScreenProps): JSX.Element
   );
 }
 
+function ExistingTabAggregationScreen(props: ExistingTabAggregationScreenProps): JSX.Element {
+  const { t } = useTranslation();
+  const senderTabIdRef = React.useRef<string>(crypto.randomUUID());
+  const [state, setState] = React.useState<ImportDelegationState>('sending');
+  const [attemptCount, setAttemptCount] = React.useState(0);
+  const [statusHint, setStatusHint] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    let cancelled = false;
+    setState('sending');
+    setStatusHint(null);
+
+    void delegateTabFocusToExistingTab(senderTabIdRef.current).then(async (result) => {
+      if (cancelled) {
+        return;
+      }
+      if (result.status === 'ack') {
+        setState('success');
+        setStatusHint(
+          result.via === 'broadcast'
+            ? t('common.import_delegation.status.ack_broadcast')
+            : t('common.import_delegation.status.ack_storage'),
+        );
+        window.setTimeout(() => {
+          tryCloseTab();
+        }, 60);
+        return;
+      }
+
+      const promoted = await props.onPromoteCurrentTab();
+      if (cancelled || promoted) {
+        return;
+      }
+      setState('failed');
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [attemptCount, props.onPromoteCurrentTab, t]);
+
+  if (state === 'sending') {
+    return (
+      <main className="page startupShell">
+        <section className="unsupported startupCard">
+          <h1>{t('common.import_delegation.sending.title')}</h1>
+          <p>{t('common.import_delegation.sending.description')}</p>
+          <div className="startupLoading" role="status" aria-live="polite" aria-label={t('common.import_delegation.sending.aria_label')}>
+            <span className="startupLoadingSpinner" aria-hidden="true" />
+          </div>
+        </section>
+      </main>
+    );
+  }
+
+  if (state === 'success') {
+    return (
+      <main className="page startupShell">
+        <section className="unsupported startupCard">
+          <h1>{t('common.import_delegation.success.title')}</h1>
+          <p>{t('common.import_delegation.success.description')}</p>
+          {statusHint ? <p className="hintText">{statusHint}</p> : null}
+          <div className="actions startupActionRow">
+            <button type="button" className="primaryActionButton" onClick={tryCloseTab}>
+              {t('common.close_this_tab')}
+            </button>
+          </div>
+        </section>
+      </main>
+    );
+  }
+
+  return (
+    <main className="page startupShell">
+      <section className="warningBox startupCard">
+        <h1>{t('common.bootstrap.already_running_in_other_tab')}</h1>
+        <p>{t('common.import_delegation.failed.description')}</p>
+        <div className="actions startupActionRow">
+          <button type="button" className="primaryActionButton" onClick={navigateToHome}>
+            {t('common.open_app')}
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              setAttemptCount((current) => current + 1);
+            }}
+          >
+            {t('common.import_delegation.retry')}
+          </button>
+        </div>
+      </section>
+    </main>
+  );
+}
+
 async function waitForLocalConsent(root: ReturnType<typeof ReactDOM.createRoot>): Promise<void> {
   if (readLocalStorage(TUTORIAL_DONE_KEY) === '1') {
     return;
@@ -651,7 +776,53 @@ async function bootstrap(): Promise<void> {
       );
       return;
     }
-    renderWithMuiTheme(root, <AppFallbackUnsupported reasons={[i18n.t('common.bootstrap.already_running_in_other_tab')]} />);
+    renderWithMuiTheme(
+      root,
+      <ExistingTabAggregationScreen
+        onPromoteCurrentTab={async () => {
+          try {
+            releaseLock = await acquireSingleTabLock('iidx-score-attack-web-lock');
+          } catch {
+            return false;
+          }
+
+          try {
+            const services = await Promise.race([
+              createAppServices(),
+              new Promise<never>((_, reject) => {
+                window.setTimeout(() => reject(new Error(i18n.t('common.bootstrap.initialization_timeout'))), 20000);
+              }),
+            ]);
+            const persistedLanguage = await services.appDb.getSetting(APP_LANGUAGE_SETTING_KEY).catch(() => null);
+            await ensureI18n(normalizeLanguage(persistedLanguage));
+
+            window.addEventListener('beforeunload', () => {
+              if (releaseLock) {
+                releaseLock();
+                releaseLock = null;
+              }
+              void services.appDb.dispose();
+            });
+
+            renderWithMuiTheme(
+              root,
+              <AppServicesProvider services={services}>
+                <App webLockAcquired />
+              </AppServicesProvider>,
+            );
+            return true;
+          } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            const reason = message.includes('no such vfs: opfs')
+              ? i18n.t('common.bootstrap.opfs_vfs_init_failed')
+              : i18n.t('common.bootstrap.initialization_error', { message });
+
+            renderWithMuiTheme(root, <AppFallbackUnsupported reasons={[reason]} />);
+            return true;
+          }
+        }}
+      />,
+    );
     return;
   }
 

--- a/packages/web-app/src/utils/import-delegation.test.ts
+++ b/packages/web-app/src/utils/import-delegation.test.ts
@@ -3,10 +3,13 @@ import { describe, expect, it } from 'vitest';
 import {
   buildImportAckMessage,
   buildImportRequestMessage,
+  buildTabFocusRequestMessage,
   isImportAckMessage,
   isImportRequestMessage,
+  isTabFocusRequestMessage,
   parseImportAckStorageValue,
   parseImportRequestStorageValue,
+  parseTabFocusRequestStorageValue,
 } from './import-delegation';
 
 describe('import delegation utility', () => {
@@ -28,6 +31,14 @@ describe('import delegation utility', () => {
     expect(isImportAckMessage(ack)).toBe(true);
   });
 
+  it('builds and validates tab focus request messages', () => {
+    const request = buildTabFocusRequestMessage({
+      requestId: 'request-focus-1',
+      senderTabId: 'tab-c',
+    });
+    expect(isTabFocusRequestMessage(request)).toBe(true);
+  });
+
   it('parses storage values safely', () => {
     const request = buildImportRequestMessage({
       requestId: 'request-2',
@@ -39,13 +50,19 @@ describe('import delegation utility', () => {
       receiverTabId: 'tab-b',
       via: 'storage',
     });
+    const focusRequest = buildTabFocusRequestMessage({
+      requestId: 'request-focus-2',
+      senderTabId: 'tab-c',
+    });
     expect(parseImportRequestStorageValue(JSON.stringify(request))?.requestId).toBe('request-2');
     expect(parseImportAckStorageValue(JSON.stringify(ack))?.requestId).toBe('request-2');
+    expect(parseTabFocusRequestStorageValue(JSON.stringify(focusRequest))?.requestId).toBe('request-focus-2');
   });
 
   it('returns null for malformed storage payloads', () => {
     expect(parseImportRequestStorageValue('{')).toBeNull();
     expect(parseImportAckStorageValue('{"type":"x"}')).toBeNull();
+    expect(parseTabFocusRequestStorageValue('{"type":"x"}')).toBeNull();
     expect(parseImportRequestStorageValue(null)).toBeNull();
   });
 });

--- a/packages/web-app/src/utils/import-delegation.ts
+++ b/packages/web-app/src/utils/import-delegation.ts
@@ -12,6 +12,15 @@ export interface ImportRequestMessage {
   sentAt: number;
 }
 
+export interface TabFocusRequestMessage {
+  type: 'TAB_FOCUS_REQUEST';
+  requestId: string;
+  senderTabId: string;
+  sentAt: number;
+}
+
+export type DelegationRequestMessage = ImportRequestMessage | TabFocusRequestMessage;
+
 export interface ImportAckMessage {
   type: 'IMPORT_ACK';
   requestId: string;
@@ -34,6 +43,15 @@ export function buildImportRequestMessage(args: {
     requestId: args.requestId,
     senderTabId: args.senderTabId,
     rawPayloadParam: args.rawPayloadParam,
+    sentAt: Date.now(),
+  };
+}
+
+export function buildTabFocusRequestMessage(args: { requestId: string; senderTabId: string }): TabFocusRequestMessage {
+  return {
+    type: 'TAB_FOCUS_REQUEST',
+    requestId: args.requestId,
+    senderTabId: args.senderTabId,
     sentAt: Date.now(),
   };
 }
@@ -68,6 +86,20 @@ export function isImportRequestMessage(value: unknown): value is ImportRequestMe
   );
 }
 
+export function isTabFocusRequestMessage(value: unknown): value is TabFocusRequestMessage {
+  if (!isObjectRecord(value)) {
+    return false;
+  }
+  return (
+    value.type === 'TAB_FOCUS_REQUEST' &&
+    typeof value.requestId === 'string' &&
+    value.requestId.length > 0 &&
+    typeof value.senderTabId === 'string' &&
+    value.senderTabId.length > 0 &&
+    typeof value.sentAt === 'number'
+  );
+}
+
 export function isImportAckMessage(value: unknown): value is ImportAckMessage {
   if (!isObjectRecord(value)) {
     return false;
@@ -90,6 +122,18 @@ export function parseImportRequestStorageValue(value: string | null): ImportRequ
   try {
     const parsed = JSON.parse(value) as unknown;
     return isImportRequestMessage(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+export function parseTabFocusRequestStorageValue(value: string | null): TabFocusRequestMessage | null {
+  if (typeof value !== 'string' || value.length === 0) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return isTabFocusRequestMessage(parsed) ? parsed : null;
   } catch {
     return null;
   }

--- a/tasks/codex-feat-single-tab-aggregation.md
+++ b/tasks/codex-feat-single-tab-aggregation.md
@@ -1,0 +1,83 @@
+# Plan: codex/feat-single-tab-aggregation
+
+## 実行コンテキスト
+
+- worktree: `C:/work/score_attack_manager/iidx_score_attack_manager-codex-single-tab-aggregation`
+- branch: `codex/feat-single-tab-aggregation`
+- BASE_SHA: `20943369062657cd332f384424f64a4d12cfe242`
+
+## 目的
+
+- 取込確認画面の既存委譲仕様を維持したまま、通常導線にも単一タブ集約を拡張する。
+- 既存主タブが生存している場合は通常導線を既存主タブへ集約し、タブ乱立を抑制する。
+- 既存主タブが応答不能な場合は現在タブを正規タブとして起動継続できるようにする。
+
+## 非目的
+
+- Web Locks 以外の単一タブ制御方式追加。
+- 通常導線での payload 受け渡しや、既存主タブの画面遷移要求追加。
+- import payload 形式、DB schema、PWA戦略、依存関係の変更。
+
+## 変更点
+
+- `packages/web-app/src/utils/import-delegation.ts`
+  - 既存 import 委譲メッセージ規約に合わせて、通常導線の「生存確認 + フォーカス誘導」用の最小メッセージ型を追加する。
+  - 既存 timeout 定数はそのまま流用し、新規 timeout 定数は追加しない。
+- `packages/web-app/src/main.tsx`
+  - 既存の import 委譲送信処理を再利用しつつ、通常導線向けの集約送信処理を追加する。
+  - ロック取得失敗時:
+    - import-confirm 到達時は従来どおり URL 委譲画面を表示。
+    - 通常導線はフォーカス誘導のみを行う集約画面へ遷移。
+    - 応答なし時は現在タブを正規タブとして再試行起動する。
+- `packages/web-app/src/App.tsx`
+  - 既存主タブ（`webLockAcquired === true`）で、通常導線向け通知を受信して ACK 返却 + `window.focus()` 誘導を行う。
+  - 通常導線受信でアプリ状態変更・画面遷移を行わないことを保証する。
+- `packages/web-app/src/utils/import-delegation.test.ts`
+  - 通常導線メッセージ型・storage パースのテストを追加する。
+
+## 影響範囲（ユーザー / データ / 互換性 / 起動）
+
+- ユーザー:
+  - 通常導線で二重起動した場合、既存主タブへの集約案内画面が表示される。
+  - import-confirm 画面の既存 UX は維持される。
+- データ:
+  - DB・payload 互換性への影響なし。
+- 起動:
+  - `main.tsx` のロック失敗時分岐を拡張するため、起動導線に影響あり（高リスク扱い）。
+- 互換性:
+  - `BroadcastChannel` 非対応時は既存 storage フォールバックを維持。
+
+## 対象ファイル / 対象パッケージ
+
+- 対象パッケージ: `packages/web-app`
+- 対象ファイル:
+  - `packages/web-app/src/utils/import-delegation.ts`
+  - `packages/web-app/src/utils/import-delegation.test.ts`
+  - `packages/web-app/src/main.tsx`
+  - `packages/web-app/src/App.tsx`
+
+## テスト観点
+
+- Web Locks 排他:
+  - 既存タブありでロック失敗時、通常導線は委譲画面へ進む。
+- 通常導線集約:
+  - ACK 受信時に成功扱いとなり、現在タブは閉じる導線を提示する。
+  - 受信側は状態変更・画面遷移せず、フォーカス誘導のみ行う。
+- 失敗時昇格:
+  - ACK 未受信時は現在タブを正規タブとして起動可能である。
+- import-confirm 回帰:
+  - 既存 import URL 委譲（broadcast/storage）が継続動作する。
+- utility:
+  - 追加メッセージ型のバリデーション/パースが通る。
+
+## ロールバック方針
+
+- 本タスクのコミットを順に `git revert` し、起動導線を従来状態へ戻す。
+- 追加メッセージ型は revert で同時に除去され、データ互換性影響は残らない。
+
+## コミット分割計画
+
+1. plan: `tasks/codex-feat-single-tab-aggregation.md` を追加。
+2. delegation-util: 通常導線用メッセージ型とテストを追加。
+3. runtime-flow: `main.tsx` / `App.tsx` を最小差分で更新。
+4. verify: 必要最小の検証実施と差分確認。


### PR DESCRIPTION
## 目的
- 取込確認画面の既存URL委譲仕様を維持したまま、通常導線でも既存タブへの単一タブ集約を行う。
- 既存主タブが応答不能な場合は、現在タブを正規タブとして起動継続できるようにする。

## 変更点
- `packages/web-app/src/utils/import-delegation.ts`
  - 通常導線向けの最小通知メッセージ `TAB_FOCUS_REQUEST` を追加。
  - 既存の `IMPORT_ACK` / timeout / storage key をそのまま流用。
- `packages/web-app/src/utils/import-delegation.test.ts`
  - `TAB_FOCUS_REQUEST` の build/validate/parse テストを追加。
- `packages/web-app/src/App.tsx`
  - 主タブ側で通常導線通知を受信したら ACK を返し、`window.focus()` を試行。
  - 通常導線通知では状態変更・画面遷移を行わない。
- `packages/web-app/src/main.tsx`
  - ロック失敗時:
    - import-confirm到達時は従来どおり `ImportDelegationScreen` で URL 委譲。
    - 通常導線は既存タブへフォーカス誘導を試行。
    - ACK 不達時はロック再取得を試行し、成功時は現在タブを正規起動。

## 非変更点
- Web Locks 以外の単一タブ制御方式は追加しない。
- 通常導線で payload 受け渡し・既存主タブの画面遷移要求は追加しない。
- DB schema / payload format / import-export format / lock 名の変更なし。

## 影響範囲
- 対象: `packages/web-app` の起動導線とタブ間通知。
- データ互換性: 影響なし。
- ブラウザ差異: `window.focus()` は可能な範囲で試行し、失敗しても破綻しない。

## テスト内容
- `pnpm --filter @iidx/web-app lint`
- `pnpm --filter @iidx/web-app test -- src/utils/import-delegation.test.ts`

## 回帰確認項目
- import-confirm起点で既存タブがいる場合、従来どおりURL委譲できる。
- 通常導線で既存タブがいる場合、既存タブ側で状態変更せずフォーカス誘導のみ行う。
- 通常導線で既存タブが応答不能な場合、現在タブが昇格して起動継続できる。

## ロールバック方針
- 本PRコミットを `git revert` して、従来の起動分岐へ戻す。

## 互換性影響
- 互換性破壊なし。

## 保存/PWA/起動導線への影響
- 保存: 影響なし
- PWA: 影響なし
- 起動導線: Web Locks取得失敗時の通常導線分岐のみ変更

## docs更新
- Plan artifact (`tasks/codex-feat-single-tab-aggregation.md`) を追加。
