### PR TITLE
feat(web,db): add home song data update banner with manual update

### DIFF
--- a/packages/db/src/song-master.ts
+++ b/packages/db/src/song-master.ts
@@ -62,6 +62,11 @@ function isIsoDateTime(value: string): boolean {
   return !Number.isNaN(Date.parse(value));
 }
 
+function parseGeneratedAtMs(value: string): number | null {
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
 function isValidSqliteFileName(value: string): boolean {
   if (value.length === 0) {
     return false;
@@ -142,9 +147,20 @@ export class SongMasterService {
     }
 
     const cachedMeta = await this.appDb.getSongMasterMeta();
-    const cachedSha = (cachedMeta.last_song_master_sha256 ?? cachedMeta.song_master_sha256 ?? '').trim();
-    const cachedByteSize = (cachedMeta.last_song_master_byte_size ?? cachedMeta.song_master_byte_size ?? '').trim();
-    const needsDownload = force || !hasCache || cachedSha !== latest.sha256 || cachedByteSize !== String(latest.byte_size);
+    const localGeneratedAtRaw = (
+      cachedMeta.last_song_master_generated_at ??
+      cachedMeta.song_master_generated_at ??
+      cachedMeta.song_master_updated_at ??
+      ''
+    ).trim();
+    const localGeneratedAtMs = localGeneratedAtRaw.length > 0 ? parseGeneratedAtMs(localGeneratedAtRaw) : null;
+    const latestGeneratedAtMs = parseGeneratedAtMs(latest.generated_at);
+    const needsDownload =
+      force ||
+      !hasCache ||
+      latestGeneratedAtMs === null ||
+      localGeneratedAtMs === null ||
+      latestGeneratedAtMs > localGeneratedAtMs;
 
     if (!needsDownload) {
       return {

--- a/packages/db/test/song-master.test.ts
+++ b/packages/db/test/song-master.test.ts
@@ -137,7 +137,7 @@ describe('SongMasterService', () => {
     expect(appDb.getSettingNow('last_song_master_generated_at')).toBe(latest.generated_at);
   });
 
-  it('skips sqlite download when sha256 and byte_size are unchanged', async () => {
+  it('skips sqlite download when latest generated_at is not newer', async () => {
     const sqliteBytes = createSqliteBytes();
     const sha256 = sha256Hex(sqliteBytes);
     const latest = {
@@ -152,8 +152,7 @@ describe('SongMasterService', () => {
     const sqliteBaseUrl = 'https://github.com/tts1374/iidx_all_songs_master/releases/latest/download';
     const fetchImpl = vi.fn(async () => new Response(JSON.stringify(latest), { status: 200 }));
     const appDb = new MockAppDatabase(true, {
-      last_song_master_sha256: sha256,
-      last_song_master_byte_size: String(sqliteBytes.byteLength),
+      last_song_master_generated_at: '2026-02-17T09:00:00.000+09:00',
       song_master_file_name: latest.file_name,
     });
     const client = new MockSqliteWorkerClient();
@@ -176,6 +175,61 @@ describe('SongMasterService', () => {
     expect(result.source).toBe('up_to_date');
     expect(fetchImpl).toHaveBeenCalledTimes(1);
     expect(opfs.writeFileAtomic).not.toHaveBeenCalled();
+  });
+
+  it('downloads sqlite when latest generated_at is newer', async () => {
+    const sqliteBytes = createSqliteBytes();
+    const sha256 = sha256Hex(sqliteBytes);
+    const latest = {
+      file_name: 'song_master_2026-02-17.sqlite',
+      schema_version: 33,
+      generated_at: '2026-02-17T00:00:01.000Z',
+      sha256,
+      byte_size: sqliteBytes.byteLength,
+    };
+
+    const latestJsonUrl = 'https://github.com/tts1374/iidx_all_songs_master/releases/latest/download/latest.json';
+    const sqliteBaseUrl = 'https://github.com/tts1374/iidx_all_songs_master/releases/latest/download';
+    const expectedSqliteUrl = `${sqliteBaseUrl}/${latest.file_name}`;
+
+    const fetchCalls: string[] = [];
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      fetchCalls.push(url);
+      if (url === latestJsonUrl) {
+        return new Response(JSON.stringify(latest), { status: 200 });
+      }
+      if (url === expectedSqliteUrl) {
+        return new Response(Uint8Array.from(sqliteBytes).buffer, { status: 200 });
+      }
+      throw new Error(`unexpected url: ${url}`);
+    });
+    const appDb = new MockAppDatabase(true, {
+      last_song_master_generated_at: '2026-02-17T00:00:00.000Z',
+      last_song_master_sha256: sha256,
+      last_song_master_byte_size: String(sqliteBytes.byteLength),
+      song_master_file_name: latest.file_name,
+    });
+    const client = new MockSqliteWorkerClient();
+    const opfs = new MockOpfsStorage();
+
+    const service = new SongMasterService(
+      appDb as unknown as AppDatabase,
+      client as unknown as SqliteWorkerClient,
+      opfs as unknown as OpfsStorage,
+      {
+        latestJsonUrl,
+        sqliteBaseUrl,
+        requiredSchemaVersion: 33,
+        fetchImpl: fetchImpl as typeof fetch,
+      },
+    );
+
+    const result = await service.updateIfNeeded(false);
+    expect(result.ok).toBe(true);
+    expect(result.source).toBe('github_download');
+    expect(fetchCalls).toEqual([latestJsonUrl, expectedSqliteUrl]);
+    expect(appDb.getSettingNow('last_song_master_generated_at')).toBe(latest.generated_at);
   });
 
   it('keeps local cache when sqlite integrity validation fails after initial cache exists', async () => {

--- a/packages/web-app/src/App.tsx
+++ b/packages/web-app/src/App.tsx
@@ -61,6 +61,7 @@ import {
   type CreateTournamentDraft,
 } from './pages/create-tournament-draft';
 import { useAppServices } from './services/context';
+import { resolveSongMasterRuntimeConfig } from './services/song-master-config';
 import { extractQrTextFromImage } from './utils/image';
 import {
   IMPORT_DELEGATION_CHANNEL,
@@ -278,6 +279,32 @@ const SW_VERSION_REQUEST_TIMEOUT_MS = 1500;
 const DEBUG_MODE_STORAGE_KEY = 'iidx:debug:mode';
 const HOME_RESULT_COUNT_MARKER = 908172635;
 const HOME_RESULT_COUNT_ANIMATION_DURATION_MS = 200;
+const HOME_SONG_DATA_RECHECK_SUPPRESS_MS = 5000;
+const runtimeConfig = resolveSongMasterRuntimeConfig(import.meta.env);
+
+function pickTrimmedText(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const normalized = value.trim();
+  return normalized.length > 0 ? normalized : null;
+}
+
+function parseGeneratedAtMs(value: string | null): number | null {
+  if (!value) {
+    return null;
+  }
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function parseLatestGeneratedAt(input: unknown): string | null {
+  if (!input || typeof input !== 'object') {
+    return null;
+  }
+  const payload = input as Record<string, unknown>;
+  return pickTrimmedText(payload.generated_at);
+}
 
 type CreateDraftDialogState =
   | { kind: 'none' }
@@ -1088,6 +1115,8 @@ export function App({ webLockAcquired = false }: AppProps = {}): JSX.Element {
   const [detail, setDetail] = React.useState<TournamentDetailItem | null>(null);
   const [detailReturnSignal, setDetailReturnSignal] = React.useState<TournamentDetailReturnSignal | null>(null);
   const [busy, setBusy] = React.useState(false);
+  const [homeSongDataLatestGeneratedAtMs, setHomeSongDataLatestGeneratedAtMs] = React.useState<number | null>(null);
+  const [homeSongDataDismissedGeneratedAtMs, setHomeSongDataDismissedGeneratedAtMs] = React.useState<number | null>(null);
   const [songMasterReady, setSongMasterReady] = React.useState(false);
   const [songMasterMeta, setSongMasterMeta] = React.useState<Record<string, string | null>>(INITIAL_SONG_MASTER_META);
   const [autoDeleteEnabled, setAutoDeleteEnabled] = React.useState(false);
@@ -1144,9 +1173,31 @@ export function App({ webLockAcquired = false }: AppProps = {}): JSX.Element {
   const homeTypeSectionRef = React.useRef<HTMLDivElement | null>(null);
   const homeAttrsSectionRef = React.useRef<HTMLDivElement | null>(null);
   const createDraftSaveTimerRef = React.useRef<number | null>(null);
+  const homeSongDataCheckInFlightRef = React.useRef<Promise<void> | null>(null);
+  const homeSongDataLastCheckedAtRef = React.useRef(0);
 
   const route = routeStack[routeStack.length - 1] ?? { name: 'home' };
   const isHomeRoute = route.name === 'home';
+  const localSongMasterGeneratedAtMs = React.useMemo(
+    () =>
+      parseGeneratedAtMs(
+        songMasterMeta.last_song_master_generated_at ??
+          songMasterMeta.song_master_generated_at ??
+          songMasterMeta.song_master_updated_at ??
+          null,
+      ),
+    [
+      songMasterMeta.last_song_master_generated_at,
+      songMasterMeta.song_master_generated_at,
+      songMasterMeta.song_master_updated_at,
+    ],
+  );
+  const homeSongDataUpdateAvailable =
+    homeSongDataLatestGeneratedAtMs !== null &&
+    localSongMasterGeneratedAtMs !== null &&
+    homeSongDataLatestGeneratedAtMs > localSongMasterGeneratedAtMs;
+  const homeSongDataBannerVisible =
+    homeSongDataUpdateAvailable && homeSongDataLatestGeneratedAtMs !== homeSongDataDismissedGeneratedAtMs;
   const isDetailRoute = route.name === 'detail';
   const isSettingsRoute = route.name === 'settings';
   const todayDate = todayJst();
@@ -1712,6 +1763,44 @@ export function App({ webLockAcquired = false }: AppProps = {}): JSX.Element {
     };
   }, [appDb]);
 
+  const checkHomeSongDataUpdateAvailability = React.useCallback(async (force = false): Promise<void> => {
+    if (homeSongDataCheckInFlightRef.current) {
+      await homeSongDataCheckInFlightRef.current;
+      return;
+    }
+
+    const now = Date.now();
+    if (!force && now - homeSongDataLastCheckedAtRef.current < HOME_SONG_DATA_RECHECK_SUPPRESS_MS) {
+      return;
+    }
+
+    const task = (async () => {
+      homeSongDataLastCheckedAtRef.current = now;
+      try {
+        const res = await fetch(runtimeConfig.latestJsonUrl, { cache: 'no-store' });
+        if (!res.ok) {
+          return;
+        }
+        const generatedAt = parseLatestGeneratedAt(await res.json());
+        const generatedAtMs = parseGeneratedAtMs(generatedAt);
+        if (generatedAtMs === null) {
+          return;
+        }
+        setHomeSongDataLatestGeneratedAtMs(generatedAtMs);
+      } catch {
+        // Keep current banner state when latest check fails.
+      }
+    })();
+
+    homeSongDataCheckInFlightRef.current = task;
+    task.finally(() => {
+      if (homeSongDataCheckInFlightRef.current === task) {
+        homeSongDataCheckInFlightRef.current = null;
+      }
+    });
+    await task;
+  }, []);
+
   const collectAppInfoDetails = React.useCallback(async (): Promise<AppInfoDetailState> => {
     const [appDbUserVersion, appDbSizeBytes, appDbIntegrityCheck, opfsStatus, swVersion, swRegistration, storageEstimate] =
       await Promise.all([
@@ -1827,6 +1916,21 @@ export function App({ webLockAcquired = false }: AppProps = {}): JSX.Element {
     },
     [appDb, appendRuntimeLog, pushToast, refreshSettingsSnapshot, songMasterService, t],
   );
+
+  const dismissHomeSongDataUpdateBanner = React.useCallback(() => {
+    if (homeSongDataLatestGeneratedAtMs === null) {
+      return;
+    }
+    setHomeSongDataDismissedGeneratedAtMs(homeSongDataLatestGeneratedAtMs);
+  }, [homeSongDataLatestGeneratedAtMs]);
+
+  const runHomeSongDataUpdate = React.useCallback(async () => {
+    if (busy || !homeSongDataBannerVisible) {
+      return;
+    }
+    await updateSongMaster(false);
+    await checkHomeSongDataUpdateAvailability(true);
+  }, [busy, checkHomeSongDataUpdateAvailability, homeSongDataBannerVisible, updateSongMaster]);
 
   React.useEffect(() => {
     if (!('serviceWorker' in navigator)) {
@@ -1955,6 +2059,13 @@ export function App({ webLockAcquired = false }: AppProps = {}): JSX.Element {
       mounted = false;
     };
   }, [appDb, appendRuntimeLog, loadHomeQueryState, pushToast, refreshSettingsSnapshot, refreshTournamentList, t]);
+
+  React.useEffect(() => {
+    if (route.name !== 'home') {
+      return;
+    }
+    void checkHomeSongDataUpdateAvailability(false);
+  }, [checkHomeSongDataUpdateAvailability, localSongMasterGeneratedAtMs, route.name]);
 
   React.useEffect(() => {
     if (route.name !== 'settings') {
@@ -2787,6 +2898,31 @@ export function App({ webLockAcquired = false }: AppProps = {}): JSX.Element {
           <div className="updateBanner">
             <span>{t('common.update_available')}</span>
             <button onClick={applyPendingAppUpdate}>{t('common.apply_update')}</button>
+          </div>
+        ) : null}
+
+        {route.name === 'home' && homeSongDataBannerVisible ? (
+          <div className="updateBanner homeSongDataUpdateBanner" role="status" aria-live="polite">
+            <span>{t('common.song_data.home_update_banner')}</span>
+            <div className="homeSongDataUpdateBannerActions">
+              <Button
+                variant="contained"
+                size="small"
+                disableElevation
+                disabled={busy}
+                onClick={() => void runHomeSongDataUpdate()}
+              >
+                {busy ? t('common.loading') : t('common.song_data.home_update_action')}
+              </Button>
+              <IconButton
+                size="small"
+                aria-label={t('common.close')}
+                disabled={busy}
+                onClick={dismissHomeSongDataUpdateBanner}
+              >
+                <CloseIcon fontSize="small" />
+              </IconButton>
+            </div>
           </div>
         ) : null}
 

--- a/packages/web-app/src/i18n/locales/en.json
+++ b/packages/web-app/src/i18n/locales/en.json
@@ -149,7 +149,9 @@
     "song_data": {
       "up_to_date": "Song data is up to date.",
       "refetched": "Song data was refetched.",
-      "update_check_executed": "Song data update check executed."
+      "update_check_executed": "Song data update check executed.",
+      "home_update_banner": "New song data is available. Please update.",
+      "home_update_action": "Update"
     },
     "runtime": {
       "unhandled_exception": "An unhandled exception occurred.",

--- a/packages/web-app/src/i18n/locales/ja.json
+++ b/packages/web-app/src/i18n/locales/ja.json
@@ -149,7 +149,9 @@
     "song_data": {
       "up_to_date": "曲データは最新です。",
       "refetched": "曲データを再取得しました。",
-      "update_check_executed": "曲データの更新確認を実行しました。"
+      "update_check_executed": "曲データの更新確認を実行しました。",
+      "home_update_banner": "新しい曲データがあります。更新してください",
+      "home_update_action": "更新する"
     },
     "runtime": {
       "unhandled_exception": "未処理の例外が発生しました。",

--- a/packages/web-app/src/i18n/locales/ko.json
+++ b/packages/web-app/src/i18n/locales/ko.json
@@ -149,7 +149,9 @@
     "song_data": {
       "up_to_date": "곡 데이터는 최신입니다.",
       "refetched": "곡 데이터를 다시 가져왔습니다.",
-      "update_check_executed": "곡 데이터 업데이트 확인을 실행했습니다."
+      "update_check_executed": "곡 데이터 업데이트 확인을 실행했습니다.",
+      "home_update_banner": "새로운 곡 데이터가 있습니다. 업데이트해 주세요.",
+      "home_update_action": "업데이트"
     },
     "runtime": {
       "unhandled_exception": "처리되지 않은 예외가 발생했습니다.",

--- a/packages/web-app/src/pages/SettingsPage.tsx
+++ b/packages/web-app/src/pages/SettingsPage.tsx
@@ -194,6 +194,14 @@ function parseLatestPayload(input: unknown): SongMasterLatestPayload {
   return { file_name: file, schema_version: schema, sha256: sha, byte_size: size, generated_at: generatedAt };
 }
 
+function parseGeneratedAtMs(value: string | null): number | null {
+  if (!value) {
+    return null;
+  }
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
 function fmtBytes(raw: string | number | null, unknownLabel: string): string {
   const b = Number(raw);
   if (!Number.isFinite(b) || b < 0) return unknownLabel;
@@ -602,12 +610,18 @@ export function SettingsPage(props: SettingsPageProps): JSX.Element {
         return;
       }
       setLatestPayload(payload);
-      const local = action.localSha256 ?? props.songMasterMeta.song_master_sha256;
-      if (!local) {
+      const latestGeneratedAtMs = parseGeneratedAtMs(payload.generated_at);
+      const localGeneratedAtMs = parseGeneratedAtMs(
+        props.songMasterMeta.last_song_master_generated_at ??
+          props.songMasterMeta.song_master_generated_at ??
+          props.songMasterMeta.song_master_updated_at ??
+          null,
+      );
+      if (latestGeneratedAtMs === null || localGeneratedAtMs === null) {
         setCheckOutcome('check_failed');
         return;
       }
-      setCheckOutcome(payload.sha256 === local ? 'latest' : 'update_available');
+      setCheckOutcome(latestGeneratedAtMs > localGeneratedAtMs ? 'update_available' : 'latest');
     } catch (error) {
       setCheckOutcome('check_failed');
       const message = error instanceof Error ? error.message : String(error);
@@ -661,11 +675,7 @@ export function SettingsPage(props: SettingsPageProps): JSX.Element {
       if (!action.ok) {
         throw new Error(action.message ?? t('settings.song_data.error.refetch_default'));
       }
-      if (action.localSha256 && action.latestSha256) {
-        setCheckOutcome(action.localSha256 === action.latestSha256 ? 'latest' : 'update_available');
-      } else {
-        setCheckOutcome(null);
-      }
+      setCheckOutcome('latest');
       setRefetchPhase('complete');
     } catch (error) {
       setRefetchError(resolveErrorMessage(t, error, 'error.description.generic'));

--- a/packages/web-app/src/styles.css
+++ b/packages/web-app/src/styles.css
@@ -2342,6 +2342,12 @@ label {
   justify-content: space-between;
 }
 
+.homeSongDataUpdateBannerActions {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
 .toast {
   position: fixed;
   right: 16px;


### PR DESCRIPTION
## 目的
- Home 画面で曲データ更新可能を明示し、ユーザー操作で手動更新できる導線を追加する。
- 20943369062657cd332f384424f64a4d12cfe242 をベースに、`codex/song-update-banner-manual` 由来の対象機能のみを取り込む。

## 変更点
- Home に「曲データ更新あり」バナーと「更新する」アクションを追加。
- バナーを閉じる（dismiss）挙動を追加。
- Song Master 更新判定を `generated_at` ベースへ変更（DBサービスと設定画面判定を整合）。
- 関連 i18n 文言（ja/en/ko）とスタイルを追加。

## 非変更点
- 単一タブ排他（Web Locks）ロジックは変更なし。
- Service Worker / COOP-COEP / 起動導線は変更なし。
- DB schema / user_version / migration は変更なし。
- import/export 形式、`def_hash` は変更なし。

## 影響範囲
- ユーザー: Home/Settings の曲データ更新案内と手動更新導線。
- データ: Song Master の更新要否判定ロジック（`generated_at` 比較）。
- 互換性: 既存保存形式互換に影響なし。
- PWA/起動: 影響なし。

## テスト内容
- `pnpm -r lint`
- `pnpm -r test`

## 回帰確認項目
- Home で最新 json の `generated_at` がローカルより新しい場合のみバナー表示されること。
- Home の「更新する」で更新処理が走り、更新後に再評価されること。
- Settings の更新確認結果が `generated_at` 比較と一致すること。