### PR TITLE
[codex] Add public catalog read API

### DIFF
--- a/packages/public-catalog-api/src/cors.ts
+++ b/packages/public-catalog-api/src/cors.ts
@@ -46,12 +46,15 @@ export function createVaryHeaders(): Headers {
   return headers;
 }
 
-export function createCorsHeaders(allowedOrigin: string): Headers {
+export function createCorsHeaders(
+  allowedOrigin: string,
+  allowedMethods: readonly string[] = ['POST', 'OPTIONS'],
+): Headers {
   const headers = createVaryHeaders();
   appendVary(headers, 'Access-Control-Request-Method');
   appendVary(headers, 'Access-Control-Request-Headers');
   headers.set('Access-Control-Allow-Origin', allowedOrigin);
-  headers.set('Access-Control-Allow-Methods', 'POST, OPTIONS');
+  headers.set('Access-Control-Allow-Methods', allowedMethods.join(', '));
   headers.set('Access-Control-Allow-Headers', 'content-type');
   headers.set('Access-Control-Max-Age', '86400');
   return headers;

--- a/packages/public-catalog-api/src/index.ts
+++ b/packages/public-catalog-api/src/index.ts
@@ -5,6 +5,7 @@ import {
   type ErrorParams,
   type PublicCatalogApiErrorCode,
   type PublicCatalogApiErrorResponse,
+  type PublicTournamentListResponse,
   type PublicTournamentRegisterResponse,
 } from '@iidx/shared';
 import {
@@ -17,6 +18,10 @@ import {
   type PublicCatalogEnv,
 } from './env.js';
 import {
+  decodePublicTournamentListCursor,
+  encodePublicTournamentListCursor,
+} from './pagination.js';
+import {
   D1PublicTournamentRepository,
   type PublicTournamentAuditLogEntry,
   type PublicTournamentAuditResult,
@@ -27,9 +32,11 @@ import {
   buildRequestFingerprint,
   getRateLimitWindowStart,
 } from './rate-limit.js';
-import { REGISTER_PUBLIC_TOURNAMENT_PATH } from './routes.js';
+import { LIST_PUBLIC_TOURNAMENTS_PATH } from './routes.js';
 
 const MAX_REQUEST_BODY_BYTES = 32 * 1024;
+const PUBLIC_TOURNAMENTS_ROUTE_METHODS = ['GET', 'POST', 'OPTIONS'] as const;
+const PUBLIC_TOURNAMENTS_PAGE_SIZE = 20;
 
 class ApiError extends Error {
   constructor(
@@ -60,12 +67,15 @@ function mergeHeaders(target: Headers, source: Headers): void {
   });
 }
 
-function buildJsonHeaders(allowedOrigin: string | null): Headers {
+function buildJsonHeaders(
+  allowedOrigin: string | null,
+  allowedMethods: readonly string[] = PUBLIC_TOURNAMENTS_ROUTE_METHODS,
+): Headers {
   const headers = createVaryHeaders();
   headers.set('Cache-Control', 'no-store');
   headers.set('Content-Type', 'application/json; charset=utf-8');
   if (allowedOrigin) {
-    mergeHeaders(headers, createCorsHeaders(allowedOrigin));
+    mergeHeaders(headers, createCorsHeaders(allowedOrigin, allowedMethods));
   }
   return headers;
 }
@@ -74,9 +84,10 @@ function jsonResponse<T>(
   status: number,
   body: T,
   allowedOrigin: string | null,
+  allowedMethods: readonly string[] = PUBLIC_TOURNAMENTS_ROUTE_METHODS,
   extraHeaders?: HeadersInit,
 ): Response {
-  const headers = buildJsonHeaders(allowedOrigin);
+  const headers = buildJsonHeaders(allowedOrigin, allowedMethods);
   if (extraHeaders) {
     mergeHeaders(headers, new Headers(extraHeaders));
   }
@@ -89,6 +100,7 @@ function errorResponse(
   message: string,
   allowedOrigin: string | null,
   details?: ErrorParams,
+  allowedMethods: readonly string[] = PUBLIC_TOURNAMENTS_ROUTE_METHODS,
   extraHeaders?: HeadersInit,
 ): Response {
   const body: PublicCatalogApiErrorResponse = {
@@ -99,7 +111,13 @@ function errorResponse(
     },
   };
 
-  return jsonResponse(status, body, allowedOrigin, extraHeaders);
+  return jsonResponse(
+    status,
+    body,
+    allowedOrigin,
+    allowedMethods,
+    extraHeaders,
+  );
 }
 
 function createAuditEntry(
@@ -249,6 +267,83 @@ async function createOrResolveTournament(
   return { created: false, record: existing };
 }
 
+function buildMethodNotAllowedResponse(
+  allowedOrigin: string | null,
+  allowedMethods: readonly string[],
+): Response {
+  return errorResponse(
+    405,
+    'METHOD_NOT_ALLOWED',
+    'method not allowed',
+    allowedOrigin,
+    undefined,
+    allowedMethods,
+    { Allow: allowedMethods.join(', ') },
+  );
+}
+
+function buildOriginNotAllowedResponse(
+  allowedMethods: readonly string[],
+): Response {
+  return errorResponse(
+    403,
+    'ORIGIN_NOT_ALLOWED',
+    'origin not allowed',
+    null,
+    undefined,
+    allowedMethods,
+  );
+}
+
+async function handleListPublicTournaments(
+  request: Request,
+  repository: PublicTournamentRepository,
+  allowedOrigin: string,
+): Promise<Response> {
+  const url = new URL(request.url);
+  const rawCursor = url.searchParams.get('cursor');
+  let cursor: { createdAt: string; publicId: string } | null = null;
+  if (rawCursor !== null) {
+    try {
+      cursor = decodePublicTournamentListCursor(rawCursor);
+    } catch {
+      return errorResponse(
+        400,
+        'BAD_REQUEST',
+        'cursor is invalid',
+        allowedOrigin,
+        undefined,
+        PUBLIC_TOURNAMENTS_ROUTE_METHODS,
+      );
+    }
+  }
+
+  const searchQuery = url.searchParams.get('q')?.trim() ?? '';
+  const result = await repository.listActive({
+    searchQuery: searchQuery.length > 0 ? searchQuery : null,
+    cursor,
+    limit: PUBLIC_TOURNAMENTS_PAGE_SIZE,
+  });
+  const lastItem = result.items.at(-1);
+  const responseBody: PublicTournamentListResponse = {
+    items: result.items,
+    nextCursor:
+      result.hasMore && lastItem
+        ? encodePublicTournamentListCursor({
+            createdAt: lastItem.createdAt,
+            publicId: lastItem.publicId,
+          })
+        : null,
+  };
+
+  return jsonResponse(
+    200,
+    responseBody,
+    allowedOrigin,
+    PUBLIC_TOURNAMENTS_ROUTE_METHODS,
+  );
+}
+
 export function createWorkerHandler(
   dependencies: PublicCatalogWorkerDependencies = {},
 ): ExportedHandler<PublicCatalogEnv> {
@@ -261,7 +356,7 @@ export function createWorkerHandler(
   return {
     async fetch(request, env) {
       const url = new URL(request.url);
-      if (url.pathname !== REGISTER_PUBLIC_TOURNAMENT_PATH) {
+      if (url.pathname !== LIST_PUBLIC_TOURNAMENTS_PATH) {
         if (request.method === 'OPTIONS') {
           return new Response(null, { status: 404, headers: createVaryHeaders() });
         }
@@ -272,29 +367,42 @@ export function createWorkerHandler(
       try {
         config = parsePublicCatalogConfig(env);
       } catch {
-        return errorResponse(500, 'INTERNAL_ERROR', 'worker configuration is invalid', null);
+        return errorResponse(
+          500,
+          'INTERNAL_ERROR',
+          'worker configuration is invalid',
+          null,
+        );
       }
 
-      const cors = resolveCorsContext(request.headers.get('Origin'), config.allowedOrigins);
+      const cors = resolveCorsContext(
+        request.headers.get('Origin'),
+        config.allowedOrigins,
+      );
+      const routeMethods = PUBLIC_TOURNAMENTS_ROUTE_METHODS;
       if (request.method === 'OPTIONS') {
         if (!cors.allowedOrigin) {
           return new Response(null, { status: 403, headers: createVaryHeaders() });
         }
         return new Response(null, {
           status: 204,
-          headers: createCorsHeaders(cors.allowedOrigin),
+          headers: createCorsHeaders(cors.allowedOrigin, routeMethods),
         });
       }
 
-      if (request.method !== 'POST') {
-        return errorResponse(
-          405,
-          'METHOD_NOT_ALLOWED',
-          'method not allowed',
+      if (request.method === 'GET') {
+        if (!cors.allowedOrigin) {
+          return buildOriginNotAllowedResponse(routeMethods);
+        }
+        return handleListPublicTournaments(
+          request,
+          createRepository(env.DB),
           cors.allowedOrigin,
-          undefined,
-          { Allow: 'POST, OPTIONS' },
         );
+      }
+
+      if (request.method !== 'POST') {
+        return buildMethodNotAllowedResponse(cors.allowedOrigin, routeMethods);
       }
 
       const repository = createRepository(env.DB);
@@ -323,6 +431,8 @@ export function createWorkerHandler(
           'RATE_LIMITED',
           'rate limit exceeded',
           cors.allowedOrigin,
+          undefined,
+          routeMethods,
         );
       }
 
@@ -340,7 +450,7 @@ export function createWorkerHandler(
             },
           ),
         );
-        return errorResponse(403, 'ORIGIN_NOT_ALLOWED', 'origin not allowed', null);
+        return buildOriginNotAllowedResponse(routeMethods);
       }
 
       let requestPayload: unknown;
@@ -365,6 +475,7 @@ export function createWorkerHandler(
             error.message,
             cors.allowedOrigin,
             error.details,
+            routeMethods,
           );
         }
         throw error;
@@ -390,6 +501,7 @@ export function createWorkerHandler(
             'tournament payload is invalid',
             cors.allowedOrigin,
             error.params,
+            routeMethods,
           );
         }
         throw error;
@@ -429,6 +541,7 @@ export function createWorkerHandler(
           result.created ? 201 : 200,
           responseBody,
           cors.allowedOrigin,
+          routeMethods,
         );
       } catch (error) {
         await repository.insertAuditLog(
@@ -448,6 +561,8 @@ export function createWorkerHandler(
           'INTERNAL_ERROR',
           'failed to register tournament',
           cors.allowedOrigin,
+          undefined,
+          routeMethods,
         );
       }
     },

--- a/packages/public-catalog-api/src/index.ts
+++ b/packages/public-catalog-api/src/index.ts
@@ -1,11 +1,13 @@
 import {
   PayloadValidationError,
   buildPublicTournamentRegistryHash,
+  encodeTournamentPayload,
   normalizeTournamentPayload,
   type ErrorParams,
   type PublicCatalogApiErrorCode,
   type PublicCatalogApiErrorResponse,
   type PublicTournamentListResponse,
+  type PublicTournamentPayloadResponse,
   type PublicTournamentRegisterResponse,
 } from '@iidx/shared';
 import {
@@ -32,10 +34,14 @@ import {
   buildRequestFingerprint,
   getRateLimitWindowStart,
 } from './rate-limit.js';
-import { LIST_PUBLIC_TOURNAMENTS_PATH } from './routes.js';
+import {
+  LIST_PUBLIC_TOURNAMENTS_PATH,
+  matchPublicTournamentPayloadPath,
+} from './routes.js';
 
 const MAX_REQUEST_BODY_BYTES = 32 * 1024;
 const PUBLIC_TOURNAMENTS_ROUTE_METHODS = ['GET', 'POST', 'OPTIONS'] as const;
+const PUBLIC_TOURNAMENT_PAYLOAD_ROUTE_METHODS = ['GET', 'OPTIONS'] as const;
 const PUBLIC_TOURNAMENTS_PAGE_SIZE = 20;
 
 class ApiError extends Error {
@@ -295,6 +301,20 @@ function buildOriginNotAllowedResponse(
   );
 }
 
+function buildNotFoundResponse(
+  allowedOrigin: string | null,
+  allowedMethods: readonly string[],
+): Response {
+  return errorResponse(
+    404,
+    'NOT_FOUND',
+    'public tournament not found',
+    allowedOrigin,
+    undefined,
+    allowedMethods,
+  );
+}
+
 async function handleListPublicTournaments(
   request: Request,
   repository: PublicTournamentRepository,
@@ -344,6 +364,43 @@ async function handleListPublicTournaments(
   );
 }
 
+async function handlePublicTournamentPayload(
+  publicId: string,
+  repository: PublicTournamentRepository,
+  allowedOrigin: string,
+): Promise<Response> {
+  const record = await repository.getActiveByPublicId(publicId);
+  if (!record) {
+    return buildNotFoundResponse(
+      allowedOrigin,
+      PUBLIC_TOURNAMENT_PAYLOAD_ROUTE_METHODS,
+    );
+  }
+
+  try {
+    const responseBody: PublicTournamentPayloadResponse = {
+      payloadParam: encodeTournamentPayload(JSON.parse(record.payloadJson)),
+    };
+
+    return jsonResponse(
+      200,
+      responseBody,
+      allowedOrigin,
+      PUBLIC_TOURNAMENT_PAYLOAD_ROUTE_METHODS,
+    );
+  } catch (error) {
+    console.error('public tournament payload encoding failed', error);
+    return errorResponse(
+      500,
+      'INTERNAL_ERROR',
+      'failed to load tournament payload',
+      allowedOrigin,
+      undefined,
+      PUBLIC_TOURNAMENT_PAYLOAD_ROUTE_METHODS,
+    );
+  }
+}
+
 export function createWorkerHandler(
   dependencies: PublicCatalogWorkerDependencies = {},
 ): ExportedHandler<PublicCatalogEnv> {
@@ -356,7 +413,10 @@ export function createWorkerHandler(
   return {
     async fetch(request, env) {
       const url = new URL(request.url);
-      if (url.pathname !== LIST_PUBLIC_TOURNAMENTS_PATH) {
+      const publicIdForPayload = matchPublicTournamentPayloadPath(url.pathname);
+      const isPublicTournamentCollectionPath =
+        url.pathname === LIST_PUBLIC_TOURNAMENTS_PATH;
+      if (!isPublicTournamentCollectionPath && !publicIdForPayload) {
         if (request.method === 'OPTIONS') {
           return new Response(null, { status: 404, headers: createVaryHeaders() });
         }
@@ -379,7 +439,10 @@ export function createWorkerHandler(
         request.headers.get('Origin'),
         config.allowedOrigins,
       );
-      const routeMethods = PUBLIC_TOURNAMENTS_ROUTE_METHODS;
+      const routeMethods = publicIdForPayload
+        ? PUBLIC_TOURNAMENT_PAYLOAD_ROUTE_METHODS
+        : PUBLIC_TOURNAMENTS_ROUTE_METHODS;
+
       if (request.method === 'OPTIONS') {
         if (!cors.allowedOrigin) {
           return new Response(null, { status: 403, headers: createVaryHeaders() });
@@ -388,6 +451,20 @@ export function createWorkerHandler(
           status: 204,
           headers: createCorsHeaders(cors.allowedOrigin, routeMethods),
         });
+      }
+
+      if (publicIdForPayload) {
+        if (request.method !== 'GET') {
+          return buildMethodNotAllowedResponse(cors.allowedOrigin, routeMethods);
+        }
+        if (!cors.allowedOrigin) {
+          return buildOriginNotAllowedResponse(routeMethods);
+        }
+        return handlePublicTournamentPayload(
+          publicIdForPayload,
+          createRepository(env.DB),
+          cors.allowedOrigin,
+        );
       }
 
       if (request.method === 'GET') {

--- a/packages/public-catalog-api/src/pagination.ts
+++ b/packages/public-catalog-api/src/pagination.ts
@@ -1,0 +1,80 @@
+import type { PublicTournamentListCursor } from '@iidx/shared';
+
+export interface PublicTournamentPageCursor {
+  createdAt: string;
+  publicId: string;
+}
+
+interface PublicTournamentPageCursorShape {
+  createdAt: string;
+  publicId: string;
+}
+
+function toBase64Url(value: string): string {
+  if (typeof Buffer !== 'undefined') {
+    return Buffer.from(value, 'utf8')
+      .toString('base64')
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=+$/g, '');
+  }
+
+  return btoa(value)
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/g, '');
+}
+
+function fromBase64Url(value: string): string {
+  if (!/^[A-Za-z0-9\-_]+$/.test(value)) {
+    throw new Error('invalid cursor');
+  }
+
+  const normalized = value.replace(/-/g, '+').replace(/_/g, '/');
+  const paddingLength = (4 - (normalized.length % 4)) % 4;
+  const padded = normalized + '='.repeat(paddingLength);
+
+  if (typeof Buffer !== 'undefined') {
+    return Buffer.from(padded, 'base64').toString('utf8');
+  }
+
+  return atob(padded);
+}
+
+export function encodePublicTournamentListCursor(
+  cursor: PublicTournamentPageCursor,
+): PublicTournamentListCursor {
+  return toBase64Url(JSON.stringify(cursor));
+}
+
+export function decodePublicTournamentListCursor(
+  cursor: PublicTournamentListCursor,
+): PublicTournamentPageCursor {
+  if (cursor.trim().length === 0) {
+    throw new Error('invalid cursor');
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(fromBase64Url(cursor));
+  } catch {
+    throw new Error('invalid cursor');
+  }
+
+  const parsedCursor = parsed as Partial<PublicTournamentPageCursorShape> | null;
+  if (
+    !parsedCursor ||
+    typeof parsedCursor !== 'object' ||
+    typeof parsedCursor.createdAt !== 'string' ||
+    typeof parsedCursor.publicId !== 'string' ||
+    parsedCursor.createdAt.trim().length === 0 ||
+    parsedCursor.publicId.trim().length === 0
+  ) {
+    throw new Error('invalid cursor');
+  }
+
+  return {
+    createdAt: parsedCursor.createdAt,
+    publicId: parsedCursor.publicId,
+  };
+}

--- a/packages/public-catalog-api/src/repository/public-tournaments.ts
+++ b/packages/public-catalog-api/src/repository/public-tournaments.ts
@@ -61,6 +61,7 @@ export interface PublicTournamentRepository {
     sinceInclusive: string,
   ): Promise<number>;
   getByRegistryHash(registryHash: string): Promise<PublicTournamentRecord | null>;
+  getActiveByPublicId(publicId: string): Promise<PublicTournamentRecord | null>;
   listActive(
     options: ListActivePublicTournamentsOptions,
   ): Promise<ListActivePublicTournamentsResult>;
@@ -183,6 +184,36 @@ export class D1PublicTournamentRepository implements PublicTournamentRepository 
         `,
       )
       .bind(registryHash)
+      .first<PublicTournamentRow>();
+
+    return row ? mapPublicTournamentRow(row) : null;
+  }
+
+  async getActiveByPublicId(publicId: string): Promise<PublicTournamentRecord | null> {
+    const row = await this.db
+      .prepare(
+        `
+          SELECT
+            public_id,
+            registry_hash,
+            payload_json,
+            name,
+            owner,
+            hashtag,
+            start_date,
+            end_date,
+            chart_count,
+            created_at,
+            updated_at,
+            deleted_at,
+            delete_reason
+          FROM public_tournaments
+          WHERE public_id = ?
+            AND deleted_at IS NULL
+          LIMIT 1
+        `,
+      )
+      .bind(publicId)
       .first<PublicTournamentRow>();
 
     return row ? mapPublicTournamentRow(row) : null;

--- a/packages/public-catalog-api/src/repository/public-tournaments.ts
+++ b/packages/public-catalog-api/src/repository/public-tournaments.ts
@@ -1,3 +1,5 @@
+import type { PublicTournamentListItem } from '@iidx/shared';
+
 export interface PublicTournamentRecord {
   publicId: string;
   registryHash: string;
@@ -37,12 +39,31 @@ export interface PublicTournamentAuditLogEntry {
   createdAt: string;
 }
 
+export interface PublicTournamentListCursorInput {
+  createdAt: string;
+  publicId: string;
+}
+
+export interface ListActivePublicTournamentsOptions {
+  searchQuery: string | null;
+  cursor: PublicTournamentListCursorInput | null;
+  limit: number;
+}
+
+export interface ListActivePublicTournamentsResult {
+  items: PublicTournamentListItem[];
+  hasMore: boolean;
+}
+
 export interface PublicTournamentRepository {
   countRecentAttempts(
     requestFingerprint: string,
     sinceInclusive: string,
   ): Promise<number>;
   getByRegistryHash(registryHash: string): Promise<PublicTournamentRecord | null>;
+  listActive(
+    options: ListActivePublicTournamentsOptions,
+  ): Promise<ListActivePublicTournamentsResult>;
   create(record: PublicTournamentRecord): Promise<boolean>;
   insertAuditLog(entry: PublicTournamentAuditLogEntry): Promise<void>;
 }
@@ -67,6 +88,17 @@ interface PublicTournamentRow {
   delete_reason: string | null;
 }
 
+interface PublicTournamentListRow {
+  public_id: string;
+  name: string;
+  owner: string;
+  hashtag: string;
+  start_date: string;
+  end_date: string;
+  chart_count: number | string;
+  created_at: string;
+}
+
 function mapPublicTournamentRow(row: PublicTournamentRow): PublicTournamentRecord {
   return {
     publicId: row.public_id,
@@ -83,6 +115,23 @@ function mapPublicTournamentRow(row: PublicTournamentRow): PublicTournamentRecor
     deletedAt: row.deleted_at,
     deleteReason: row.delete_reason,
   };
+}
+
+function mapPublicTournamentListRow(row: PublicTournamentListRow): PublicTournamentListItem {
+  return {
+    publicId: row.public_id,
+    name: row.name,
+    owner: row.owner,
+    hashtag: row.hashtag,
+    start: row.start_date,
+    end: row.end_date,
+    chartCount: Number(row.chart_count),
+    createdAt: row.created_at,
+  };
+}
+
+function escapeLikePattern(value: string): string {
+  return value.replace(/[\\%_]/g, '\\$&');
 }
 
 export class D1PublicTournamentRepository implements PublicTournamentRepository {
@@ -137,6 +186,63 @@ export class D1PublicTournamentRepository implements PublicTournamentRepository 
       .first<PublicTournamentRow>();
 
     return row ? mapPublicTournamentRow(row) : null;
+  }
+
+  async listActive(
+    options: ListActivePublicTournamentsOptions,
+  ): Promise<ListActivePublicTournamentsResult> {
+    const trimmedSearch = options.searchQuery?.trim() ?? '';
+    const searchPattern =
+      trimmedSearch.length > 0 ? `%${escapeLikePattern(trimmedSearch)}%` : null;
+    const rows =
+      (
+        await this.db
+          .prepare(
+            `
+              SELECT
+                public_id,
+                name,
+                owner,
+                hashtag,
+                start_date,
+                end_date,
+                chart_count,
+                created_at
+              FROM public_tournaments
+              WHERE deleted_at IS NULL
+                AND (
+                  ? IS NULL
+                  OR name LIKE ? ESCAPE '\\'
+                  OR owner LIKE ? ESCAPE '\\'
+                  OR hashtag LIKE ? ESCAPE '\\'
+                )
+                AND (
+                  ? IS NULL
+                  OR created_at < ?
+                  OR (created_at = ? AND public_id < ?)
+                )
+              ORDER BY created_at DESC, public_id DESC
+              LIMIT ?
+            `,
+          )
+          .bind(
+            searchPattern,
+            searchPattern,
+            searchPattern,
+            searchPattern,
+            options.cursor?.createdAt ?? null,
+            options.cursor?.createdAt ?? null,
+            options.cursor?.createdAt ?? null,
+            options.cursor?.publicId ?? null,
+            options.limit + 1,
+          )
+          .all<PublicTournamentListRow>()
+      ).results ?? [];
+
+    return {
+      items: rows.slice(0, options.limit).map(mapPublicTournamentListRow),
+      hasMore: rows.length > options.limit,
+    };
   }
 
   async create(record: PublicTournamentRecord): Promise<boolean> {

--- a/packages/public-catalog-api/src/routes.ts
+++ b/packages/public-catalog-api/src/routes.ts
@@ -1,1 +1,3 @@
-export const REGISTER_PUBLIC_TOURNAMENT_PATH = '/api/public-tournaments';
+export const PUBLIC_TOURNAMENTS_PATH = '/api/public-tournaments';
+export const LIST_PUBLIC_TOURNAMENTS_PATH = PUBLIC_TOURNAMENTS_PATH;
+export const REGISTER_PUBLIC_TOURNAMENT_PATH = PUBLIC_TOURNAMENTS_PATH;

--- a/packages/public-catalog-api/src/routes.ts
+++ b/packages/public-catalog-api/src/routes.ts
@@ -1,3 +1,30 @@
 export const PUBLIC_TOURNAMENTS_PATH = '/api/public-tournaments';
 export const LIST_PUBLIC_TOURNAMENTS_PATH = PUBLIC_TOURNAMENTS_PATH;
 export const REGISTER_PUBLIC_TOURNAMENT_PATH = PUBLIC_TOURNAMENTS_PATH;
+
+const PUBLIC_TOURNAMENT_PAYLOAD_SUFFIX = '/payload';
+
+export function matchPublicTournamentPayloadPath(pathname: string): string | null {
+  const prefix = `${PUBLIC_TOURNAMENTS_PATH}/`;
+  if (
+    !pathname.startsWith(prefix) ||
+    !pathname.endsWith(PUBLIC_TOURNAMENT_PAYLOAD_SUFFIX)
+  ) {
+    return null;
+  }
+
+  const rawPublicId = pathname.slice(
+    prefix.length,
+    -PUBLIC_TOURNAMENT_PAYLOAD_SUFFIX.length,
+  );
+  if (!rawPublicId || rawPublicId.includes('/')) {
+    return null;
+  }
+
+  try {
+    const publicId = decodeURIComponent(rawPublicId);
+    return publicId && !publicId.includes('/') ? publicId : null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/public-catalog-api/test/index.test.ts
+++ b/packages/public-catalog-api/test/index.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest';
 import { createWorkerHandler } from '../src/index.js';
 import { REGISTER_PUBLIC_TOURNAMENT_PATH } from '../src/routes.js';
 import type {
+  ListActivePublicTournamentsOptions,
+  ListActivePublicTournamentsResult,
   PublicTournamentAuditLogEntry,
   PublicTournamentRecord,
   PublicTournamentRepository,
@@ -28,6 +30,15 @@ class InMemoryRepository implements PublicTournamentRepository {
     registryHash: string,
   ): Promise<PublicTournamentRecord | null> {
     return this.recordsByRegistryHash.get(registryHash) ?? null;
+  }
+
+  async listActive(
+    _options: ListActivePublicTournamentsOptions,
+  ): Promise<ListActivePublicTournamentsResult> {
+    return {
+      items: [],
+      hasMore: false,
+    };
   }
 
   async create(record: PublicTournamentRecord): Promise<boolean> {

--- a/packages/public-catalog-api/test/index.test.ts
+++ b/packages/public-catalog-api/test/index.test.ts
@@ -1,6 +1,13 @@
+import {
+  encodeTournamentPayload,
+  normalizeTournamentPayload,
+} from '@iidx/shared';
 import { describe, expect, it } from 'vitest';
 import { createWorkerHandler } from '../src/index.js';
-import { REGISTER_PUBLIC_TOURNAMENT_PATH } from '../src/routes.js';
+import {
+  LIST_PUBLIC_TOURNAMENTS_PATH,
+  REGISTER_PUBLIC_TOURNAMENT_PATH,
+} from '../src/routes.js';
 import type {
   ListActivePublicTournamentsOptions,
   ListActivePublicTournamentsResult,
@@ -32,12 +39,61 @@ class InMemoryRepository implements PublicTournamentRepository {
     return this.recordsByRegistryHash.get(registryHash) ?? null;
   }
 
+  async getActiveByPublicId(publicId: string): Promise<PublicTournamentRecord | null> {
+    const record = this.recordsByPublicId.get(publicId) ?? null;
+    return record && !record.deletedAt ? record : null;
+  }
+
   async listActive(
-    _options: ListActivePublicTournamentsOptions,
+    options: ListActivePublicTournamentsOptions,
   ): Promise<ListActivePublicTournamentsResult> {
+    const normalizedSearch = options.searchQuery?.trim().toLowerCase() ?? '';
+    const filtered = [...this.recordsByPublicId.values()]
+      .filter((record) => !record.deletedAt)
+      .filter((record) => {
+        if (!normalizedSearch) {
+          return true;
+        }
+
+        return [record.name, record.owner, record.hashtag].some((value) =>
+          value.toLowerCase().includes(normalizedSearch),
+        );
+      })
+      .sort(
+        (left, right) =>
+          right.createdAt.localeCompare(left.createdAt) ||
+          right.publicId.localeCompare(left.publicId),
+      );
+
+    const paged = options.cursor
+      ? filtered.filter((record) => {
+          const cursor = options.cursor;
+          if (!cursor) {
+            return true;
+          }
+
+          return (
+            record.createdAt < cursor.createdAt ||
+            (record.createdAt === cursor.createdAt &&
+              record.publicId < cursor.publicId)
+          );
+        })
+      : filtered;
+
+    const items = paged.slice(0, options.limit + 1).map((record) => ({
+      publicId: record.publicId,
+      name: record.name,
+      owner: record.owner,
+      hashtag: record.hashtag,
+      start: record.startDate,
+      end: record.endDate,
+      chartCount: record.chartCount,
+      createdAt: record.createdAt,
+    }));
+
     return {
-      items: [],
-      hasMore: false,
+      items: items.slice(0, options.limit),
+      hasMore: items.length > options.limit,
     };
   }
 
@@ -80,12 +136,23 @@ function createEnv(overrides: Partial<Record<string, string>> = {}) {
 
 function createRequest(
   init: {
+    path?: string;
     method?: string;
     origin?: string;
     body?: unknown;
     headers?: Record<string, string>;
+    searchParams?: Record<string, string | undefined>;
   } = {},
 ): Request {
+  const url = new URL(
+    `https://api.example.com${init.path ?? REGISTER_PUBLIC_TOURNAMENT_PATH}`,
+  );
+  for (const [key, value] of Object.entries(init.searchParams ?? {})) {
+    if (value !== undefined) {
+      url.searchParams.set(key, value);
+    }
+  }
+
   const headers = new Headers(init.headers);
   headers.set('Origin', init.origin ?? 'https://tts1374.github.io');
   headers.set('CF-Connecting-IP', '203.0.113.10');
@@ -102,10 +169,7 @@ function createRequest(
     requestInit.body = JSON.stringify(init.body);
   }
 
-  return new Request(
-    `https://api.example.com${REGISTER_PUBLIC_TOURNAMENT_PATH}`,
-    requestInit,
-  );
+  return new Request(url, requestInit);
 }
 
 function createStreamingRequest(rawText: string): Request {
@@ -135,6 +199,37 @@ function createStreamingRequest(rawText: string): Request {
   } as Request;
 }
 
+function createRecord(
+  publicId: string,
+  createdAt: string,
+  overrides: Partial<PublicTournamentRecord> = {},
+): PublicTournamentRecord {
+  const normalizedPayload = normalizeTournamentPayload({
+    ...validPayload,
+    name: overrides.name ?? validPayload.name,
+    owner: overrides.owner ?? validPayload.owner,
+    hashtag: overrides.hashtag ?? validPayload.hashtag,
+    start: overrides.startDate ?? validPayload.start,
+    end: overrides.endDate ?? validPayload.end,
+  });
+
+  return {
+    publicId,
+    registryHash: `registry-${publicId}`,
+    payloadJson: JSON.stringify(normalizedPayload),
+    name: overrides.name ?? normalizedPayload.name,
+    owner: overrides.owner ?? normalizedPayload.owner,
+    hashtag: overrides.hashtag ?? normalizedPayload.hashtag,
+    startDate: overrides.startDate ?? normalizedPayload.start,
+    endDate: overrides.endDate ?? normalizedPayload.end,
+    chartCount: overrides.chartCount ?? normalizedPayload.charts.length,
+    createdAt,
+    updatedAt: overrides.updatedAt ?? createdAt,
+    deletedAt: overrides.deletedAt ?? null,
+    deleteReason: overrides.deleteReason ?? null,
+  };
+}
+
 function invokeWorker(
   worker: ReturnType<typeof createWorkerHandler>,
   request: Request,
@@ -149,7 +244,7 @@ function invokeWorker(
   );
 }
 
-describe('public catalog register worker', () => {
+describe('public catalog worker', () => {
   it('creates a public tournament and returns a publicId', async () => {
     const repository = new InMemoryRepository();
     const worker = createWorkerHandler({
@@ -438,5 +533,221 @@ describe('public catalog register worker', () => {
     expect(response.status).toBe(413);
     expect(body.error.code).toBe('PAYLOAD_TOO_LARGE');
     expect(repository.auditLogs.at(-1)?.result).toBe('payload_too_large');
+  });
+
+  it('lists active public tournaments with stable cursor pagination', async () => {
+    const repository = new InMemoryRepository();
+    const worker = createWorkerHandler({
+      createRepository: () => repository,
+    });
+
+    for (let index = 0; index < 19; index += 1) {
+      const publicId = `public-${String(index + 1).padStart(2, '0')}`;
+      const createdAt = `2026-04-${String(28 - index).padStart(2, '0')}T12:00:00.000Z`;
+      await repository.create(createRecord(publicId, createdAt));
+    }
+    await repository.create(
+      createRecord('public-20b', '2026-04-01T12:00:00.000Z', {
+        name: 'Boundary B',
+      }),
+    );
+    await repository.create(
+      createRecord('public-20a', '2026-04-01T12:00:00.000Z', {
+        name: 'Boundary A',
+      }),
+    );
+    await repository.create(
+      createRecord('deleted-public', '2026-05-01T12:00:00.000Z', {
+        deletedAt: '2026-05-02T12:00:00.000Z',
+        deleteReason: 'spam',
+      }),
+    );
+
+    const firstPage = await invokeWorker(
+      worker,
+      createRequest({
+        path: LIST_PUBLIC_TOURNAMENTS_PATH,
+        method: 'GET',
+      }),
+      createEnv(),
+    );
+    const firstBody = (await firstPage.json()) as {
+      items: Array<{ publicId: string }>;
+      nextCursor: string | null;
+    };
+
+    expect(firstPage.status).toBe(200);
+    expect(firstBody.items).toHaveLength(20);
+    expect(firstBody.items[0]?.publicId).toBe('public-01');
+    expect(firstBody.items.at(-1)?.publicId).toBe('public-20b');
+    expect(firstBody.items.some((item) => item.publicId === 'deleted-public')).toBe(
+      false,
+    );
+    expect(firstBody.nextCursor).toEqual(expect.any(String));
+
+    const secondPage = await invokeWorker(
+      worker,
+      createRequest({
+        path: LIST_PUBLIC_TOURNAMENTS_PATH,
+        method: 'GET',
+        searchParams: {
+          cursor: firstBody.nextCursor ?? undefined,
+        },
+      }),
+      createEnv(),
+    );
+    const secondBody = (await secondPage.json()) as {
+      items: Array<{ publicId: string }>;
+      nextCursor: string | null;
+    };
+
+    expect(secondPage.status).toBe(200);
+    expect(secondBody.items.map((item) => item.publicId)).toEqual(['public-20a']);
+    expect(secondBody.nextCursor).toBeNull();
+  });
+
+  it('trims search queries and treats blank q as unfiltered', async () => {
+    const repository = new InMemoryRepository();
+    const worker = createWorkerHandler({
+      createRepository: () => repository,
+    });
+
+    await repository.create(
+      createRecord('public-alpha', '2026-04-19T12:00:00.000Z', {
+        name: 'Alpha Cup',
+        owner: 'owner-a',
+        hashtag: 'alpha',
+      }),
+    );
+    await repository.create(
+      createRecord('public-beta', '2026-04-18T12:00:00.000Z', {
+        name: 'Beta Cup',
+        owner: 'owner-b',
+        hashtag: 'beta',
+      }),
+    );
+
+    const filtered = await invokeWorker(
+      worker,
+      createRequest({
+        path: LIST_PUBLIC_TOURNAMENTS_PATH,
+        method: 'GET',
+        searchParams: {
+          q: '  owner-b  ',
+        },
+      }),
+      createEnv(),
+    );
+    const filteredBody = (await filtered.json()) as {
+      items: Array<{ publicId: string }>;
+    };
+    const blankQuery = await invokeWorker(
+      worker,
+      createRequest({
+        path: LIST_PUBLIC_TOURNAMENTS_PATH,
+        method: 'GET',
+        searchParams: {
+          q: '   ',
+        },
+      }),
+      createEnv(),
+    );
+    const blankQueryBody = (await blankQuery.json()) as {
+      items: Array<{ publicId: string }>;
+    };
+
+    expect(filtered.status).toBe(200);
+    expect(filteredBody.items.map((item) => item.publicId)).toEqual(['public-beta']);
+    expect(blankQuery.status).toBe(200);
+    expect(blankQueryBody.items.map((item) => item.publicId)).toEqual([
+      'public-alpha',
+      'public-beta',
+    ]);
+  });
+
+  it('rejects invalid list cursors', async () => {
+    const repository = new InMemoryRepository();
+    const worker = createWorkerHandler({
+      createRepository: () => repository,
+    });
+
+    const response = await invokeWorker(
+      worker,
+      createRequest({
+        path: LIST_PUBLIC_TOURNAMENTS_PATH,
+        method: 'GET',
+        searchParams: {
+          cursor: 'not-a-valid-cursor',
+        },
+      }),
+      createEnv(),
+    );
+    const body = (await response.json()) as {
+      error: { code: string };
+    };
+
+    expect(response.status).toBe(400);
+    expect(body.error.code).toBe('BAD_REQUEST');
+  });
+
+  it('returns payloadParam for active public tournaments', async () => {
+    const repository = new InMemoryRepository();
+    const worker = createWorkerHandler({
+      createRepository: () => repository,
+    });
+
+    const record = createRecord('public-payload', '2026-04-19T12:00:00.000Z');
+    await repository.create(record);
+
+    const response = await invokeWorker(
+      worker,
+      createRequest({
+        path: `${LIST_PUBLIC_TOURNAMENTS_PATH}/public-payload/payload`,
+        method: 'GET',
+      }),
+      createEnv(),
+    );
+    const body = (await response.json()) as {
+      payloadParam: string;
+    };
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({
+      payloadParam: encodeTournamentPayload(JSON.parse(record.payloadJson)),
+    });
+  });
+
+  it('returns 404 for missing or deleted payload lookups', async () => {
+    const repository = new InMemoryRepository();
+    const worker = createWorkerHandler({
+      createRepository: () => repository,
+    });
+
+    await repository.create(
+      createRecord('public-deleted', '2026-04-19T12:00:00.000Z', {
+        deletedAt: '2026-04-20T12:00:00.000Z',
+        deleteReason: 'deleted',
+      }),
+    );
+
+    const missing = await invokeWorker(
+      worker,
+      createRequest({
+        path: `${LIST_PUBLIC_TOURNAMENTS_PATH}/missing/payload`,
+        method: 'GET',
+      }),
+      createEnv(),
+    );
+    const deleted = await invokeWorker(
+      worker,
+      createRequest({
+        path: `${LIST_PUBLIC_TOURNAMENTS_PATH}/public-deleted/payload`,
+        method: 'GET',
+      }),
+      createEnv(),
+    );
+
+    expect(missing.status).toBe(404);
+    expect(deleted.status).toBe(404);
   });
 });

--- a/packages/shared/src/public-catalog.ts
+++ b/packages/shared/src/public-catalog.ts
@@ -15,6 +15,28 @@ export interface PublicTournamentRegisterResponse {
   publicId: string;
 }
 
+export type PublicTournamentListCursor = string;
+
+export interface PublicTournamentListItem {
+  publicId: string;
+  name: string;
+  owner: string;
+  hashtag: string;
+  start: string;
+  end: string;
+  chartCount: number;
+  createdAt: string;
+}
+
+export interface PublicTournamentListResponse {
+  items: PublicTournamentListItem[];
+  nextCursor: PublicTournamentListCursor | null;
+}
+
+export interface PublicTournamentPayloadResponse {
+  payloadParam: string;
+}
+
 export type PublicCatalogApiErrorCode =
   | 'BAD_REQUEST'
   | 'INVALID_JSON'

--- a/tasks/codex-feat-public-catalog-v1-read-api.md
+++ b/tasks/codex-feat-public-catalog-v1-read-api.md
@@ -1,0 +1,112 @@
+# Plan: codex/feat-public-catalog-v1-read-api
+
+## 実行コンテキスト（予定）
+
+- worktree: `C:/work/score_attack_manager/iidx_score_attack_manager-codex-public-catalog-v1-read-api`
+- branch: `codex/feat-public-catalog-v1-read-api`
+- BASE_SHA: `cf7c4ebbc7ac7cfc6504de9840b3e9a5e7fe0e05`
+- 実装開始条件: #48 で追加される `packages/public-catalog-api` と公開大会 schema / contract が main に取り込まれているか、同等差分を base に含むこと。本ブランチで #48 の bootstrap を再実装しない。
+
+## 目的
+
+- 公開カタログの read API として `GET /api/public-tournaments`、`GET /api/public-tournaments/:publicId/payload` を追加し、公開一覧・検索・既存 `import/confirm` 導線の server 側橋渡しを提供する。
+- 公開登録側で保存された大会定義を、`name / owner / hashtag` 検索と新着順ページングで取得できるようにする。
+- 既存の import payload 契約と `def_hash` を変えず、shared の payload encode ロジックを使って `payloadParam` を返せるようにする。
+
+## 非目的
+
+- 公開登録 `POST /api/public-tournaments` と `registry_hash` 重複判定基盤の再実装や拡張（#48）。
+- クライアント側の公開状態保持、再試行導線、一覧 UI、import 導線接続（#50 / #51）。
+- `import/confirm` 以降の検証、期限切れ判定、曲マスタ確認、既存大会マージ処理の変更。
+- `def_hash`、既存 import payload、Web Locks、PWA 起動導線、OPFS/SQLite ローカル保存の仕様変更。
+- 高度な検索条件、ランキング、人気順、編集/削除 API の追加。
+- read API のためだけの D1 schema 再設計や Worker framework 導入。
+
+## 変更点
+
+- `packages/shared`
+  - 公開カタログ read API の response 型と cursor 型を `public-catalog` 系の shared module に追加または拡張する。
+  - 保存済み大会 payload から `payloadParam` を作るため、既存 `encodeTournamentPayload` を read API から安全に再利用できる export を整理する。
+- `packages/public-catalog-api`
+  - `GET /api/public-tournaments?q=&cursor=` を追加し、active な公開大会だけを新着順で返す。
+  - `q` は trim 後に `name / owner / hashtag` の部分一致検索として扱い、空文字は無検索と同義にする。
+  - ページングは `createdAt` と `publicId` を使う安定順序の opaque cursor 方式とし、同時刻データでも取りこぼし・重複を避ける。
+  - `GET /api/public-tournaments/:publicId/payload` を追加し、対象大会が active の場合だけ `{ payloadParam }` を返す。
+  - `payloadParam` は保存済み payload から shared の既存 encode ロジックで生成し、full URL ではなく import-confirm 用 query 値だけを返す。
+  - #48 で導入される CORS / エラーレスポンス方針を流用し、新たな write endpoint や認証処理は増やさない。
+- D1 access
+  - 公開大会 repository に read 用メソッドを追加し、soft-delete / tombstone 済みデータを一覧・payload 両方から除外する。
+  - 一覧レスポンスは `publicId, name, owner, hashtag, start, end, chartCount, createdAt` の最小項目だけを返し、payload 本体は含めない。
+  - `publicId` 未存在または inactive な大会に対する payload 取得は 404 系で扱い、クライアントが存在しない公開大会を判別できるようにする。
+
+## 影響範囲（ユーザー / データ / 互換性 / PWA / 保存 / 起動）
+
+- ユーザー:
+  - このブランチ単体では UI は変わらない。
+  - 後続の #51 から使う公開一覧・検索・取込 API が利用可能になる。
+- データ:
+  - 既存 D1 の公開大会データを read するのみで、新規のローカル保存変更はない。
+  - 一覧用メタと保存済み payload を読み出すが、payload 本体を一覧レスポンスへ展開しない。
+- 互換性:
+  - 既存 `def_hash` と import payload 契約は維持する。
+  - 追加される契約は read API response と opaque cursor に閉じる。
+- PWA:
+  - Service Worker、COOP/COEP、single-tab 制御には触れない。
+- 保存:
+  - OPFS/SQLite のローカル保存方式に変更なし。
+  - D1 schema は #48 由来を前提とし、本ブランチでは read API に不要な migration を増やさない。
+- 起動:
+  - web-app の startup/import routing には変更なし。
+- 運用:
+  - Worker route の追加と、公開一覧 API の CORS/Origin 設定確認が必要になる。
+
+## 対象ファイル / 対象パッケージ
+
+- 対象パッケージ:
+  - `packages/shared`
+  - `packages/public-catalog-api`
+- 想定対象ファイル:
+  - `packages/shared/src/index.ts`
+  - `packages/shared/src/public-catalog.ts`
+  - `packages/shared/src/public-catalog.test.ts`
+  - `packages/public-catalog-api/src/index.ts`
+  - `packages/public-catalog-api/src/repository/public-tournaments.ts`
+  - `packages/public-catalog-api/src/pagination.ts`（新規、cursor helper が必要な場合）
+  - `packages/public-catalog-api/src/*.test.ts`
+
+### 変更スコープ固定
+
+- `packages/web-app`、`packages/db`、`packages/pwa` は本ブランチでは変更しない。
+- #48 の bootstrap や D1 schema 基盤が不足していても、本ブランチで write API まで巻き取らない。
+- 親 Issue #47 で固定された `def_hash` 非変更、既存 import-confirm 導線流用、単一タブ凍結は前提として維持する。
+
+## テスト観点
+
+- list API:
+  - `q` 未指定で新着順一覧が返り、`createdAt` 同値でも cursor 境界で順序が安定する。
+  - `name / owner / hashtag` の部分一致検索で対象だけが返る。
+  - 空文字や空白だけの `q` は無検索として扱われる。
+  - tombstone / inactive データは一覧に出ない。
+- payload API:
+  - 既存公開大会に対して `{ payloadParam }` が返り、shared の `encodeTournamentPayload` と同じ値になる。
+  - 存在しない `publicId`、削除済み `publicId` では 404 系になる。
+  - `payloadParam` から組んだ `/import/confirm?p=...` が既存 import-confirm で decode 可能な契約を維持する。
+- shared contract:
+  - 追加する response 型 / cursor 型が API 実装と一致する。
+  - 既存 `def_hash` helper や payload encode/decode の挙動は変わらない。
+- 回帰:
+  - #48 の write API 契約や CORS 方針を壊さない。
+  - `packages/web-app` / `packages/db` / `packages/pwa` に不要な変更が混ざらない。
+
+## ロールバック方針
+
+- コードは commit 単位で `git revert` し、read API ルート、repository read helper、shared の response 型追加をまとめて戻す。
+- 本ブランチでは D1 schema の新規 migration を持ち込まない前提のため、ロールバックは基本的にアプリコード差分の撤回だけで完結させる。
+- 既存 write API やローカル import 処理には触れないため、ロールバック時の影響は公開 read API の停止に限定される。
+
+## コミット分割計画
+
+1. `plan`: `tasks/codex-feat-public-catalog-v1-read-api.md` を追加。
+2. `shared-read-contract`: 公開一覧 / payload endpoint の response 型と必要な shared export を追加。
+3. `list-api`: `GET /api/public-tournaments`、検索、cursor paging、repository read 処理を実装。
+4. `payload-api-and-tests`: `GET /api/public-tournaments/:publicId/payload` と関連テストを追加し、最小検証を行う。


### PR DESCRIPTION
## 目的
- Issue #49 の task artifact に沿って、公開カタログ read API を追加する。
- Cloudflare Worker から公開大会の一覧検索と import-confirm 用 payload 取得を提供する。

## 変更点
- `tasks/codex-feat-public-catalog-v1-read-api.md` を branch の plan artifact として追加。
- `packages/shared/src/public-catalog.ts` に一覧 response / cursor / payload response の shared contract を追加。
- `packages/public-catalog-api` に `GET /api/public-tournaments` の検索・cursor paging を追加。
- `GET /api/public-tournaments/:publicId/payload` を追加し、active な大会だけ `payloadParam` を返すようにした。
- read API 用の repository 読み出しと Vitest を追加した。

## 非変更点
- `POST /api/public-tournaments` の write API 契約や rate limit 方針の再設計はしていない。
- `packages/web-app` / `packages/db` / `packages/pwa` は変更していない。
- `def_hash` と既存 import payload 契約は変更していない。

## 影響範囲
- 公開カタログの server-side read API が利用可能になる。
- D1 既存データの read のみで、新しい migration は追加していない。
- CORS は既存 allowlist 方針を流用し、GET 系も同じ Worker 内で扱う。

## テスト内容
- `pnpm --filter @iidx/shared lint`
- `pnpm --filter @iidx/public-catalog-api lint`
- `pnpm --filter @iidx/public-catalog-api test`
- `pnpm --filter @iidx/public-catalog-api exec wrangler deploy --dry-run`

## 回帰確認
- 一覧 API の正常系: 新着順一覧、検索、cursor paging。
- 境界/異常系: blank query、invalid cursor 400、missing/deleted payload 404。
- 既存 register API tests も継続して通過。