### PR TITLE
[codex] public catalog register api

### DIFF
--- a/packages/public-catalog-api/migrations/0001_public_tournaments.sql
+++ b/packages/public-catalog-api/migrations/0001_public_tournaments.sql
@@ -1,0 +1,38 @@
+CREATE TABLE IF NOT EXISTS public_tournaments (
+  public_id TEXT PRIMARY KEY,
+  registry_hash TEXT NOT NULL UNIQUE,
+  payload_json TEXT NOT NULL,
+  name TEXT NOT NULL,
+  owner TEXT NOT NULL,
+  hashtag TEXT NOT NULL,
+  start_date TEXT NOT NULL,
+  end_date TEXT NOT NULL,
+  chart_count INTEGER NOT NULL,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  deleted_at TEXT,
+  delete_reason TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_public_tournaments_created_at
+  ON public_tournaments (created_at DESC, public_id DESC);
+
+CREATE INDEX IF NOT EXISTS idx_public_tournaments_deleted_at
+  ON public_tournaments (deleted_at, created_at DESC, public_id DESC);
+
+CREATE TABLE IF NOT EXISTS public_tournament_audit_logs (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  public_id TEXT,
+  registry_hash TEXT,
+  result TEXT NOT NULL,
+  request_fingerprint TEXT NOT NULL,
+  origin TEXT,
+  detail_json TEXT,
+  created_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_public_tournament_audit_logs_request_fingerprint
+  ON public_tournament_audit_logs (request_fingerprint, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_public_tournament_audit_logs_public_id
+  ON public_tournament_audit_logs (public_id, created_at DESC);

--- a/packages/public-catalog-api/package.json
+++ b/packages/public-catalog-api/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@iidx/public-catalog-api",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "vitest run",
+    "lint": "tsc -p tsconfig.json --noEmit",
+    "cf:check": "wrangler check",
+    "cf:typegen": "wrangler types ./src/worker-configuration.d.ts"
+  },
+  "dependencies": {
+    "@iidx/shared": "workspace:*"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20260418.1",
+    "vitest": "^2.1.8",
+    "wrangler": "^4.83.0"
+  }
+}

--- a/packages/public-catalog-api/scripts/delete-public-tournament-lib.d.mts
+++ b/packages/public-catalog-api/scripts/delete-public-tournament-lib.d.mts
@@ -1,0 +1,10 @@
+export interface DeletePublicTournamentSqlOptions {
+  publicId: string;
+  deletedAt: string;
+  reason?: string;
+  requestFingerprint?: string;
+}
+
+export function buildDeletePublicTournamentSql(
+  options: DeletePublicTournamentSqlOptions,
+): string;

--- a/packages/public-catalog-api/scripts/delete-public-tournament-lib.mjs
+++ b/packages/public-catalog-api/scripts/delete-public-tournament-lib.mjs
@@ -1,0 +1,30 @@
+function assertNonEmpty(value, name) {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new Error(`${name} is required`);
+  }
+}
+
+function sqlString(value) {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
+export function buildDeletePublicTournamentSql({
+  publicId,
+  deletedAt,
+  reason = 'manual moderation delete',
+  requestFingerprint = 'ops:manual',
+}) {
+  assertNonEmpty(publicId, 'publicId');
+  assertNonEmpty(deletedAt, 'deletedAt');
+  assertNonEmpty(reason, 'reason');
+  assertNonEmpty(requestFingerprint, 'requestFingerprint');
+
+  const detailJson = JSON.stringify({ reason });
+
+  return [
+    'BEGIN;',
+    `UPDATE public_tournaments SET deleted_at = ${sqlString(deletedAt)}, updated_at = ${sqlString(deletedAt)}, delete_reason = ${sqlString(reason)} WHERE public_id = ${sqlString(publicId)} AND deleted_at IS NULL;`,
+    `INSERT INTO public_tournament_audit_logs (public_id, registry_hash, result, request_fingerprint, origin, detail_json, created_at) SELECT public_id, registry_hash, 'deleted', ${sqlString(requestFingerprint)}, 'ops', ${sqlString(detailJson)}, ${sqlString(deletedAt)} FROM public_tournaments WHERE public_id = ${sqlString(publicId)} AND deleted_at = ${sqlString(deletedAt)};`,
+    'COMMIT;',
+  ].join(' ');
+}

--- a/packages/public-catalog-api/scripts/delete-public-tournament.mjs
+++ b/packages/public-catalog-api/scripts/delete-public-tournament.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import { buildDeletePublicTournamentSql } from './delete-public-tournament-lib.mjs';
+
+function parseArgs(argv) {
+  const parsed = {
+    database: '',
+    publicId: '',
+    reason: 'manual moderation delete',
+    operator: 'manual',
+    local: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    switch (arg) {
+      case '--database':
+        parsed.database = argv[index + 1] ?? '';
+        index += 1;
+        break;
+      case '--public-id':
+        parsed.publicId = argv[index + 1] ?? '';
+        index += 1;
+        break;
+      case '--reason':
+        parsed.reason = argv[index + 1] ?? parsed.reason;
+        index += 1;
+        break;
+      case '--operator':
+        parsed.operator = argv[index + 1] ?? parsed.operator;
+        index += 1;
+        break;
+      case '--local':
+        parsed.local = true;
+        break;
+      default:
+        throw new Error(`unknown argument: ${arg}`);
+    }
+  }
+
+  if (!parsed.database || !parsed.publicId) {
+    throw new Error(
+      'usage: node scripts/delete-public-tournament.mjs --database <name> --public-id <id> [--reason <text>] [--operator <name>] [--local]',
+    );
+  }
+
+  return parsed;
+}
+
+function run() {
+  const args = parseArgs(process.argv.slice(2));
+  const deletedAt = new Date().toISOString();
+  const sql = buildDeletePublicTournamentSql({
+    publicId: args.publicId,
+    deletedAt,
+    reason: args.reason,
+    requestFingerprint: `ops:${args.operator}`,
+  });
+
+  const commandArgs = [
+    'exec',
+    'wrangler',
+    'd1',
+    'execute',
+    args.database,
+    args.local ? '--local' : '--remote',
+    '--command',
+    sql,
+  ];
+
+  const result = spawnSync('pnpm', commandArgs, {
+    stdio: 'inherit',
+    shell: process.platform === 'win32',
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  process.exit(result.status ?? 1);
+}
+
+try {
+  run();
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(message);
+  process.exit(1);
+}

--- a/packages/public-catalog-api/src/cors.ts
+++ b/packages/public-catalog-api/src/cors.ts
@@ -1,0 +1,58 @@
+export interface CorsContext {
+  requestOrigin: string | null;
+  allowedOrigin: string | null;
+}
+
+function appendVary(headers: Headers, value: string): void {
+  const current = headers.get('Vary');
+  if (!current) {
+    headers.set('Vary', value);
+    return;
+  }
+
+  const values = current.split(',').map((entry) => entry.trim());
+  if (!values.includes(value)) {
+    headers.set('Vary', `${current}, ${value}`);
+  }
+}
+
+export function normalizeRequestOrigin(originHeader: string | null): string | null {
+  if (!originHeader) {
+    return null;
+  }
+
+  try {
+    return new URL(originHeader).origin;
+  } catch {
+    return null;
+  }
+}
+
+export function resolveCorsContext(
+  originHeader: string | null,
+  allowedOrigins: Set<string>,
+): CorsContext {
+  const requestOrigin = normalizeRequestOrigin(originHeader);
+  return {
+    requestOrigin,
+    allowedOrigin:
+      requestOrigin && allowedOrigins.has(requestOrigin) ? requestOrigin : null,
+  };
+}
+
+export function createVaryHeaders(): Headers {
+  const headers = new Headers();
+  appendVary(headers, 'Origin');
+  return headers;
+}
+
+export function createCorsHeaders(allowedOrigin: string): Headers {
+  const headers = createVaryHeaders();
+  appendVary(headers, 'Access-Control-Request-Method');
+  appendVary(headers, 'Access-Control-Request-Headers');
+  headers.set('Access-Control-Allow-Origin', allowedOrigin);
+  headers.set('Access-Control-Allow-Methods', 'POST, OPTIONS');
+  headers.set('Access-Control-Allow-Headers', 'content-type');
+  headers.set('Access-Control-Max-Age', '86400');
+  return headers;
+}

--- a/packages/public-catalog-api/src/env.ts
+++ b/packages/public-catalog-api/src/env.ts
@@ -1,0 +1,76 @@
+export interface PublicCatalogEnv {
+  DB: D1Database;
+  ALLOWED_ORIGINS: string;
+  RATE_LIMIT_SALT: string;
+  RATE_LIMIT_MAX_REQUESTS?: string;
+  RATE_LIMIT_WINDOW_SECONDS?: string;
+}
+
+export interface PublicCatalogConfig {
+  allowedOrigins: Set<string>;
+  rateLimitSalt: string;
+  rateLimitMaxRequests: number;
+  rateLimitWindowSeconds: number;
+}
+
+const DEFAULT_RATE_LIMIT_MAX_REQUESTS = 10;
+const DEFAULT_RATE_LIMIT_WINDOW_SECONDS = 3600;
+
+function parsePositiveInteger(
+  value: string | undefined,
+  fallback: number,
+  name: string,
+): number {
+  if (value === undefined || value.trim() === '') {
+    return fallback;
+  }
+
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function normalizeOrigin(origin: string): string {
+  const url = new URL(origin.trim());
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new Error(`unsupported origin protocol: ${url.protocol}`);
+  }
+  return url.origin;
+}
+
+function parseAllowedOrigins(value: string): Set<string> {
+  const entries = value
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+
+  if (entries.length === 0) {
+    throw new Error('ALLOWED_ORIGINS must include at least one origin');
+  }
+
+  return new Set(entries.map(normalizeOrigin));
+}
+
+export function parsePublicCatalogConfig(env: PublicCatalogEnv): PublicCatalogConfig {
+  const rateLimitSalt = env.RATE_LIMIT_SALT?.trim();
+  if (!rateLimitSalt) {
+    throw new Error('RATE_LIMIT_SALT is required');
+  }
+
+  return {
+    allowedOrigins: parseAllowedOrigins(env.ALLOWED_ORIGINS),
+    rateLimitSalt,
+    rateLimitMaxRequests: parsePositiveInteger(
+      env.RATE_LIMIT_MAX_REQUESTS,
+      DEFAULT_RATE_LIMIT_MAX_REQUESTS,
+      'RATE_LIMIT_MAX_REQUESTS',
+    ),
+    rateLimitWindowSeconds: parsePositiveInteger(
+      env.RATE_LIMIT_WINDOW_SECONDS,
+      DEFAULT_RATE_LIMIT_WINDOW_SECONDS,
+      'RATE_LIMIT_WINDOW_SECONDS',
+    ),
+  };
+}

--- a/packages/public-catalog-api/src/index.ts
+++ b/packages/public-catalog-api/src/index.ts
@@ -1,0 +1,415 @@
+import {
+  PayloadValidationError,
+  buildPublicTournamentRegistryHash,
+  normalizeTournamentPayload,
+  type ErrorParams,
+  type PublicCatalogApiErrorCode,
+  type PublicCatalogApiErrorResponse,
+  type PublicTournamentRegisterResponse,
+} from '@iidx/shared';
+import {
+  createCorsHeaders,
+  createVaryHeaders,
+  resolveCorsContext,
+} from './cors.js';
+import {
+  parsePublicCatalogConfig,
+  type PublicCatalogEnv,
+} from './env.js';
+import {
+  D1PublicTournamentRepository,
+  type PublicTournamentAuditLogEntry,
+  type PublicTournamentAuditResult,
+  type PublicTournamentRecord,
+  type PublicTournamentRepository,
+} from './repository/public-tournaments.js';
+import {
+  buildRequestFingerprint,
+  getRateLimitWindowStart,
+} from './rate-limit.js';
+
+export const REGISTER_PUBLIC_TOURNAMENT_PATH = '/api/public-tournaments';
+
+const MAX_REQUEST_BODY_BYTES = 32 * 1024;
+
+class ApiError extends Error {
+  constructor(
+    readonly status: number,
+    readonly code: PublicCatalogApiErrorCode,
+    message: string,
+    readonly details?: ErrorParams,
+  ) {
+    super(message);
+    this.name = 'ApiError';
+  }
+}
+
+export interface PublicCatalogWorkerDependencies {
+  createRepository?: (db: D1Database) => PublicTournamentRepository;
+  now?: () => Date;
+  randomUUID?: () => string;
+}
+
+interface CreateOrResolveTournamentResult {
+  created: boolean;
+  record: PublicTournamentRecord;
+}
+
+function mergeHeaders(target: Headers, source: Headers): void {
+  source.forEach((value, key) => {
+    target.set(key, value);
+  });
+}
+
+function buildJsonHeaders(allowedOrigin: string | null): Headers {
+  const headers = createVaryHeaders();
+  headers.set('Cache-Control', 'no-store');
+  headers.set('Content-Type', 'application/json; charset=utf-8');
+  if (allowedOrigin) {
+    mergeHeaders(headers, createCorsHeaders(allowedOrigin));
+  }
+  return headers;
+}
+
+function jsonResponse<T>(
+  status: number,
+  body: T,
+  allowedOrigin: string | null,
+  extraHeaders?: HeadersInit,
+): Response {
+  const headers = buildJsonHeaders(allowedOrigin);
+  if (extraHeaders) {
+    mergeHeaders(headers, new Headers(extraHeaders));
+  }
+  return new Response(JSON.stringify(body), { status, headers });
+}
+
+function errorResponse(
+  status: number,
+  code: PublicCatalogApiErrorCode,
+  message: string,
+  allowedOrigin: string | null,
+  details?: ErrorParams,
+  extraHeaders?: HeadersInit,
+): Response {
+  const body: PublicCatalogApiErrorResponse = {
+    error: {
+      code,
+      message,
+      ...(details ? { details } : {}),
+    },
+  };
+
+  return jsonResponse(status, body, allowedOrigin, extraHeaders);
+}
+
+function createAuditEntry(
+  result: PublicTournamentAuditResult,
+  requestFingerprint: string,
+  createdAt: string,
+  origin: string | null,
+  options: {
+    publicId?: string | null;
+    registryHash?: string | null;
+    details?: Record<string, unknown>;
+  } = {},
+): PublicTournamentAuditLogEntry {
+  return {
+    publicId: options.publicId ?? null,
+    registryHash: options.registryHash ?? null,
+    result,
+    requestFingerprint,
+    origin,
+    createdAt,
+    ...(options.details ? { details: options.details } : {}),
+  };
+}
+
+async function parseJsonBody(request: Request): Promise<unknown> {
+  const contentType = request.headers.get('content-type') ?? '';
+  if (!contentType.toLowerCase().includes('application/json')) {
+    throw new ApiError(
+      415,
+      'UNSUPPORTED_MEDIA_TYPE',
+      'content-type must be application/json',
+    );
+  }
+
+  const declaredLength = request.headers.get('content-length');
+  if (declaredLength) {
+    const parsedLength = Number(declaredLength);
+    if (!Number.isFinite(parsedLength) || parsedLength < 0) {
+      throw new ApiError(400, 'BAD_REQUEST', 'invalid content-length header');
+    }
+    if (parsedLength > MAX_REQUEST_BODY_BYTES) {
+      throw new ApiError(413, 'PAYLOAD_TOO_LARGE', 'request body too large');
+    }
+  }
+
+  const rawBody = await request.text();
+  if (rawBody.trim().length === 0) {
+    throw new ApiError(400, 'BAD_REQUEST', 'request body is required');
+  }
+
+  if (new TextEncoder().encode(rawBody).byteLength > MAX_REQUEST_BODY_BYTES) {
+    throw new ApiError(413, 'PAYLOAD_TOO_LARGE', 'request body too large');
+  }
+
+  try {
+    return JSON.parse(rawBody);
+  } catch {
+    throw new ApiError(400, 'INVALID_JSON', 'request body must be valid json');
+  }
+}
+
+function toPublicTournamentRecord(
+  payload: ReturnType<typeof normalizeTournamentPayload>,
+  registryHash: string,
+  publicId: string,
+  createdAt: string,
+): PublicTournamentRecord {
+  const payloadJson = JSON.stringify(payload);
+
+  return {
+    publicId,
+    registryHash,
+    payloadJson,
+    name: payload.name,
+    owner: payload.owner,
+    hashtag: payload.hashtag,
+    startDate: payload.start,
+    endDate: payload.end,
+    chartCount: payload.charts.length,
+    createdAt,
+    updatedAt: createdAt,
+    deletedAt: null,
+    deleteReason: null,
+  };
+}
+
+async function createOrResolveTournament(
+  repository: PublicTournamentRepository,
+  record: PublicTournamentRecord,
+): Promise<CreateOrResolveTournamentResult> {
+  const created = await repository.create(record);
+  if (created) {
+    return { created: true, record };
+  }
+
+  const existing = await repository.getByRegistryHash(record.registryHash);
+  if (!existing) {
+    throw new Error('existing public tournament not found after duplicate insert');
+  }
+
+  return { created: false, record: existing };
+}
+
+export function createWorkerHandler(
+  dependencies: PublicCatalogWorkerDependencies = {},
+): ExportedHandler<PublicCatalogEnv> {
+  const createRepository =
+    dependencies.createRepository ??
+    ((db: D1Database) => new D1PublicTournamentRepository(db));
+  const now = dependencies.now ?? (() => new Date());
+  const randomUUID = dependencies.randomUUID ?? (() => crypto.randomUUID());
+
+  return {
+    async fetch(request, env) {
+      const url = new URL(request.url);
+      if (url.pathname !== REGISTER_PUBLIC_TOURNAMENT_PATH) {
+        if (request.method === 'OPTIONS') {
+          return new Response(null, { status: 404, headers: createVaryHeaders() });
+        }
+        return errorResponse(404, 'NOT_FOUND', 'route not found', null);
+      }
+
+      let config;
+      try {
+        config = parsePublicCatalogConfig(env);
+      } catch {
+        return errorResponse(500, 'INTERNAL_ERROR', 'worker configuration is invalid', null);
+      }
+
+      const cors = resolveCorsContext(request.headers.get('Origin'), config.allowedOrigins);
+      if (request.method === 'OPTIONS') {
+        if (!cors.allowedOrigin) {
+          return new Response(null, { status: 403, headers: createVaryHeaders() });
+        }
+        return new Response(null, {
+          status: 204,
+          headers: createCorsHeaders(cors.allowedOrigin),
+        });
+      }
+
+      if (request.method !== 'POST') {
+        return errorResponse(
+          405,
+          'METHOD_NOT_ALLOWED',
+          'method not allowed',
+          cors.allowedOrigin,
+          undefined,
+          { Allow: 'POST, OPTIONS' },
+        );
+      }
+
+      const repository = createRepository(env.DB);
+      const currentTime = now();
+      const createdAt = currentTime.toISOString();
+      const requestFingerprint = buildRequestFingerprint(
+        request,
+        config.rateLimitSalt,
+      );
+      const auditOrigin = cors.requestOrigin ?? request.headers.get('Origin');
+
+      if (!cors.allowedOrigin) {
+        await repository.insertAuditLog(
+          createAuditEntry(
+            'origin_rejected',
+            requestFingerprint,
+            createdAt,
+            auditOrigin,
+            {
+              details: {
+                origin: request.headers.get('Origin') ?? null,
+              },
+            },
+          ),
+        );
+        return errorResponse(403, 'ORIGIN_NOT_ALLOWED', 'origin not allowed', null);
+      }
+
+      const windowStart = getRateLimitWindowStart(
+        currentTime,
+        config.rateLimitWindowSeconds,
+      );
+      const recentAttempts = await repository.countRecentAttempts(
+        requestFingerprint,
+        windowStart,
+      );
+
+      if (recentAttempts >= config.rateLimitMaxRequests) {
+        await repository.insertAuditLog(
+          createAuditEntry('rate_limited', requestFingerprint, createdAt, auditOrigin),
+        );
+        return errorResponse(
+          429,
+          'RATE_LIMITED',
+          'rate limit exceeded',
+          cors.allowedOrigin,
+        );
+      }
+
+      let requestPayload: unknown;
+      try {
+        requestPayload = await parseJsonBody(request);
+      } catch (error) {
+        if (error instanceof ApiError) {
+          const auditResult: PublicTournamentAuditResult =
+            error.code === 'INVALID_JSON'
+              ? 'invalid_json'
+              : error.code === 'PAYLOAD_TOO_LARGE'
+                ? 'payload_too_large'
+                : error.code === 'UNSUPPORTED_MEDIA_TYPE'
+                  ? 'unsupported_media_type'
+                  : 'bad_request';
+          await repository.insertAuditLog(
+            createAuditEntry(auditResult, requestFingerprint, createdAt, auditOrigin),
+          );
+          return errorResponse(
+            error.status,
+            error.code,
+            error.message,
+            cors.allowedOrigin,
+            error.details,
+          );
+        }
+        throw error;
+      }
+
+      let normalizedPayload: ReturnType<typeof normalizeTournamentPayload>;
+      try {
+        normalizedPayload = normalizeTournamentPayload(requestPayload);
+      } catch (error) {
+        if (error instanceof PayloadValidationError) {
+          await repository.insertAuditLog(
+            createAuditEntry(
+              'invalid_payload',
+              requestFingerprint,
+              createdAt,
+              auditOrigin,
+              error.params ? { details: error.params } : {},
+            ),
+          );
+          return errorResponse(
+            400,
+            'INVALID_PAYLOAD',
+            'tournament payload is invalid',
+            cors.allowedOrigin,
+            error.params,
+          );
+        }
+        throw error;
+      }
+
+      const registryHash = buildPublicTournamentRegistryHash(normalizedPayload);
+      const record = toPublicTournamentRecord(
+        normalizedPayload,
+        registryHash,
+        randomUUID(),
+        createdAt,
+      );
+
+      try {
+        const result = await createOrResolveTournament(repository, record);
+        const responseBody: PublicTournamentRegisterResponse = {
+          status: result.created ? 'created' : 'duplicate',
+          publicId: result.record.publicId,
+        };
+        await repository.insertAuditLog(
+          createAuditEntry(
+            result.created ? 'accepted' : 'duplicate',
+            requestFingerprint,
+            createdAt,
+            auditOrigin,
+            {
+              publicId: result.record.publicId,
+              registryHash,
+              details: {
+                status: responseBody.status,
+              },
+            },
+          ),
+        );
+
+        return jsonResponse(
+          result.created ? 201 : 200,
+          responseBody,
+          cors.allowedOrigin,
+        );
+      } catch (error) {
+        await repository.insertAuditLog(
+          createAuditEntry(
+            'internal_error',
+            requestFingerprint,
+            createdAt,
+            auditOrigin,
+            {
+              registryHash,
+            },
+          ),
+        );
+        console.error('public tournament registration failed', error);
+        return errorResponse(
+          500,
+          'INTERNAL_ERROR',
+          'failed to register tournament',
+          cors.allowedOrigin,
+        );
+      }
+    },
+  };
+}
+
+const worker = createWorkerHandler();
+
+export default worker;

--- a/packages/public-catalog-api/src/index.ts
+++ b/packages/public-catalog-api/src/index.ts
@@ -27,8 +27,7 @@ import {
   buildRequestFingerprint,
   getRateLimitWindowStart,
 } from './rate-limit.js';
-
-export const REGISTER_PUBLIC_TOURNAMENT_PATH = '/api/public-tournaments';
+import { REGISTER_PUBLIC_TOURNAMENT_PATH } from './routes.js';
 
 const MAX_REQUEST_BODY_BYTES = 32 * 1024;
 
@@ -125,6 +124,52 @@ function createAuditEntry(
   };
 }
 
+function normalizeBodyChunk(value: Uint8Array | ArrayBuffer): Uint8Array {
+  if (value instanceof Uint8Array) {
+    return value;
+  }
+  return new Uint8Array(value);
+}
+
+async function readRequestTextWithLimit(
+  request: Request,
+  maxBytes: number,
+): Promise<string> {
+  const body = request.body;
+  if (!body) {
+    throw new ApiError(400, 'BAD_REQUEST', 'request body is required');
+  }
+
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  const chunks: string[] = [];
+  let totalBytes = 0;
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      if (!value) {
+        continue;
+      }
+
+      const chunk = normalizeBodyChunk(value);
+      totalBytes += chunk.byteLength;
+      if (totalBytes > maxBytes) {
+        throw new ApiError(413, 'PAYLOAD_TOO_LARGE', 'request body too large');
+      }
+
+      chunks.push(decoder.decode(chunk, { stream: true }));
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  return chunks.join('') + decoder.decode();
+}
+
 async function parseJsonBody(request: Request): Promise<unknown> {
   const contentType = request.headers.get('content-type') ?? '';
   if (!contentType.toLowerCase().includes('application/json')) {
@@ -146,13 +191,9 @@ async function parseJsonBody(request: Request): Promise<unknown> {
     }
   }
 
-  const rawBody = await request.text();
+  const rawBody = await readRequestTextWithLimit(request, MAX_REQUEST_BODY_BYTES);
   if (rawBody.trim().length === 0) {
     throw new ApiError(400, 'BAD_REQUEST', 'request body is required');
-  }
-
-  if (new TextEncoder().encode(rawBody).byteLength > MAX_REQUEST_BODY_BYTES) {
-    throw new ApiError(413, 'PAYLOAD_TOO_LARGE', 'request body too large');
   }
 
   try {

--- a/packages/public-catalog-api/src/index.ts
+++ b/packages/public-catalog-api/src/index.ts
@@ -170,9 +170,13 @@ async function readRequestTextWithLimit(
   return chunks.join('') + decoder.decode();
 }
 
+function getMediaType(contentTypeHeader: string | null): string {
+  return (contentTypeHeader ?? '').split(';', 1)[0]?.trim().toLowerCase() ?? '';
+}
+
 async function parseJsonBody(request: Request): Promise<unknown> {
-  const contentType = request.headers.get('content-type') ?? '';
-  if (!contentType.toLowerCase().includes('application/json')) {
+  const mediaType = getMediaType(request.headers.get('content-type'));
+  if (mediaType !== 'application/json') {
     throw new ApiError(
       415,
       'UNSUPPORTED_MEDIA_TYPE',

--- a/packages/public-catalog-api/src/index.ts
+++ b/packages/public-catalog-api/src/index.ts
@@ -260,24 +260,6 @@ export function createWorkerHandler(
         config.rateLimitSalt,
       );
       const auditOrigin = cors.requestOrigin ?? request.headers.get('Origin');
-
-      if (!cors.allowedOrigin) {
-        await repository.insertAuditLog(
-          createAuditEntry(
-            'origin_rejected',
-            requestFingerprint,
-            createdAt,
-            auditOrigin,
-            {
-              details: {
-                origin: request.headers.get('Origin') ?? null,
-              },
-            },
-          ),
-        );
-        return errorResponse(403, 'ORIGIN_NOT_ALLOWED', 'origin not allowed', null);
-      }
-
       const windowStart = getRateLimitWindowStart(
         currentTime,
         config.rateLimitWindowSeconds,
@@ -297,6 +279,23 @@ export function createWorkerHandler(
           'rate limit exceeded',
           cors.allowedOrigin,
         );
+      }
+
+      if (!cors.allowedOrigin) {
+        await repository.insertAuditLog(
+          createAuditEntry(
+            'origin_rejected',
+            requestFingerprint,
+            createdAt,
+            auditOrigin,
+            {
+              details: {
+                origin: request.headers.get('Origin') ?? null,
+              },
+            },
+          ),
+        );
+        return errorResponse(403, 'ORIGIN_NOT_ALLOWED', 'origin not allowed', null);
       }
 
       let requestPayload: unknown;

--- a/packages/public-catalog-api/src/rate-limit.ts
+++ b/packages/public-catalog-api/src/rate-limit.ts
@@ -1,0 +1,34 @@
+import { sha256Text } from '@iidx/shared';
+
+function firstForwardedIp(value: string): string {
+  const first = value.split(',')[0];
+  return first?.trim() || 'unknown';
+}
+
+export function getClientIp(request: Request): string {
+  const cfConnectingIp = request.headers.get('CF-Connecting-IP');
+  if (cfConnectingIp?.trim()) {
+    return cfConnectingIp.trim();
+  }
+
+  const xForwardedFor = request.headers.get('X-Forwarded-For');
+  if (xForwardedFor?.trim()) {
+    return firstForwardedIp(xForwardedFor);
+  }
+
+  return 'unknown';
+}
+
+export function buildRequestFingerprint(
+  request: Request,
+  salt: string,
+): string {
+  return sha256Text(`${salt}:${getClientIp(request)}`);
+}
+
+export function getRateLimitWindowStart(
+  now: Date,
+  windowSeconds: number,
+): string {
+  return new Date(now.getTime() - windowSeconds * 1000).toISOString();
+}

--- a/packages/public-catalog-api/src/repository/public-tournaments.ts
+++ b/packages/public-catalog-api/src/repository/public-tournaments.ts
@@ -1,0 +1,209 @@
+export interface PublicTournamentRecord {
+  publicId: string;
+  registryHash: string;
+  payloadJson: string;
+  name: string;
+  owner: string;
+  hashtag: string;
+  startDate: string;
+  endDate: string;
+  chartCount: number;
+  createdAt: string;
+  updatedAt: string;
+  deletedAt: string | null;
+  deleteReason: string | null;
+}
+
+export type PublicTournamentAuditResult =
+  | 'accepted'
+  | 'bad_request'
+  | 'deleted'
+  | 'duplicate'
+  | 'internal_error'
+  | 'invalid_json'
+  | 'invalid_payload'
+  | 'origin_rejected'
+  | 'payload_too_large'
+  | 'rate_limited'
+  | 'unsupported_media_type';
+
+export interface PublicTournamentAuditLogEntry {
+  publicId: string | null;
+  registryHash: string | null;
+  result: PublicTournamentAuditResult;
+  requestFingerprint: string;
+  origin: string | null;
+  details?: Record<string, unknown>;
+  createdAt: string;
+}
+
+export interface PublicTournamentRepository {
+  countRecentAttempts(
+    requestFingerprint: string,
+    sinceInclusive: string,
+  ): Promise<number>;
+  getByRegistryHash(registryHash: string): Promise<PublicTournamentRecord | null>;
+  create(record: PublicTournamentRecord): Promise<boolean>;
+  insertAuditLog(entry: PublicTournamentAuditLogEntry): Promise<void>;
+}
+
+interface CountRow {
+  count: number | string;
+}
+
+interface PublicTournamentRow {
+  public_id: string;
+  registry_hash: string;
+  payload_json: string;
+  name: string;
+  owner: string;
+  hashtag: string;
+  start_date: string;
+  end_date: string;
+  chart_count: number;
+  created_at: string;
+  updated_at: string;
+  deleted_at: string | null;
+  delete_reason: string | null;
+}
+
+function mapPublicTournamentRow(row: PublicTournamentRow): PublicTournamentRecord {
+  return {
+    publicId: row.public_id,
+    registryHash: row.registry_hash,
+    payloadJson: row.payload_json,
+    name: row.name,
+    owner: row.owner,
+    hashtag: row.hashtag,
+    startDate: row.start_date,
+    endDate: row.end_date,
+    chartCount: row.chart_count,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    deletedAt: row.deleted_at,
+    deleteReason: row.delete_reason,
+  };
+}
+
+export class D1PublicTournamentRepository implements PublicTournamentRepository {
+  constructor(private readonly db: D1Database) {}
+
+  async countRecentAttempts(
+    requestFingerprint: string,
+    sinceInclusive: string,
+  ): Promise<number> {
+    const row = await this.db
+      .prepare(
+        `
+          SELECT COUNT(*) AS count
+          FROM public_tournament_audit_logs
+          WHERE request_fingerprint = ?
+            AND created_at >= ?
+            AND result != 'deleted'
+        `,
+      )
+      .bind(requestFingerprint, sinceInclusive)
+      .first<CountRow>();
+
+    return Number(row?.count ?? 0);
+  }
+
+  async getByRegistryHash(
+    registryHash: string,
+  ): Promise<PublicTournamentRecord | null> {
+    const row = await this.db
+      .prepare(
+        `
+          SELECT
+            public_id,
+            registry_hash,
+            payload_json,
+            name,
+            owner,
+            hashtag,
+            start_date,
+            end_date,
+            chart_count,
+            created_at,
+            updated_at,
+            deleted_at,
+            delete_reason
+          FROM public_tournaments
+          WHERE registry_hash = ?
+          LIMIT 1
+        `,
+      )
+      .bind(registryHash)
+      .first<PublicTournamentRow>();
+
+    return row ? mapPublicTournamentRow(row) : null;
+  }
+
+  async create(record: PublicTournamentRecord): Promise<boolean> {
+    const result = await this.db
+      .prepare(
+        `
+          INSERT OR IGNORE INTO public_tournaments (
+            public_id,
+            registry_hash,
+            payload_json,
+            name,
+            owner,
+            hashtag,
+            start_date,
+            end_date,
+            chart_count,
+            created_at,
+            updated_at,
+            deleted_at,
+            delete_reason
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `,
+      )
+      .bind(
+        record.publicId,
+        record.registryHash,
+        record.payloadJson,
+        record.name,
+        record.owner,
+        record.hashtag,
+        record.startDate,
+        record.endDate,
+        record.chartCount,
+        record.createdAt,
+        record.updatedAt,
+        record.deletedAt,
+        record.deleteReason,
+      )
+      .run();
+
+    return (result.meta.changes ?? 0) > 0;
+  }
+
+  async insertAuditLog(entry: PublicTournamentAuditLogEntry): Promise<void> {
+    await this.db
+      .prepare(
+        `
+          INSERT INTO public_tournament_audit_logs (
+            public_id,
+            registry_hash,
+            result,
+            request_fingerprint,
+            origin,
+            detail_json,
+            created_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?)
+        `,
+      )
+      .bind(
+        entry.publicId,
+        entry.registryHash,
+        entry.result,
+        entry.requestFingerprint,
+        entry.origin,
+        entry.details ? JSON.stringify(entry.details) : null,
+        entry.createdAt,
+      )
+      .run();
+  }
+}

--- a/packages/public-catalog-api/src/routes.ts
+++ b/packages/public-catalog-api/src/routes.ts
@@ -1,0 +1,1 @@
+export const REGISTER_PUBLIC_TOURNAMENT_PATH = '/api/public-tournaments';

--- a/packages/public-catalog-api/test/delete-public-tournament-lib.test.ts
+++ b/packages/public-catalog-api/test/delete-public-tournament-lib.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { buildDeletePublicTournamentSql } from '../scripts/delete-public-tournament-lib.mjs';
+
+describe('delete public tournament sql builder', () => {
+  it('builds a soft-delete statement with audit insert', () => {
+    const sql = buildDeletePublicTournamentSql({
+      publicId: "public-'id",
+      deletedAt: '2026-04-19T12:00:00.000Z',
+      reason: "moderator's note",
+      requestFingerprint: 'ops:tester',
+    });
+
+    expect(sql).toContain('UPDATE public_tournaments SET deleted_at');
+    expect(sql).toContain('INSERT INTO public_tournament_audit_logs');
+    expect(sql).toContain("'public-''id'");
+    expect(sql).toContain(`'{"reason":"moderator''s note"}'`);
+  });
+});

--- a/packages/public-catalog-api/test/index.test.ts
+++ b/packages/public-catalog-api/test/index.test.ts
@@ -85,7 +85,9 @@ function createRequest(
   };
 
   if (init.body !== undefined) {
-    headers.set('Content-Type', 'application/json');
+    if (!headers.has('Content-Type')) {
+      headers.set('Content-Type', 'application/json');
+    }
     requestInit.body = JSON.stringify(init.body);
   }
 
@@ -229,6 +231,33 @@ describe('public catalog register worker', () => {
     expect(body.error.code).toBe('INVALID_PAYLOAD');
     expect(body.error.details?.reason).toBe('CHARTS_REQUIRED');
     expect(repository.auditLogs.at(-1)?.result).toBe('invalid_payload');
+  });
+
+  it('rejects non-standard json media types', async () => {
+    const repository = new InMemoryRepository();
+    const worker = createWorkerHandler({
+      createRepository: () => repository,
+      now: () => new Date('2026-04-19T12:00:00.000Z'),
+      randomUUID: () => 'public-created-id',
+    });
+
+    const response = await invokeWorker(
+      worker,
+      createRequest({
+        body: validPayload,
+        headers: {
+          'Content-Type': 'application/json-patch+json',
+        },
+      }),
+      createEnv(),
+    );
+    const body = (await response.json()) as {
+      error: { code: string };
+    };
+
+    expect(response.status).toBe(415);
+    expect(body.error.code).toBe('UNSUPPORTED_MEDIA_TYPE');
+    expect(repository.auditLogs.at(-1)?.result).toBe('unsupported_media_type');
   });
 
   it('rate limits repeated requests and stores a hashed fingerprint', async () => {

--- a/packages/public-catalog-api/test/index.test.ts
+++ b/packages/public-catalog-api/test/index.test.ts
@@ -277,4 +277,44 @@ describe('public catalog register worker', () => {
     expect(rejected.headers.get('Access-Control-Allow-Origin')).toBeNull();
     expect(repository.auditLogs.at(-1)?.result).toBe('origin_rejected');
   });
+
+  it('applies rate limiting before logging repeated disallowed origins', async () => {
+    const repository = new InMemoryRepository();
+    const worker = createWorkerHandler({
+      createRepository: () => repository,
+      now: () => new Date('2026-04-19T12:00:00.000Z'),
+      randomUUID: () => 'public-created-id',
+    });
+
+    const firstRejected = await invokeWorker(
+      worker,
+      createRequest({
+        origin: 'https://evil.example.com',
+        body: validPayload,
+      }),
+      createEnv({ RATE_LIMIT_MAX_REQUESTS: '1' }),
+    );
+    const rateLimited = await invokeWorker(
+      worker,
+      createRequest({
+        origin: 'https://evil.example.com',
+        body: {
+          ...validPayload,
+          uuid: '11111111-1111-4111-8111-111111111111',
+        },
+      }),
+      createEnv({ RATE_LIMIT_MAX_REQUESTS: '1' }),
+    );
+    const body = (await rateLimited.json()) as {
+      error: { code: string };
+    };
+
+    expect(firstRejected.status).toBe(403);
+    expect(rateLimited.status).toBe(429);
+    expect(body.error.code).toBe('RATE_LIMITED');
+    expect(repository.auditLogs.map((entry) => entry.result)).toEqual([
+      'origin_rejected',
+      'rate_limited',
+    ]);
+  });
 });

--- a/packages/public-catalog-api/test/index.test.ts
+++ b/packages/public-catalog-api/test/index.test.ts
@@ -1,8 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import {
-  createWorkerHandler,
-  REGISTER_PUBLIC_TOURNAMENT_PATH,
-} from '../src/index.js';
+import { createWorkerHandler } from '../src/index.js';
+import { REGISTER_PUBLIC_TOURNAMENT_PATH } from '../src/routes.js';
 import type {
   PublicTournamentAuditLogEntry,
   PublicTournamentRecord,
@@ -95,6 +93,33 @@ function createRequest(
     `https://api.example.com${REGISTER_PUBLIC_TOURNAMENT_PATH}`,
     requestInit,
   );
+}
+
+function createStreamingRequest(rawText: string): Request {
+  const bytes = new TextEncoder().encode(rawText);
+  let offset = 0;
+
+  return {
+    url: `https://api.example.com${REGISTER_PUBLIC_TOURNAMENT_PATH}`,
+    method: 'POST',
+    headers: new Headers({
+      Origin: 'https://tts1374.github.io',
+      'CF-Connecting-IP': '203.0.113.10',
+      'Content-Type': 'application/json',
+    }),
+    body: new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (offset >= bytes.length) {
+          controller.close();
+          return;
+        }
+
+        const nextOffset = Math.min(offset + 1024, bytes.length);
+        controller.enqueue(bytes.slice(offset, nextOffset));
+        offset = nextOffset;
+      },
+    }),
+  } as Request;
 }
 
 function invokeWorker(
@@ -316,5 +341,31 @@ describe('public catalog register worker', () => {
       'origin_rejected',
       'rate_limited',
     ]);
+  });
+
+  it('rejects oversized streaming bodies before buffering the full payload', async () => {
+    const repository = new InMemoryRepository();
+    const worker = createWorkerHandler({
+      createRepository: () => repository,
+      now: () => new Date('2026-04-19T12:00:00.000Z'),
+      randomUUID: () => 'public-created-id',
+    });
+    const oversizedBody = JSON.stringify({
+      ...validPayload,
+      name: 'A'.repeat(33000),
+    });
+
+    const response = await invokeWorker(
+      worker,
+      createStreamingRequest(oversizedBody),
+      createEnv(),
+    );
+    const body = (await response.json()) as {
+      error: { code: string };
+    };
+
+    expect(response.status).toBe(413);
+    expect(body.error.code).toBe('PAYLOAD_TOO_LARGE');
+    expect(repository.auditLogs.at(-1)?.result).toBe('payload_too_large');
   });
 });

--- a/packages/public-catalog-api/test/index.test.ts
+++ b/packages/public-catalog-api/test/index.test.ts
@@ -260,6 +260,37 @@ describe('public catalog register worker', () => {
     expect(repository.auditLogs.at(-1)?.result).toBe('unsupported_media_type');
   });
 
+  it('accepts application json with charset parameter', async () => {
+    const repository = new InMemoryRepository();
+    const worker = createWorkerHandler({
+      createRepository: () => repository,
+      now: () => new Date('2026-04-19T12:00:00.000Z'),
+      randomUUID: () => 'public-created-id',
+    });
+
+    const response = await invokeWorker(
+      worker,
+      createRequest({
+        body: validPayload,
+        headers: {
+          'Content-Type': 'application/json; charset=utf-8',
+        },
+      }),
+      createEnv(),
+    );
+    const body = (await response.json()) as {
+      status: string;
+      publicId: string;
+    };
+
+    expect(response.status).toBe(201);
+    expect(body).toEqual({
+      status: 'created',
+      publicId: 'public-created-id',
+    });
+    expect(repository.auditLogs.at(-1)?.result).toBe('accepted');
+  });
+
   it('rate limits repeated requests and stores a hashed fingerprint', async () => {
     const repository = new InMemoryRepository();
     const worker = createWorkerHandler({

--- a/packages/public-catalog-api/test/index.test.ts
+++ b/packages/public-catalog-api/test/index.test.ts
@@ -1,0 +1,280 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createWorkerHandler,
+  REGISTER_PUBLIC_TOURNAMENT_PATH,
+} from '../src/index.js';
+import type {
+  PublicTournamentAuditLogEntry,
+  PublicTournamentRecord,
+  PublicTournamentRepository,
+} from '../src/repository/public-tournaments.js';
+
+class InMemoryRepository implements PublicTournamentRepository {
+  readonly recordsByPublicId = new Map<string, PublicTournamentRecord>();
+  readonly recordsByRegistryHash = new Map<string, PublicTournamentRecord>();
+  readonly auditLogs: PublicTournamentAuditLogEntry[] = [];
+
+  async countRecentAttempts(
+    requestFingerprint: string,
+    sinceInclusive: string,
+  ): Promise<number> {
+    return this.auditLogs.filter(
+      (entry) =>
+        entry.requestFingerprint === requestFingerprint &&
+        entry.createdAt >= sinceInclusive &&
+        entry.result !== 'deleted',
+    ).length;
+  }
+
+  async getByRegistryHash(
+    registryHash: string,
+  ): Promise<PublicTournamentRecord | null> {
+    return this.recordsByRegistryHash.get(registryHash) ?? null;
+  }
+
+  async create(record: PublicTournamentRecord): Promise<boolean> {
+    if (this.recordsByRegistryHash.has(record.registryHash)) {
+      return false;
+    }
+
+    this.recordsByPublicId.set(record.publicId, record);
+    this.recordsByRegistryHash.set(record.registryHash, record);
+    return true;
+  }
+
+  async insertAuditLog(entry: PublicTournamentAuditLogEntry): Promise<void> {
+    this.auditLogs.push(entry);
+  }
+}
+
+const validPayload = {
+  v: 1,
+  uuid: '9f5fb95d-0f2a-4270-81c9-a7f4b58f32af',
+  name: 'PUBLIC TOURNAMENT',
+  owner: 'owner',
+  hashtag: 'iidx',
+  start: '2026-02-01',
+  end: '2026-02-28',
+  charts: [200, 100],
+};
+
+function createEnv(overrides: Partial<Record<string, string>> = {}) {
+  return {
+    DB: {} as D1Database,
+    ALLOWED_ORIGINS: 'https://tts1374.github.io',
+    RATE_LIMIT_SALT: 'test-salt',
+    RATE_LIMIT_MAX_REQUESTS: '10',
+    RATE_LIMIT_WINDOW_SECONDS: '3600',
+    ...overrides,
+  };
+}
+
+function createRequest(
+  init: {
+    method?: string;
+    origin?: string;
+    body?: unknown;
+    headers?: Record<string, string>;
+  } = {},
+): Request {
+  const headers = new Headers(init.headers);
+  headers.set('Origin', init.origin ?? 'https://tts1374.github.io');
+  headers.set('CF-Connecting-IP', '203.0.113.10');
+
+  const requestInit: RequestInit = {
+    method: init.method ?? 'POST',
+    headers,
+  };
+
+  if (init.body !== undefined) {
+    headers.set('Content-Type', 'application/json');
+    requestInit.body = JSON.stringify(init.body);
+  }
+
+  return new Request(
+    `https://api.example.com${REGISTER_PUBLIC_TOURNAMENT_PATH}`,
+    requestInit,
+  );
+}
+
+function invokeWorker(
+  worker: ReturnType<typeof createWorkerHandler>,
+  request: Request,
+  env: ReturnType<typeof createEnv>,
+): Promise<Response> {
+  return Promise.resolve(
+    worker.fetch!(
+      request as Request<unknown, IncomingRequestCfProperties<unknown>>,
+      env,
+      {} as ExecutionContext,
+    ),
+  );
+}
+
+describe('public catalog register worker', () => {
+  it('creates a public tournament and returns a publicId', async () => {
+    const repository = new InMemoryRepository();
+    const worker = createWorkerHandler({
+      createRepository: () => repository,
+      now: () => new Date('2026-04-19T12:00:00.000Z'),
+      randomUUID: () => 'public-created-id',
+    });
+
+    const response = await invokeWorker(
+      worker,
+      createRequest({ body: validPayload }),
+      createEnv(),
+    );
+    const body = (await response.json()) as {
+      status: string;
+      publicId: string;
+    };
+
+    expect(response.status).toBe(201);
+    expect(body).toEqual({
+      status: 'created',
+      publicId: 'public-created-id',
+    });
+    expect(repository.recordsByPublicId.size).toBe(1);
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe(
+      'https://tts1374.github.io',
+    );
+  });
+
+  it('returns duplicate when the same registry hash is registered again', async () => {
+    const repository = new InMemoryRepository();
+    const generatedIds = ['public-first-id', 'public-second-id'];
+    const worker = createWorkerHandler({
+      createRepository: () => repository,
+      now: () => new Date('2026-04-19T12:00:00.000Z'),
+      randomUUID: () => generatedIds.shift() ?? 'fallback-id',
+    });
+
+    await invokeWorker(worker, createRequest({ body: validPayload }), createEnv());
+    const duplicateResponse = await invokeWorker(
+      worker,
+      createRequest({
+        body: {
+          ...validPayload,
+          uuid: '11111111-1111-4111-8111-111111111111',
+        },
+      }),
+      createEnv(),
+    );
+
+    const body = (await duplicateResponse.json()) as {
+      status: string;
+      publicId: string;
+    };
+
+    expect(duplicateResponse.status).toBe(200);
+    expect(body).toEqual({
+      status: 'duplicate',
+      publicId: 'public-first-id',
+    });
+    expect(repository.recordsByPublicId.size).toBe(1);
+  });
+
+  it('rejects invalid payloads and records an audit log', async () => {
+    const repository = new InMemoryRepository();
+    const worker = createWorkerHandler({
+      createRepository: () => repository,
+      now: () => new Date('2026-04-19T12:00:00.000Z'),
+      randomUUID: () => 'public-created-id',
+    });
+
+    const response = await invokeWorker(
+      worker,
+      createRequest({
+        body: {
+          ...validPayload,
+          charts: [],
+        },
+      }),
+      createEnv(),
+    );
+    const body = (await response.json()) as {
+      error: {
+        code: string;
+        details?: { reason?: string };
+      };
+    };
+
+    expect(response.status).toBe(400);
+    expect(body.error.code).toBe('INVALID_PAYLOAD');
+    expect(body.error.details?.reason).toBe('CHARTS_REQUIRED');
+    expect(repository.auditLogs.at(-1)?.result).toBe('invalid_payload');
+  });
+
+  it('rate limits repeated requests and stores a hashed fingerprint', async () => {
+    const repository = new InMemoryRepository();
+    const worker = createWorkerHandler({
+      createRepository: () => repository,
+      now: () => new Date('2026-04-19T12:00:00.000Z'),
+      randomUUID: () => 'public-created-id',
+    });
+
+    await invokeWorker(
+      worker,
+      createRequest({ body: validPayload }),
+      createEnv({ RATE_LIMIT_MAX_REQUESTS: '1' }),
+    );
+    const response = await invokeWorker(
+      worker,
+      createRequest({
+        body: {
+          ...validPayload,
+          uuid: '11111111-1111-4111-8111-111111111111',
+        },
+      }),
+      createEnv({ RATE_LIMIT_MAX_REQUESTS: '1' }),
+    );
+    const body = (await response.json()) as {
+      error: { code: string };
+    };
+
+    expect(response.status).toBe(429);
+    expect(body.error.code).toBe('RATE_LIMITED');
+    expect(repository.auditLogs.at(-1)?.result).toBe('rate_limited');
+    expect(repository.auditLogs.at(-1)?.requestFingerprint).not.toBe(
+      '203.0.113.10',
+    );
+  });
+
+  it('handles CORS allowlist for preflight and rejects disallowed origins', async () => {
+    const repository = new InMemoryRepository();
+    const worker = createWorkerHandler({
+      createRepository: () => repository,
+      now: () => new Date('2026-04-19T12:00:00.000Z'),
+      randomUUID: () => 'public-created-id',
+    });
+
+    const preflight = await invokeWorker(
+      worker,
+      createRequest({
+        method: 'OPTIONS',
+        body: undefined,
+        headers: {
+          'Access-Control-Request-Method': 'POST',
+        },
+      }),
+      createEnv(),
+    );
+    const rejected = await invokeWorker(
+      worker,
+      createRequest({
+        origin: 'https://evil.example.com',
+        body: validPayload,
+      }),
+      createEnv(),
+    );
+
+    expect(preflight.status).toBe(204);
+    expect(preflight.headers.get('Access-Control-Allow-Origin')).toBe(
+      'https://tts1374.github.io',
+    );
+    expect(rejected.status).toBe(403);
+    expect(rejected.headers.get('Access-Control-Allow-Origin')).toBeNull();
+    expect(repository.auditLogs.at(-1)?.result).toBe('origin_rejected');
+  });
+});

--- a/packages/public-catalog-api/tsconfig.json
+++ b/packages/public-catalog-api/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "dist",
+    "declaration": true,
+    "types": ["@cloudflare/workers-types"]
+  },
+  "include": ["src", "test", "scripts/**/*.d.mts"]
+}

--- a/packages/public-catalog-api/wrangler.jsonc
+++ b/packages/public-catalog-api/wrangler.jsonc
@@ -1,0 +1,25 @@
+{
+  "$schema": "./node_modules/wrangler/config-schema.json",
+  "name": "iidx-public-catalog-api",
+  "main": "src/index.ts",
+  "compatibility_date": "2026-04-19",
+  "compatibility_flags": ["nodejs_compat"],
+  "observability": {
+    "enabled": true,
+    "head_sampling_rate": 1
+  },
+  "vars": {
+    "ALLOWED_ORIGINS": "https://tts1374.github.io",
+    "RATE_LIMIT_MAX_REQUESTS": "10",
+    "RATE_LIMIT_WINDOW_SECONDS": "3600"
+  },
+  "d1_databases": [
+    {
+      "binding": "DB",
+      "database_name": "iidx-public-catalog",
+      "database_id": "00000000-0000-0000-0000-000000000000",
+      "preview_database_id": "00000000-0000-0000-0000-000000000000",
+      "migrations_dir": "./migrations"
+    }
+  ]
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -4,5 +4,6 @@ export * from './errors.js';
 export * from './hash.js';
 export * from './normalize.js';
 export * from './payload.js';
+export * from './public-catalog.js';
 export * from './types.js';
 export * from './validation.js';

--- a/packages/shared/src/public-catalog.ts
+++ b/packages/shared/src/public-catalog.ts
@@ -1,0 +1,68 @@
+import type { ErrorParams } from './errors.js';
+import type { TournamentPayload } from './types.js';
+import { sha256Text } from './hash.js';
+import {
+  canonicalTournamentPayload,
+  normalizeTournamentPayload,
+} from './normalize.js';
+
+export type PublicTournamentRegisterRequest = TournamentPayload;
+
+export type PublicTournamentRegisterStatus = 'created' | 'duplicate';
+
+export interface PublicTournamentRegisterResponse {
+  status: PublicTournamentRegisterStatus;
+  publicId: string;
+}
+
+export type PublicCatalogApiErrorCode =
+  | 'BAD_REQUEST'
+  | 'INVALID_JSON'
+  | 'INVALID_PAYLOAD'
+  | 'INTERNAL_ERROR'
+  | 'METHOD_NOT_ALLOWED'
+  | 'NOT_FOUND'
+  | 'ORIGIN_NOT_ALLOWED'
+  | 'PAYLOAD_TOO_LARGE'
+  | 'RATE_LIMITED'
+  | 'UNSUPPORTED_MEDIA_TYPE';
+
+export interface PublicCatalogApiError {
+  code: PublicCatalogApiErrorCode;
+  message: string;
+  details?: ErrorParams;
+}
+
+export interface PublicCatalogApiErrorResponse {
+  error: PublicCatalogApiError;
+}
+
+export interface PublicTournamentRegistryCanonicalPayload {
+  name: string;
+  owner: string;
+  hashtag: string;
+  start: string;
+  end: string;
+  charts: number[];
+}
+
+export function canonicalPublicTournamentRegistryPayload(
+  payload: TournamentPayload,
+): PublicTournamentRegistryCanonicalPayload {
+  const canonical = canonicalTournamentPayload(normalizeTournamentPayload(payload));
+
+  return {
+    name: canonical.name,
+    owner: canonical.owner,
+    hashtag: canonical.hashtag,
+    start: canonical.start,
+    end: canonical.end,
+    charts: canonical.charts,
+  };
+}
+
+export function buildPublicTournamentRegistryHash(payload: TournamentPayload): string {
+  return sha256Text(
+    JSON.stringify(canonicalPublicTournamentRegistryPayload(payload)),
+  );
+}

--- a/packages/shared/test/public-catalog.test.ts
+++ b/packages/shared/test/public-catalog.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildPublicTournamentRegistryHash,
+  buildTournamentDefHash,
+  canonicalPublicTournamentRegistryPayload,
+} from '../src/index.js';
+
+const basePayload = {
+  v: 1,
+  uuid: '9f5fb95d-0f2a-4270-81c9-a7f4b58f32af',
+  name: 'PUBLIC TOURNAMENT',
+  owner: 'owner',
+  hashtag: 'iidx',
+  start: '2026-02-01',
+  end: '2026-02-28',
+  charts: [300, 100],
+};
+
+describe('public catalog helpers', () => {
+  it('builds registry hash without uuid influence', () => {
+    const a = buildPublicTournamentRegistryHash(basePayload);
+    const b = buildPublicTournamentRegistryHash({
+      ...basePayload,
+      uuid: '11111111-1111-4111-8111-111111111111',
+    });
+
+    expect(a).toBe(b);
+  });
+
+  it('sorts charts for registry hash canonicalization', () => {
+    const a = buildPublicTournamentRegistryHash(basePayload);
+    const b = buildPublicTournamentRegistryHash({
+      ...basePayload,
+      charts: [100, 300],
+    });
+
+    expect(a).toBe(b);
+  });
+
+  it('keeps def hash behavior unchanged', () => {
+    const a = buildTournamentDefHash(basePayload);
+    const b = buildTournamentDefHash({
+      ...basePayload,
+      uuid: '11111111-1111-4111-8111-111111111111',
+    });
+
+    expect(a).not.toBe(b);
+  });
+
+  it('excludes payload version and uuid from canonical registry payload', () => {
+    expect(canonicalPublicTournamentRegistryPayload(basePayload)).toEqual({
+      name: 'PUBLIC TOURNAMENT',
+      owner: 'owner',
+      hashtag: 'iidx',
+      start: '2026-02-01',
+      end: '2026-02-28',
+      charts: [100, 300],
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,6 +37,22 @@ importers:
         specifier: ^2.1.8
         version: 2.1.9(@types/node@22.19.11)(jsdom@25.0.1)
 
+  packages/public-catalog-api:
+    dependencies:
+      '@iidx/shared':
+        specifier: workspace:*
+        version: link:../shared
+    devDependencies:
+      '@cloudflare/workers-types':
+        specifier: ^4.20260418.1
+        version: 4.20260418.1
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.9(@types/node@22.19.11)(jsdom@25.0.1)
+      wrangler:
+        specifier: ^4.83.0
+        version: 4.83.0(@cloudflare/workers-types@4.20260418.1)
+
   packages/pwa:
     devDependencies:
       vitest:
@@ -227,6 +243,56 @@ packages:
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
+  '@cloudflare/kv-asset-handler@0.4.2':
+    resolution: {integrity: sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@cloudflare/unenv-preset@2.16.0':
+    resolution: {integrity: sha512-8ovsRpwzPoEqPUzoErAYVv8l3FMZNeBVQfJTvtzP4AgLSRGZISRfuChFxHWUQd3n6cnrwkuTGxT+2cGo8EsyYg==}
+    peerDependencies:
+      unenv: 2.0.0-rc.24
+      workerd: 1.20260301.1 || ~1.20260302.1 || ~1.20260303.1 || ~1.20260304.1 || >1.20260305.0 <2.0.0-0
+    peerDependenciesMeta:
+      workerd:
+        optional: true
+
+  '@cloudflare/workerd-darwin-64@1.20260415.1':
+    resolution: {integrity: sha512-dsxaKsQm3LnPGNPEdsRv09QN3Y4DqCw7kX5j6noKqbAtro2jTr95sVlYM1jUxZ5FkOl1f7SXgaKKB9t5H5Nkbg==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@cloudflare/workerd-darwin-arm64@1.20260415.1':
+    resolution: {integrity: sha512-+JgSgVA49KyKteHRA1SnonE4Zn5Ei5zdAp5FQMxFmXI8qulZw4Hl7safXxRyK4i9sTO8gl7TFOKO5Q64VPvSDQ==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@cloudflare/workerd-linux-64@1.20260415.1':
+    resolution: {integrity: sha512-tU+9pwsqCy8afOVlGtiWrWQc/fedQK4SRm4KPIAt+zOiQWDxWASm6YGBUJis5c648WN80yz47qnmdDi8DQNOcA==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [linux]
+
+  '@cloudflare/workerd-linux-arm64@1.20260415.1':
+    resolution: {integrity: sha512-bR9uITnV19r5NQ14xnypi2xHXu2iQvfYV8cVgx0JouFUmWwTEEAwFVojDdssGq93VHX9hr/pi2IRUZeegbYBog==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@cloudflare/workerd-windows-64@1.20260415.1':
+    resolution: {integrity: sha512-4NuMLlerI0Ijua3Ir8HXQ+qyNvCUDEG5gDco5Om+sAiK6rnWiz+aGoSlbB8W16yW9QAgzCstbmXLiVknUBflfQ==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [win32]
+
+  '@cloudflare/workers-types@4.20260418.1':
+    resolution: {integrity: sha512-bywXb2XmeSqrLCQYipcupLneqx015YhhNWz2v9b9iatpe8Cg551vP7ZuD5S2a6GfBka0dDnO70kIBiBvFglcrg==}
+
+  '@cspotcode/source-map-support@0.8.1':
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
+
   '@csstools/color-helpers@5.1.0':
     resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
     engines: {node: '>=18'}
@@ -254,6 +320,9 @@ packages:
   '@csstools/css-tokenizer@3.0.4':
     resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
   '@emotion/babel-plugin@11.13.5':
     resolution: {integrity: sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==}
@@ -315,9 +384,21 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.27.3':
+    resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.21.5':
     resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
     engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.27.3':
+    resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
@@ -327,9 +408,21 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.27.3':
+    resolution: {integrity: sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.21.5':
     resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.3':
+    resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
@@ -339,9 +432,21 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.27.3':
+    resolution: {integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.21.5':
     resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.3':
+    resolution: {integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
@@ -351,9 +456,21 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.27.3':
+    resolution: {integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.21.5':
     resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.3':
+    resolution: {integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
@@ -363,9 +480,21 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.27.3':
+    resolution: {integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.21.5':
     resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
     engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.3':
+    resolution: {integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
@@ -375,9 +504,21 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.27.3':
+    resolution: {integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.21.5':
     resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
     engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.3':
+    resolution: {integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==}
+    engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
@@ -387,9 +528,21 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.27.3':
+    resolution: {integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.21.5':
     resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
     engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.3':
+    resolution: {integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
@@ -399,9 +552,21 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.27.3':
+    resolution: {integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.21.5':
     resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
     engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.3':
+    resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
+    engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
@@ -411,11 +576,35 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.27.3':
+    resolution: {integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.21.5':
     resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.3':
+    resolution: {integrity: sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
 
   '@esbuild/openbsd-x64@0.21.5':
     resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
@@ -423,9 +612,27 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.27.3':
+    resolution: {integrity: sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.3':
+    resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@esbuild/sunos-x64@0.21.5':
     resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.27.3':
+    resolution: {integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
@@ -435,15 +642,170 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-arm64@0.27.3':
+    resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.21.5':
     resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.27.3':
+    resolution: {integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.21.5':
     resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.3':
+    resolution: {integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
+    engines: {node: '>=18'}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.34.5':
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linux-arm64@0.34.5':
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linux-arm@0.34.5':
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@img/sharp-linux-s390x@0.34.5':
+    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-linux-x64@0.34.5':
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-wasm32@0.34.5':
+    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-arm64@0.34.5':
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.34.5':
+    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.34.5':
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [win32]
 
@@ -462,6 +824,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@jridgewell/trace-mapping@0.3.9':
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
   '@mui/core-downloads-tracker@7.3.8':
     resolution: {integrity: sha512-s9UHZo7QJVly7gNArEZkbbsimHqJZhElgBpXIJdehZ4OWXt+CCr0SBDgUCDJnQrqpd1dWK2dLq5rmO4mCBmI3w==}
@@ -604,6 +969,15 @@ packages:
   '@popperjs/core@2.11.8':
     resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
 
+  '@poppinss/colors@4.1.6':
+    resolution: {integrity: sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==}
+
+  '@poppinss/dumper@0.6.5':
+    resolution: {integrity: sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==}
+
+  '@poppinss/exception@1.2.3':
+    resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
+
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
 
@@ -731,6 +1105,13 @@ packages:
     resolution: {integrity: sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==}
     cpu: [x64]
     os: [win32]
+
+  '@sindresorhus/is@7.2.0':
+    resolution: {integrity: sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==}
+    engines: {node: '>=18'}
+
+  '@speed-highlight/core@1.2.15':
+    resolution: {integrity: sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==}
 
   '@sqlite.org/sqlite-wasm@3.51.2-build6':
     resolution: {integrity: sha512-5ibsgipkqcLINZ5qNSp5KfrtL6KwiNVtwBksNO6zhTghhLmEf3/u1sPoAkgH5RzuLpMw7zi50IWgkZ0WhfqpaA==}
@@ -882,6 +1263,9 @@ packages:
     resolution: {integrity: sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==}
     hasBin: true
 
+  blake3-wasm@2.1.5:
+    resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
+
   browserslist@4.28.1:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
@@ -938,6 +1322,10 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
+
   cosmiconfig@7.1.0:
     resolution: {integrity: sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==}
     engines: {node: '>=10'}
@@ -984,6 +1372,10 @@ packages:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
 
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
   dijkstrajs@1.0.3:
     resolution: {integrity: sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==}
 
@@ -1010,6 +1402,9 @@ packages:
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
 
+  error-stack-parser-es@1.0.5:
+    resolution: {integrity: sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==}
+
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
     engines: {node: '>= 0.4'}
@@ -1032,6 +1427,11 @@ packages:
   esbuild@0.21.5:
     resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
     engines: {node: '>=12'}
+    hasBin: true
+
+  esbuild@0.27.3:
+    resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
+    engines: {node: '>=18'}
     hasBin: true
 
   escalade@3.2.0:
@@ -1176,6 +1576,10 @@ packages:
   jsqr@1.4.0:
     resolution: {integrity: sha512-dxLob7q65Xg2DvstYkRpkYtmKm2sPJ9oFhrhmudT1dZvNFFTlroai3AWSpLey/w5vMcLBXRgOJsbXpdN9HzU/A==}
 
+  kleur@4.1.5:
+    resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
+    engines: {node: '>=6'}
+
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
@@ -1214,6 +1618,11 @@ packages:
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
+
+  miniflare@4.20260415.0:
+    resolution: {integrity: sha512-JoExRWN4YBI2luA5BoSMFEgi8rQWXUGzo3mtE+58VXCLV3jj/Xnk5Yeqs/IXWz8Es5GJIaq6BtsixDvAxXSIng==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -1266,12 +1675,18 @@ packages:
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
+  path-to-regexp@6.3.0:
+    resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
+
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
   pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   pathval@2.0.1:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
@@ -1392,8 +1807,17 @@ packages:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
+
+  sharp@0.34.5:
+    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -1425,6 +1849,10 @@ packages:
 
   stylis@4.2.0:
     resolution: {integrity: sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==}
+
+  supports-color@10.2.2:
+    resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
+    engines: {node: '>=18'}
 
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
@@ -1466,6 +1894,9 @@ packages:
     resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
     engines: {node: '>=18'}
 
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -1473,6 +1904,13 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici@7.24.8:
+    resolution: {integrity: sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==}
+    engines: {node: '>=20.18.1'}
+
+  unenv@2.0.0-rc.24:
+    resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
 
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
@@ -1579,9 +2017,36 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  workerd@1.20260415.1:
+    resolution: {integrity: sha512-phyPjRnx+mQDfkhN9ENPioL1L0SdhYs4S0YmJK/xF9Oga+ykNfdSy1MHnsOj8yqnOV96zcVQMx32dJ0r3pq0jQ==}
+    engines: {node: '>=16'}
+    hasBin: true
+
+  wrangler@4.83.0:
+    resolution: {integrity: sha512-gw5g3LCiuAqVWxaoKY6+quE0HzAUEFb/FV3oAlNkE1ttd4XP3FiV91XDkkzUCcdqxS4WjhQvPhIDBNdhEi8P0A==}
+    engines: {node: '>=20.3.0'}
+    hasBin: true
+    peerDependencies:
+      '@cloudflare/workers-types': ^4.20260415.1
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
+
   wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
     engines: {node: '>=8'}
+
+  ws@8.18.0:
+    resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   ws@8.19.0:
     resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
@@ -1619,6 +2084,12 @@ packages:
   yargs@15.4.1:
     resolution: {integrity: sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==}
     engines: {node: '>=8'}
+
+  youch-core@0.3.3:
+    resolution: {integrity: sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==}
+
+  youch@4.1.0-beta.10:
+    resolution: {integrity: sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==}
 
 snapshots:
 
@@ -1744,6 +2215,35 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
+  '@cloudflare/kv-asset-handler@0.4.2': {}
+
+  '@cloudflare/unenv-preset@2.16.0(unenv@2.0.0-rc.24)(workerd@1.20260415.1)':
+    dependencies:
+      unenv: 2.0.0-rc.24
+    optionalDependencies:
+      workerd: 1.20260415.1
+
+  '@cloudflare/workerd-darwin-64@1.20260415.1':
+    optional: true
+
+  '@cloudflare/workerd-darwin-arm64@1.20260415.1':
+    optional: true
+
+  '@cloudflare/workerd-linux-64@1.20260415.1':
+    optional: true
+
+  '@cloudflare/workerd-linux-arm64@1.20260415.1':
+    optional: true
+
+  '@cloudflare/workerd-windows-64@1.20260415.1':
+    optional: true
+
+  '@cloudflare/workers-types@4.20260418.1': {}
+
+  '@cspotcode/source-map-support@0.8.1':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
+
   '@csstools/color-helpers@5.1.0': {}
 
   '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
@@ -1763,6 +2263,11 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.4
 
   '@csstools/css-tokenizer@3.0.4': {}
+
+  '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
 
   '@emotion/babel-plugin@11.13.5':
     dependencies:
@@ -1850,70 +2355,244 @@ snapshots:
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
 
+  '@esbuild/aix-ppc64@0.27.3':
+    optional: true
+
   '@esbuild/android-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.3':
     optional: true
 
   '@esbuild/android-arm@0.21.5':
     optional: true
 
+  '@esbuild/android-arm@0.27.3':
+    optional: true
+
   '@esbuild/android-x64@0.21.5':
+    optional: true
+
+  '@esbuild/android-x64@0.27.3':
     optional: true
 
   '@esbuild/darwin-arm64@0.21.5':
     optional: true
 
+  '@esbuild/darwin-arm64@0.27.3':
+    optional: true
+
   '@esbuild/darwin-x64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.3':
     optional: true
 
   '@esbuild/freebsd-arm64@0.21.5':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.27.3':
+    optional: true
+
   '@esbuild/freebsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.3':
     optional: true
 
   '@esbuild/linux-arm64@0.21.5':
     optional: true
 
+  '@esbuild/linux-arm64@0.27.3':
+    optional: true
+
   '@esbuild/linux-arm@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.3':
     optional: true
 
   '@esbuild/linux-ia32@0.21.5':
     optional: true
 
+  '@esbuild/linux-ia32@0.27.3':
+    optional: true
+
   '@esbuild/linux-loong64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.3':
     optional: true
 
   '@esbuild/linux-mips64el@0.21.5':
     optional: true
 
+  '@esbuild/linux-mips64el@0.27.3':
+    optional: true
+
   '@esbuild/linux-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.3':
     optional: true
 
   '@esbuild/linux-riscv64@0.21.5':
     optional: true
 
+  '@esbuild/linux-riscv64@0.27.3':
+    optional: true
+
   '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.3':
     optional: true
 
   '@esbuild/linux-x64@0.21.5':
     optional: true
 
+  '@esbuild/linux-x64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.3':
+    optional: true
+
   '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.3':
     optional: true
 
   '@esbuild/openbsd-x64@0.21.5':
     optional: true
 
+  '@esbuild/openbsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.3':
+    optional: true
+
   '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.3':
     optional: true
 
   '@esbuild/win32-arm64@0.21.5':
     optional: true
 
+  '@esbuild/win32-arm64@0.27.3':
+    optional: true
+
   '@esbuild/win32-ia32@0.21.5':
     optional: true
 
+  '@esbuild/win32-ia32@0.27.3':
+    optional: true
+
   '@esbuild/win32-x64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.3':
+    optional: true
+
+  '@img/colour@1.1.0': {}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-darwin-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-s390x@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-wasm32@0.34.5':
+    dependencies:
+      '@emnapi/runtime': 1.10.0
+    optional: true
+
+  '@img/sharp-win32-arm64@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-ia32@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.34.5':
     optional: true
 
   '@jridgewell/gen-mapping@0.3.13':
@@ -1931,6 +2610,11 @@ snapshots:
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@jridgewell/trace-mapping@0.3.9':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -2056,6 +2740,18 @@ snapshots:
 
   '@popperjs/core@2.11.8': {}
 
+  '@poppinss/colors@4.1.6':
+    dependencies:
+      kleur: 4.1.5
+
+  '@poppinss/dumper@0.6.5':
+    dependencies:
+      '@poppinss/colors': 4.1.6
+      '@sindresorhus/is': 7.2.0
+      supports-color: 10.2.2
+
+  '@poppinss/exception@1.2.3': {}
+
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
   '@rollup/rollup-android-arm-eabi@4.57.1':
@@ -2132,6 +2828,10 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.57.1':
     optional: true
+
+  '@sindresorhus/is@7.2.0': {}
+
+  '@speed-highlight/core@1.2.15': {}
 
   '@sqlite.org/sqlite-wasm@3.51.2-build6': {}
 
@@ -2297,6 +2997,8 @@ snapshots:
 
   baseline-browser-mapping@2.9.19: {}
 
+  blake3-wasm@2.1.5: {}
+
   browserslist@4.28.1:
     dependencies:
       baseline-browser-mapping: 2.9.19
@@ -2350,6 +3052,8 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  cookie@1.1.1: {}
+
   cosmiconfig@7.1.0:
     dependencies:
       '@types/parse-json': 4.0.2
@@ -2386,6 +3090,8 @@ snapshots:
 
   dequal@2.0.3: {}
 
+  detect-libc@2.1.2: {}
+
   dijkstrajs@1.0.3: {}
 
   dom-accessibility-api@0.5.16: {}
@@ -2410,6 +3116,8 @@ snapshots:
   error-ex@1.3.4:
     dependencies:
       is-arrayish: 0.2.1
+
+  error-stack-parser-es@1.0.5: {}
 
   es-define-property@1.0.1: {}
 
@@ -2453,6 +3161,35 @@ snapshots:
       '@esbuild/win32-arm64': 0.21.5
       '@esbuild/win32-ia32': 0.21.5
       '@esbuild/win32-x64': 0.21.5
+
+  esbuild@0.27.3:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.3
+      '@esbuild/android-arm': 0.27.3
+      '@esbuild/android-arm64': 0.27.3
+      '@esbuild/android-x64': 0.27.3
+      '@esbuild/darwin-arm64': 0.27.3
+      '@esbuild/darwin-x64': 0.27.3
+      '@esbuild/freebsd-arm64': 0.27.3
+      '@esbuild/freebsd-x64': 0.27.3
+      '@esbuild/linux-arm': 0.27.3
+      '@esbuild/linux-arm64': 0.27.3
+      '@esbuild/linux-ia32': 0.27.3
+      '@esbuild/linux-loong64': 0.27.3
+      '@esbuild/linux-mips64el': 0.27.3
+      '@esbuild/linux-ppc64': 0.27.3
+      '@esbuild/linux-riscv64': 0.27.3
+      '@esbuild/linux-s390x': 0.27.3
+      '@esbuild/linux-x64': 0.27.3
+      '@esbuild/netbsd-arm64': 0.27.3
+      '@esbuild/netbsd-x64': 0.27.3
+      '@esbuild/openbsd-arm64': 0.27.3
+      '@esbuild/openbsd-x64': 0.27.3
+      '@esbuild/openharmony-arm64': 0.27.3
+      '@esbuild/sunos-x64': 0.27.3
+      '@esbuild/win32-arm64': 0.27.3
+      '@esbuild/win32-ia32': 0.27.3
+      '@esbuild/win32-x64': 0.27.3
 
   escalade@3.2.0: {}
 
@@ -2607,6 +3344,8 @@ snapshots:
 
   jsqr@1.4.0: {}
 
+  kleur@4.1.5: {}
+
   lines-and-columns@1.2.4: {}
 
   locate-path@5.0.0:
@@ -2638,6 +3377,18 @@ snapshots:
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  miniflare@4.20260415.0:
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      sharp: 0.34.5
+      undici: 7.24.8
+      workerd: 1.20260415.1
+      ws: 8.18.0
+      youch: 4.1.0-beta.10
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   ms@2.1.3: {}
 
@@ -2680,9 +3431,13 @@ snapshots:
 
   path-parse@1.0.7: {}
 
+  path-to-regexp@6.3.0: {}
+
   path-type@4.0.0: {}
 
   pathe@1.1.2: {}
+
+  pathe@2.0.3: {}
 
   pathval@2.0.1: {}
 
@@ -2815,7 +3570,40 @@ snapshots:
 
   semver@6.3.1: {}
 
+  semver@7.7.4: {}
+
   set-blocking@2.0.0: {}
+
+  sharp@0.34.5:
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.7.4
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-linux-arm': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-ppc64': 0.34.5
+      '@img/sharp-linux-riscv64': 0.34.5
+      '@img/sharp-linux-s390x': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-wasm32': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-ia32': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
 
   siginfo@2.0.0: {}
 
@@ -2840,6 +3628,8 @@ snapshots:
       ansi-regex: 5.0.1
 
   stylis@4.2.0: {}
+
+  supports-color@10.2.2: {}
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
@@ -2869,9 +3659,18 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  tslib@2.8.1:
+    optional: true
+
   typescript@5.9.3: {}
 
   undici-types@6.21.0: {}
+
+  undici@7.24.8: {}
+
+  unenv@2.0.0-rc.24:
+    dependencies:
+      pathe: 2.0.3
 
   update-browserslist-db@1.2.3(browserslist@4.28.1):
     dependencies:
@@ -2972,11 +3771,38 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  workerd@1.20260415.1:
+    optionalDependencies:
+      '@cloudflare/workerd-darwin-64': 1.20260415.1
+      '@cloudflare/workerd-darwin-arm64': 1.20260415.1
+      '@cloudflare/workerd-linux-64': 1.20260415.1
+      '@cloudflare/workerd-linux-arm64': 1.20260415.1
+      '@cloudflare/workerd-windows-64': 1.20260415.1
+
+  wrangler@4.83.0(@cloudflare/workers-types@4.20260418.1):
+    dependencies:
+      '@cloudflare/kv-asset-handler': 0.4.2
+      '@cloudflare/unenv-preset': 2.16.0(unenv@2.0.0-rc.24)(workerd@1.20260415.1)
+      blake3-wasm: 2.1.5
+      esbuild: 0.27.3
+      miniflare: 4.20260415.0
+      path-to-regexp: 6.3.0
+      unenv: 2.0.0-rc.24
+      workerd: 1.20260415.1
+    optionalDependencies:
+      '@cloudflare/workers-types': 4.20260418.1
+      fsevents: 2.3.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   wrap-ansi@6.2.0:
     dependencies:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
+
+  ws@8.18.0: {}
 
   ws@8.19.0: {}
 
@@ -3008,3 +3834,16 @@ snapshots:
       which-module: 2.0.1
       y18n: 4.0.3
       yargs-parser: 18.1.3
+
+  youch-core@0.3.3:
+    dependencies:
+      '@poppinss/exception': 1.2.3
+      error-stack-parser-es: 1.0.5
+
+  youch@4.1.0-beta.10:
+    dependencies:
+      '@poppinss/colors': 4.1.6
+      '@poppinss/dumper': 0.6.5
+      '@speed-highlight/core': 1.2.15
+      cookie: 1.1.1
+      youch-core: 0.3.3

--- a/tasks/codex-feat-public-catalog-v1-register-api.md
+++ b/tasks/codex-feat-public-catalog-v1-register-api.md
@@ -1,0 +1,132 @@
+# Plan: codex/feat-public-catalog-v1-register-api
+
+## 実行コンテキスト（予定）
+
+- worktree: `C:/work/score_attack_manager/iidx_score_attack_manager-codex-public-catalog-v1-register-api`
+- branch: `codex/feat-public-catalog-v1-register-api`
+- BASE_SHA: `0e2d7d0c26b65966b518fcaacdcf56d8bb977ae1`
+
+## 目的
+
+- Cloudflare Workers + D1 上に匿名公開用の `POST /api/public-tournaments` を追加し、ローカル大会作成後に公開登録できるサーバー基盤を用意する。
+- 既存の `def_hash` や import payload 契約を変更せず、`registry_hash` による重複判定基盤を `packages/shared` と API 層で共通化する。
+- 匿名書き込み v1 の最低限運用として、IP 単位抑制・監査ログ・運営削除手段を整備する。
+
+## 非目的
+
+- 公開一覧・検索 API（#49）。
+- `payloadParam` を返す read API（#50）。
+- クライアント側の公開状態表示、再試行 UI、公開導線接続（#51）。
+- 投稿者認証、一般ユーザー向けの編集/削除 UI や公開削除 API。
+- `def_hash`、既存 import payload、Web Locks、PWA 起動導線、OPFS/SQLite ローカル保存の仕様変更。
+- ルーター導入など、Worker 実装に不要な依存追加。
+
+## 変更点
+
+- `packages/shared`
+  - 公開登録 API で使う request/response 型を追加する。
+  - 既存 `normalizeTournamentPayload` を再利用しつつ、`uuid` を重複判定対象から外した canonical object を生成する helper を追加する。
+  - `name / owner / hashtag / start / end / charts(sorted)` を入力に `registry_hash` を算出する helper を追加し、`def_hash` とは分離する。
+- `packages/public-catalog-api`（新規）
+  - Cloudflare Workers 用 package を新設し、monorepo の `build/test/lint` に参加できる最小構成を追加する。
+  - Worker エントリ、環境変数/bindings 型、CORS ユーティリティ、D1 access layer を追加する。
+  - `POST /api/public-tournaments` を実装し、payload 検証、`registry_hash` 算出、重複解決、`publicId` 発行、監査ログ記録を行う。
+  - GitHub Pages からのブラウザ呼び出しだけを許可する allowlist 型 CORS を実装し、wildcard 許可は行わない。
+  - 書き込み抑制は Cloudflare から得られるクライアント IP を直接永続化せず、ハッシュ化した request key と時間窓で判定する。
+  - 誤登録/違反登録への運営対応は browser-facing delete API ではなく、D1 に対する運営用削除手段で実現する。
+- D1 schema / access
+  - 公開大会本体テーブルを追加し、`public_id`、`registry_hash`、正規化済み payload JSON、検索用メタ、監査参照列を保持する。
+  - 監査ログテーブルを追加し、`accepted / duplicate / rate_limited / deleted` などの結果と request fingerprint を残す。
+  - `registry_hash` は unique 制約を持たせ、同一内容の再登録では既存 `publicId` を返す。
+  - 運営削除は soft-delete/tombstone 前提とし、監査履歴と重複判定キーは保持する。
+- 運営削除導線
+  - 運営用の削除手段は repo 内スクリプトまたは `wrangler d1 execute` ベースの運用コマンドとして整備し、一般公開エンドポイントは増やさない。
+  - 削除時は対象 row の公開状態変更と監査ログ追記を同時に行う。
+- 依存/設定
+  - Worker 実装に必要な最小依存だけを追加し、router/framework 依存は持ち込まない。
+  - lockfile 変更が必要な場合は Worker bootstrap コミットへ閉じ込める。
+
+## 影響範囲（ユーザー / データ / 互換性 / PWA / 保存 / 起動）
+
+- ユーザー:
+  - このブランチ単体では既存 UI の見た目は変わらない。
+  - 後続の #51 が接続される前提となる公開登録 API が追加される。
+- データ:
+  - 新規 D1 データストアに公開大会定義と監査ログを保存する。
+  - 既存 OPFS/SQLite のローカル保存データには影響しない。
+- 互換性:
+  - 既存 `def_hash` と import payload 契約は維持する。
+  - `publicId` / `registry_hash` は新規サーバー側契約として閉じる。
+- PWA:
+  - Service Worker、COOP/COEP、single-tab 制御には触れない。
+- 保存:
+  - ローカル保存方式には変更なし。追加されるのは Cloudflare D1 のみ。
+- 起動:
+  - web-app の startup/import routing には変更なし。
+- 運用:
+  - Cloudflare Worker 配備、D1 binding、許可 origin、運営削除手順が新たに必要になる。
+
+## 対象ファイル / 対象パッケージ
+
+- 対象パッケージ:
+  - `packages/shared`
+  - `packages/public-catalog-api`（新規）
+- 想定対象ファイル:
+  - `packages/shared/src/index.ts`
+  - `packages/shared/src/public-catalog.ts`（新規）
+  - `packages/shared/src/public-catalog.test.ts`（新規）
+  - `packages/public-catalog-api/package.json`（新規）
+  - `packages/public-catalog-api/tsconfig.json`（新規）
+  - `packages/public-catalog-api/wrangler.jsonc` もしくは同等の Wrangler 設定（新規）
+  - `packages/public-catalog-api/migrations/*.sql`（新規）
+  - `packages/public-catalog-api/src/index.ts`（新規）
+  - `packages/public-catalog-api/src/env.ts`（新規）
+  - `packages/public-catalog-api/src/cors.ts`（新規）
+  - `packages/public-catalog-api/src/repository/public-tournaments.ts`（新規）
+  - `packages/public-catalog-api/src/rate-limit.ts`（新規）
+  - `packages/public-catalog-api/src/*.test.ts`（新規）
+  - `packages/public-catalog-api/scripts/*`（運営削除手段が script 化される場合）
+  - `pnpm-lock.yaml`（依存追加が必要な場合のみ）
+
+### 変更スコープ固定
+
+- `packages/web-app`、`packages/db`、`packages/pwa` は本ブランチでは変更しない。
+- 親 Issue #47 で決めた `def_hash` 非変更、既存 import-confirm 導線流用、単一タブ凍結は前提として維持する。
+
+## テスト観点
+
+- shared helper:
+  - 同一内容で `uuid` だけ違う payload から同じ `registry_hash` が得られる。
+  - `charts` 順序差分があっても canonical 化後の hash が一致する。
+  - `def_hash` 既存 helper の挙動は変わらない。
+- POST API:
+  - 正常 payload で `created` と `publicId` が返る。
+  - 同一内容の再登録では新規 row を増やさず `duplicate` と既存 `publicId` を返す。
+  - 不正 payload は 4xx で拒否され、監査ログに失敗理由が残る。
+- abuse 対策:
+  - 閾値超過時に rate limit が発火し、登録は作成されず監査ログだけ残る。
+  - request fingerprint に生 IP が平文保存されない。
+- CORS:
+  - 許可 origin の preflight / POST は通る。
+  - 非許可 origin は拒否され、wildcard 応答しない。
+- 運営削除:
+  - 削除手段実行で対象 row が active 一覧から外れ、監査ログに `deleted` が記録される。
+  - tombstone 後も同一 `registry_hash` の重複防止が維持される。
+- 回帰:
+  - 既存 web-app / shared / db の build に不要な変更が混ざらない。
+  - `packages/shared` の既存 payload import/export 契約に差分がない。
+
+## ロールバック方針
+
+- コードは commit 単位で `git revert` し、Worker package と shared helper をまとめて無効化する。
+- D1 schema は既存ローカル DB と分離された加算変更なので、ロールバック時はまず Worker 配備を止めて新規流入を止める。
+- 既に作成済みの D1 テーブル/データは、運用判断に応じて保持するか、専用 SQL で後処理する。
+- 既存 web-app / OPFS / import payload には変更を入れないため、ロールバック時の互換性リスクはサーバー新設分に限定される。
+
+## コミット分割計画
+
+1. `plan`: `tasks/codex-feat-public-catalog-v1-register-api.md` を追加。
+2. `shared-contract`: `registry_hash` helper と公開登録 API 型を `packages/shared` に追加。
+3. `worker-bootstrap`: `packages/public-catalog-api` の package 基盤、Wrangler 設定、D1 migration、最小依存を追加。
+4. `write-api`: `POST /api/public-tournaments`、duplicate 解決、CORS、監査ログ、rate limit を実装。
+5. `ops-delete-and-tests`: 運営削除手段と shared/API の関連テストを追加し、最小検証を行う。


### PR DESCRIPTION
## 目的
公開カタログ v1 の #48 として、匿名公開用の POST /api/public-tournaments と registry_hash 重複判定基盤を追加します。

## 変更点
- packages/shared に公開登録 API contract と registry_hash helper を追加
- packages/public-catalog-api を新設し、Cloudflare Workers + D1 向けの write API、CORS、rate limit、監査ログを実装
- D1 migration と運営用 soft-delete script、shared/API の関連テストを追加

## 非変更点
- 公開一覧・検索 API
- payloadParam を返す read API
- web-app / db / pwa の既存挙動
- def_hash と既存 import payload 契約

## 影響範囲
- 新規 package: packages/public-catalog-api
- shared の export 追加あり
- Cloudflare Workers / D1 の新規運用設定が必要

## テスト
- pnpm build
- pnpm test
- pnpm lint