### PR TITLE
fix(web-app): improve home song-update banner layout on mobile

### DIFF
--- a/packages/web-app/src/styles.css
+++ b/packages/web-app/src/styles.css
@@ -2346,6 +2346,17 @@ label {
   display: inline-flex;
   align-items: center;
   gap: 4px;
+  flex-shrink: 0;
+}
+
+.homeSongDataUpdateBanner > span {
+  min-width: 0;
+  line-height: 1.35;
+}
+
+.homeSongDataUpdateBannerActions .MuiButton-root {
+  min-inline-size: 72px;
+  white-space: nowrap;
 }
 
 .toast {


### PR DESCRIPTION
## 目的
- SP表示で Home の曲データ更新バナー内「更新する」ボタンが狭くなって読みにくい問題を解消する。

## 変更点
- `homeSongDataUpdateBanner` のアクション領域が縮まないように調整。
- 更新ボタンに最小表示幅 (`min-inline-size: 72px`) を設定し、ボタン内改行を禁止。
- 本文テキスト側は自然改行されるように調整（`line-height`/`min-width`）。

## 非変更点
- 文言自体（i18n）は変更なし。
- Home バナー表示条件や更新ロジックは変更なし。
- 単一タブ排他、起動導線、DB/PWA関連は変更なし。

## 影響範囲
- `packages/web-app/src/styles.css` のみ。
- UIレイアウト（Home更新バナーのSP表示）に限定。

## テスト内容
- `pnpm -C packages/web-app lint`

## 回帰確認項目
- SP幅で更新ボタンが1行表示され、可読性が維持されること。
- 本文は必要に応じて改行されること。
- PC表示でバナー崩れがないこと。