### PR TITLE
fix(web-app): prevent icon 404 on stg base-path deployment

### DIFF
--- a/packages/web-app/index.html
+++ b/packages/web-app/index.html
@@ -5,9 +5,9 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="theme-color" content="#243a5e" />
-  <link rel="icon" type="image/png" href="/icon-512.png" />
-  <link rel="apple-touch-icon" href="/icon-512.png" />
-  <link rel="manifest" href="/manifest.webmanifest" />
+  <link rel="icon" type="image/png" href="%BASE_URL%icon-512.png" />
+  <link rel="apple-touch-icon" href="%BASE_URL%icon-512.png" />
+  <link rel="manifest" href="%BASE_URL%manifest.webmanifest" />
   <title>スコアタログ</title>
 </head>
 

--- a/packages/web-app/public/manifest.webmanifest
+++ b/packages/web-app/public/manifest.webmanifest
@@ -1,13 +1,13 @@
 {
   "name": "スコアタログ",
   "short_name": "スコアタログ",
-  "start_url": "/",
+  "start_url": ".",
   "display": "standalone",
   "background_color": "#f4f6fb",
   "theme_color": "#243a5e",
   "icons": [
     {
-      "src": "/icon-512.png",
+      "src": "icon-512.png",
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "any maskable"


### PR DESCRIPTION
## 目的
- stg の base path 配下デプロイ時に icon/manifest が 404 になる問題を解消する。

## 変更点
- `packages/web-app/index.html`
  - icon/apple-touch-icon/manifest の `href` をルート絶対パス (`/...`) から `%BASE_URL%...` へ変更。
- `packages/web-app/public/manifest.webmanifest`
  - `start_url` を `"/"` から `"."` へ変更。
  - icon `src` を `"/icon-512.png"` から相対パス `"icon-512.png"` へ変更。

## 非変更点
- 画像ファイル本体（`icon-512.png`）は変更なし。
- Service Worker / Web Locks / DB / 起動ロジックの実装変更なし。

## 影響範囲
- web-app の静的参照パス（index/manifest）のみ。
- base path 配下（例: `/iidx_score_attack_manager-stg/`）での icon/manifest 解決に影響。

## テスト内容
- `pnpm -C packages/web-app build`
- `VITE_BASE_PATH=/iidx_score_attack_manager-stg/` 指定で再ビルドし、`dist/index.html` を確認
  - icon/manifest/script/css が `/iidx_score_attack_manager-stg/` プレフィックスで出力されること
- `dist/manifest.webmanifest` を確認
  - `start_url: "."`, `icons[0].src: "icon-512.png"`

## 回帰確認項目
- stg で favicon / apple-touch-icon / manifest が 404 にならないこと。
- 本番 base path でも同様に解決されること。