### PR TITLE
[codex] add local public catalog publish state

### DIFF
--- a/packages/db/src/app-db.ts
+++ b/packages/db/src/app-db.ts
@@ -502,6 +502,18 @@ export class AppDatabase {
     );
   }
 
+  async reconcileInterruptedTournamentPublications(): Promise<void> {
+    const now = this.clock.nowIso();
+    await this.exec(
+      `UPDATE tournaments
+       SET public_status = 'retryable',
+           last_publish_attempt_at = COALESCE(last_publish_attempt_at, ?),
+           updated_at = ?
+       WHERE public_status = 'publishing'`,
+      [now, now],
+    );
+  }
+
   async findImportTargetTournament(sourceTournamentUuid: string): Promise<ImportTargetTournament | null> {
     const today = this.clock.todayJst();
     const rows = await this.query<{

--- a/packages/db/src/app-db.ts
+++ b/packages/db/src/app-db.ts
@@ -21,6 +21,7 @@ import {
   TournamentDetailChart,
   TournamentDetailItem,
   TournamentListItem,
+  TournamentPublicationStatus,
   TournamentTab,
 } from './models.js';
 import { migrateAppDatabase } from './schema.js';
@@ -75,6 +76,18 @@ function normalizeDbText(value: unknown): string | null {
   }
   const text = String(value).trim();
   return text.length > 0 ? text : null;
+}
+
+function normalizeTournamentPublicationStatus(value: unknown): TournamentPublicationStatus {
+  const normalized = normalizeDbText(value);
+  if (
+    normalized === 'publishing' ||
+    normalized === 'published' ||
+    normalized === 'retryable'
+  ) {
+    return normalized;
+  }
+  return 'unpublished';
 }
 
 function toSongDisplayTitle(title: unknown, titleQualifier: unknown): string | null {
@@ -384,6 +397,9 @@ export class AppDatabase {
 
     const tournamentUuid = input.tournamentUuid ?? this.idFactory.uuid();
     const now = this.clock.nowIso();
+    const publicStatus = input.publicStatus ?? 'unpublished';
+    const lastPublishAttemptAt =
+      input.lastPublishAttemptAt ?? (publicStatus === 'publishing' ? now : null);
     const payload: TournamentPayload = normalizeTournamentPayload({
       v: PAYLOAD_VERSION,
       uuid: tournamentUuid,
@@ -409,9 +425,12 @@ export class AppDatabase {
            start_date,
            end_date,
            is_imported,
+           public_id,
+           public_status,
+           last_publish_attempt_at,
            created_at,
            updated_at
-         ) VALUES(?, NULL, ?, ?, ?, ?, ?, ?, 0, ?, ?)`,
+         ) VALUES(?, NULL, ?, ?, ?, ?, ?, ?, 0, NULL, ?, ?, ?, ?)`,
         [
           tournamentUuid,
           defHash,
@@ -420,6 +439,8 @@ export class AppDatabase {
           payload.hashtag,
           payload.start,
           payload.end,
+          publicStatus,
+          lastPublishAttemptAt,
           now,
           now,
         ],
@@ -438,6 +459,47 @@ export class AppDatabase {
       await this.exec('ROLLBACK');
       throw error;
     }
+  }
+
+  async markTournamentPublishing(tournamentUuid: string): Promise<void> {
+    const now = this.clock.nowIso();
+    await this.exec(
+      `UPDATE tournaments
+       SET public_status = 'publishing',
+           last_publish_attempt_at = ?,
+           updated_at = ?
+       WHERE tournament_uuid = ?`,
+      [now, now, tournamentUuid],
+    );
+  }
+
+  async markTournamentPublished(tournamentUuid: string, publicId: string): Promise<void> {
+    const normalizedPublicId = normalizeDbText(publicId);
+    if (!normalizedPublicId) {
+      throw new Error('publicId is required.');
+    }
+    const now = this.clock.nowIso();
+    await this.exec(
+      `UPDATE tournaments
+       SET public_id = ?,
+           public_status = 'published',
+           last_publish_attempt_at = ?,
+           updated_at = ?
+       WHERE tournament_uuid = ?`,
+      [normalizedPublicId, now, now, tournamentUuid],
+    );
+  }
+
+  async markTournamentPublishRetryable(tournamentUuid: string): Promise<void> {
+    const now = this.clock.nowIso();
+    await this.exec(
+      `UPDATE tournaments
+       SET public_status = 'retryable',
+           last_publish_attempt_at = ?,
+           updated_at = ?
+       WHERE tournament_uuid = ?`,
+      [now, now, tournamentUuid],
+    );
   }
 
   async findImportTargetTournament(sourceTournamentUuid: string): Promise<ImportTargetTournament | null> {
@@ -720,6 +782,9 @@ export class AppDatabase {
       start_date: string;
       end_date: string;
       is_imported: number;
+      public_id: string | null;
+      public_status: string | null;
+      last_publish_attempt_at: string | null;
       chart_count: number;
       submitted_count: number;
       send_waiting_count: number;
@@ -734,6 +799,9 @@ export class AppDatabase {
         t.start_date,
         t.end_date,
         t.is_imported,
+        t.public_id,
+        t.public_status,
+        t.last_publish_attempt_at,
         COUNT(DISTINCT tc.chart_id) AS chart_count,
         COUNT(DISTINCT CASE WHEN e.file_deleted = 0 THEN tc.chart_id END) AS submitted_count,
         COUNT(DISTINCT CASE WHEN e.file_deleted = 0 AND e.needs_send = 1 THEN tc.chart_id END) AS send_waiting_count
@@ -768,6 +836,9 @@ export class AppDatabase {
         submittedCount,
         sendWaitingCount,
         pendingCount: Math.max(0, chartCount - submittedCount),
+        publicId: row.public_id,
+        publicStatus: normalizeTournamentPublicationStatus(row.public_status),
+        lastPublishAttemptAt: row.last_publish_attempt_at,
       };
     });
   }
@@ -784,6 +855,9 @@ export class AppDatabase {
       start_date: string;
       end_date: string;
       is_imported: number;
+      public_id: string | null;
+      public_status: string | null;
+      last_publish_attempt_at: string | null;
       chart_count: number;
       submitted_count: number;
       send_waiting_count: number;
@@ -800,6 +874,9 @@ export class AppDatabase {
         t.start_date,
         t.end_date,
         t.is_imported,
+        t.public_id,
+        t.public_status,
+        t.last_publish_attempt_at,
         COUNT(DISTINCT tc.chart_id) AS chart_count,
         COUNT(DISTINCT CASE WHEN e.file_deleted = 0 THEN tc.chart_id END) AS submitted_count,
         COUNT(DISTINCT CASE WHEN e.file_deleted = 0 AND e.needs_send = 1 THEN tc.chart_id END) AS send_waiting_count,
@@ -838,6 +915,9 @@ export class AppDatabase {
       submittedCount: Number(base.submitted_count),
       sendWaitingCount: Number(base.send_waiting_count),
       pendingCount: Math.max(0, Number(base.chart_count) - Number(base.submitted_count)),
+      publicId: base.public_id,
+      publicStatus: normalizeTournamentPublicationStatus(base.public_status),
+      lastPublishAttemptAt: base.last_publish_attempt_at,
       lastSubmittedAt: base.last_submitted_at,
       charts,
     };

--- a/packages/db/src/models.ts
+++ b/packages/db/src/models.ts
@@ -1,6 +1,7 @@
 import type { TournamentPayload } from '@iidx/shared';
 
 export type TournamentTab = 'active' | 'upcoming' | 'ended';
+export type TournamentPublicationStatus = 'unpublished' | 'publishing' | 'published' | 'retryable';
 
 export interface TournamentListItem {
   tournamentUuid: string;
@@ -15,6 +16,9 @@ export interface TournamentListItem {
   submittedCount: number;
   sendWaitingCount: number;
   pendingCount: number;
+  publicId?: string | null;
+  publicStatus?: TournamentPublicationStatus;
+  lastPublishAttemptAt?: string | null;
 }
 
 export interface TournamentDetailItem extends TournamentListItem {
@@ -46,6 +50,8 @@ export interface CreateTournamentInput {
   startDate: string;
   endDate: string;
   chartIds: number[];
+  publicStatus?: TournamentPublicationStatus;
+  lastPublishAttemptAt?: string | null;
 }
 
 export interface ImportTournamentImportedResult {

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1,4 +1,4 @@
-export const APP_DB_USER_VERSION = 2;
+export const APP_DB_USER_VERSION = 3;
 
 export const APP_DB_SCHEMA_SQL = `
 PRAGMA foreign_keys = ON;
@@ -13,6 +13,9 @@ CREATE TABLE IF NOT EXISTS tournaments (
   start_date TEXT NOT NULL,
   end_date TEXT NOT NULL,
   is_imported INTEGER NOT NULL CHECK(is_imported IN (0,1)),
+  public_id TEXT,
+  public_status TEXT NOT NULL DEFAULT 'unpublished' CHECK(public_status IN ('unpublished','publishing','published','retryable')),
+  last_publish_attempt_at TEXT,
   created_at TEXT NOT NULL,
   updated_at TEXT NOT NULL
 );
@@ -54,11 +57,41 @@ CREATE INDEX IF NOT EXISTS idx_tournament_charts_tournament_uuid ON tournament_c
 CREATE INDEX IF NOT EXISTS idx_evidences_tournament_uuid ON evidences(tournament_uuid);
 CREATE INDEX IF NOT EXISTS idx_evidences_file_deleted ON evidences(file_deleted);
 
-PRAGMA user_version = 2;
+PRAGMA user_version = 3;
 `;
 
 export async function migrateAppDatabase(executeSql: (sql: string) => Promise<void>): Promise<void> {
   await executeSql(APP_DB_SCHEMA_SQL);
+  try {
+    await executeSql(`
+      ALTER TABLE tournaments
+      ADD COLUMN public_id TEXT;
+    `);
+  } catch {
+    // Column already exists.
+  }
+  try {
+    await executeSql(`
+      ALTER TABLE tournaments
+      ADD COLUMN public_status TEXT NOT NULL DEFAULT 'unpublished' CHECK(public_status IN ('unpublished','publishing','published','retryable'));
+    `);
+  } catch {
+    // Column already exists.
+  }
+  try {
+    await executeSql(`
+      ALTER TABLE tournaments
+      ADD COLUMN last_publish_attempt_at TEXT;
+    `);
+  } catch {
+    // Column already exists.
+  }
+  await executeSql(`
+    UPDATE tournaments
+    SET public_status = COALESCE(NULLIF(public_status, ''), 'unpublished')
+    WHERE public_status IS NULL
+       OR TRIM(public_status) = '';
+  `);
   try {
     await executeSql(`
       ALTER TABLE evidences

--- a/packages/db/test/app-db-publication.test.ts
+++ b/packages/db/test/app-db-publication.test.ts
@@ -151,6 +151,87 @@ describe('AppDatabase publication state', () => {
     }
   });
 
+  it('reconciles interrupted publishing tournaments as retryable on startup', async () => {
+    const { appDb, db } = await createAppDb([
+      '2026-04-20T13:00:00.000Z',
+      '2026-04-20T13:10:00.000Z',
+    ]);
+
+    try {
+      const tournamentUuid = await appDb.createTournament({
+        tournamentName: '中断公開テスト',
+        owner: '',
+        hashtag: 'RECOVER',
+        startDate: '2026-04-20',
+        endDate: '2026-04-25',
+        chartIds: [505],
+        publicStatus: 'publishing',
+      });
+
+      await appDb.reconcileInterruptedTournamentPublications();
+
+      const detail = await appDb.getTournamentDetail(tournamentUuid);
+      expect(detail).toMatchObject({
+        tournamentUuid,
+        publicId: null,
+        publicStatus: 'retryable',
+        lastPublishAttemptAt: '2026-04-20T13:00:00.000Z',
+      });
+    } finally {
+      db.close();
+    }
+  });
+
+  it('leaves settled publication states unchanged during interrupted publish reconciliation', async () => {
+    const { appDb, db } = await createAppDb([
+      '2026-04-20T14:00:00.000Z',
+      '2026-04-20T14:05:00.000Z',
+      '2026-04-20T14:10:00.000Z',
+      '2026-04-20T14:15:00.000Z',
+    ]);
+
+    try {
+      const unpublishedTournamentUuid = await appDb.createTournament({
+        tournamentUuid: '44444444-4444-4444-8444-444444444444',
+        tournamentName: '未公開大会',
+        owner: '',
+        hashtag: 'UNPUBLISHED',
+        startDate: '2026-04-20',
+        endDate: '2026-04-25',
+        chartIds: [606],
+      });
+      const publishedTournamentUuid = await appDb.createTournament({
+        tournamentUuid: '55555555-5555-4555-8555-555555555555',
+        tournamentName: '公開済み大会',
+        owner: '',
+        hashtag: 'PUBLISHED',
+        startDate: '2026-04-20',
+        endDate: '2026-04-25',
+        chartIds: [707],
+      });
+      await appDb.markTournamentPublished(publishedTournamentUuid, 'public-707');
+
+      await appDb.reconcileInterruptedTournamentPublications();
+
+      const unpublishedDetail = await appDb.getTournamentDetail(unpublishedTournamentUuid);
+      const publishedDetail = await appDb.getTournamentDetail(publishedTournamentUuid);
+      expect(unpublishedDetail).toMatchObject({
+        tournamentUuid: unpublishedTournamentUuid,
+        publicId: null,
+        publicStatus: 'unpublished',
+        lastPublishAttemptAt: null,
+      });
+      expect(publishedDetail).toMatchObject({
+        tournamentUuid: publishedTournamentUuid,
+        publicId: 'public-707',
+        publicStatus: 'published',
+        lastPublishAttemptAt: '2026-04-20T14:10:00.000Z',
+      });
+    } finally {
+      db.close();
+    }
+  });
+
   it('rejects published updates without a usable publicId', async () => {
     const { appDb, db } = await createAppDb(['2026-04-20T12:00:00.000Z']);
 

--- a/packages/db/test/app-db-publication.test.ts
+++ b/packages/db/test/app-db-publication.test.ts
@@ -1,0 +1,172 @@
+import { createRequire } from 'node:module';
+
+import initSqlJs from 'sql.js';
+import { describe, expect, it } from 'vitest';
+
+import { AppDatabase } from '../src/app-db.js';
+import { OpfsStorage } from '../src/opfs.js';
+import { SqliteDbId, SqliteWorkerClient } from '../src/sqlite-client.js';
+
+const require = createRequire(import.meta.url);
+const sqlWasmPath = require.resolve('sql.js/dist/sql-wasm.wasm');
+
+async function loadSqlJs() {
+  return initSqlJs({
+    locateFile: (file: string) => {
+      if (file === 'sql-wasm.wasm') {
+        return sqlWasmPath;
+      }
+      return file;
+    },
+  });
+}
+
+class SqlJsWorkerClientMock {
+  constructor(private readonly db: initSqlJs.Database) {}
+
+  async open(_options: { filename: string }): Promise<SqliteDbId> {
+    return 1;
+  }
+
+  async close(_dbId: SqliteDbId): Promise<void> {
+    return;
+  }
+
+  async exec(input: { dbId: SqliteDbId; sql: string; bind?: unknown[] }): Promise<void> {
+    if (input.bind && input.bind.length > 0) {
+      this.db.run(input.sql, input.bind as any);
+      return;
+    }
+    this.db.exec(input.sql);
+  }
+
+  async query<T extends Record<string, unknown>>(input: {
+    dbId: SqliteDbId;
+    sql: string;
+    bind?: unknown[];
+  }): Promise<T[]> {
+    const statement =
+      input.bind && input.bind.length > 0
+        ? this.db.prepare(input.sql, input.bind as any)
+        : this.db.prepare(input.sql);
+    const rows: T[] = [];
+    try {
+      while (statement.step()) {
+        rows.push(statement.getAsObject() as T);
+      }
+    } finally {
+      statement.free();
+    }
+    return rows;
+  }
+}
+
+async function createAppDb(nowValues: string[]) {
+  const SQL = await loadSqlJs();
+  const db = new SQL.Database();
+  const client = new SqlJsWorkerClientMock(db);
+  const clock = {
+    nowIso: () => nowValues.shift() ?? '2026-04-20T23:59:59.000Z',
+    todayJst: () => '2026-04-20',
+  };
+  const appDb = new AppDatabase(
+    client as unknown as SqliteWorkerClient,
+    {} as OpfsStorage,
+    clock,
+    { uuid: () => '33333333-3333-4333-8333-333333333333' },
+  );
+  await appDb.init();
+  return { appDb, db };
+}
+
+describe('AppDatabase publication state', () => {
+  it('stores published tournament metadata in list and detail views', async () => {
+    const { appDb, db } = await createAppDb([
+      '2026-04-20T10:00:00.000Z',
+      '2026-04-20T10:05:00.000Z',
+    ]);
+
+    try {
+      const tournamentUuid = await appDb.createTournament({
+        tournamentName: '公開テスト',
+        owner: '',
+        hashtag: 'PUBLIC',
+        startDate: '2026-04-20',
+        endDate: '2026-04-25',
+        chartIds: [101, 202],
+        publicStatus: 'publishing',
+      });
+
+      await appDb.markTournamentPublished(tournamentUuid, 'public-001');
+
+      const list = await appDb.listTournaments('active');
+      const detail = await appDb.getTournamentDetail(tournamentUuid);
+
+      expect(list[0]).toMatchObject({
+        tournamentUuid,
+        publicId: 'public-001',
+        publicStatus: 'published',
+        lastPublishAttemptAt: '2026-04-20T10:05:00.000Z',
+      });
+      expect(detail).toMatchObject({
+        tournamentUuid,
+        publicId: 'public-001',
+        publicStatus: 'published',
+        lastPublishAttemptAt: '2026-04-20T10:05:00.000Z',
+      });
+    } finally {
+      db.close();
+    }
+  });
+
+  it('marks tournament publication as retryable after a failed publish attempt', async () => {
+    const { appDb, db } = await createAppDb([
+      '2026-04-20T11:00:00.000Z',
+      '2026-04-20T11:10:00.000Z',
+      '2026-04-20T11:20:00.000Z',
+    ]);
+
+    try {
+      const tournamentUuid = await appDb.createTournament({
+        tournamentName: '再試行テスト',
+        owner: '',
+        hashtag: 'RETRY',
+        startDate: '2026-04-20',
+        endDate: '2026-04-25',
+        chartIds: [303],
+      });
+
+      await appDb.markTournamentPublishing(tournamentUuid);
+      await appDb.markTournamentPublishRetryable(tournamentUuid);
+
+      const detail = await appDb.getTournamentDetail(tournamentUuid);
+      expect(detail).toMatchObject({
+        tournamentUuid,
+        publicId: null,
+        publicStatus: 'retryable',
+        lastPublishAttemptAt: '2026-04-20T11:20:00.000Z',
+      });
+    } finally {
+      db.close();
+    }
+  });
+
+  it('rejects published updates without a usable publicId', async () => {
+    const { appDb, db } = await createAppDb(['2026-04-20T12:00:00.000Z']);
+
+    try {
+      const tournamentUuid = await appDb.createTournament({
+        tournamentName: 'invalid id',
+        owner: '',
+        hashtag: 'INVALID',
+        startDate: '2026-04-20',
+        endDate: '2026-04-25',
+        chartIds: [404],
+      });
+
+      await expect(appDb.markTournamentPublished(tournamentUuid, '   ')).rejects.toThrow('publicId is required.');
+    } finally {
+      db.close();
+    }
+  });
+});

--- a/packages/db/test/schema.test.ts
+++ b/packages/db/test/schema.test.ts
@@ -28,7 +28,7 @@ describe('db schema and mode2 import', () => {
     const db = await createMemoryDb();
     const result = db.exec('PRAGMA user_version;');
     const userVersion = result[0]?.values?.[0]?.[0];
-    expect(userVersion).toBe(2);
+    expect(userVersion).toBe(3);
     db.close();
   });
 
@@ -53,6 +53,17 @@ describe('db schema and mode2 import', () => {
     const rows = result[0]?.values ?? [];
     const columnNames = rows.map((row) => String(row[1]));
     expect(columnNames).toContain('needs_send');
+    db.close();
+  });
+
+  it('adds publication columns to tournaments', async () => {
+    const db = await createMemoryDb();
+    const result = db.exec(`PRAGMA table_info('tournaments');`);
+    const rows = result[0]?.values ?? [];
+    const columnNames = rows.map((row) => String(row[1]));
+    expect(columnNames).toEqual(
+      expect.arrayContaining(['public_id', 'public_status', 'last_publish_attempt_at']),
+    );
     db.close();
   });
 

--- a/packages/web-app/.env.example
+++ b/packages/web-app/.env.example
@@ -4,3 +4,8 @@ VITE_SONG_MASTER_SCHEMA_VERSION=33
 # DEV mode uses local mock server:
 # node scripts/mock-song-master-server.mjs --sqlite ./song_master.sqlite --schema 33 --port 8787
 # PROD mode serves /song-master/* from the deployed artifact (synced in deploy workflow).
+
+# Optional public catalog API base URL. Leave blank to keep local publish disabled.
+# Example DEV:  VITE_PUBLIC_CATALOG_API_BASE_URL=http://127.0.0.1:8787/
+# Example PROD: VITE_PUBLIC_CATALOG_API_BASE_URL=https://iidx-public-catalog-api.<your-subdomain>.workers.dev/
+VITE_PUBLIC_CATALOG_API_BASE_URL=

--- a/packages/web-app/src/App.tsx
+++ b/packages/web-app/src/App.tsx
@@ -2037,6 +2037,7 @@ export function App({ webLockAcquired = false }: AppProps = {}): JSX.Element {
     const bootstrap = async () => {
       try {
         await appDb.reconcileEvidenceFiles();
+        await appDb.reconcileInterruptedTournamentPublications();
         const purged = await appDb.purgeExpiredEvidenceIfNeeded();
         if (purged > 0) {
           appendRuntimeLog({

--- a/packages/web-app/src/App.tsx
+++ b/packages/web-app/src/App.tsx
@@ -60,7 +60,9 @@ import {
   restoreCreateTournamentDraft,
   type CreateTournamentDraft,
 } from './pages/create-tournament-draft';
+import { resolvePublicCatalogErrorI18n } from './services/public-catalog-client';
 import { useAppServices } from './services/context';
+import { buildPublicTournamentPayload, publishTournamentDefinition } from './services/public-catalog-publish';
 import { resolveSongMasterRuntimeConfig } from './services/song-master-config';
 import { extractQrTextFromImage } from './utils/image';
 import {
@@ -1083,7 +1085,7 @@ async function resolveOpfsStatus(): Promise<AppInfoCardData['opfsStatus']> {
 }
 
 export function App({ webLockAcquired = false }: AppProps = {}): JSX.Element {
-  const { appDb, opfs, songMasterService } = useAppServices();
+  const { appDb, opfs, publicCatalogClient, songMasterService } = useAppServices();
   const { t } = useTranslation();
   const theme = useTheme();
   const prefersReducedMotion = usePrefersReducedMotion();
@@ -1749,6 +1751,41 @@ export function App({ webLockAcquired = false }: AppProps = {}): JSX.Element {
     setHomeTournamentBuckets({ active, upcoming, ended });
   }, [appDb]);
 
+  const startBackgroundTournamentPublication = React.useCallback(
+    (tournamentUuid: string, payload: TournamentPayload) => {
+      if (!publicCatalogClient.isAvailable()) {
+        return;
+      }
+
+      void (async () => {
+        const result = await publishTournamentDefinition({
+          appDb,
+          publicCatalogClient,
+          tournamentUuid,
+          payload,
+        });
+        await refreshTournamentList();
+
+        if (result.status === 'published') {
+          pushToast(t('public_catalog.notice.published'));
+          return;
+        }
+        if (result.status === 'duplicate') {
+          pushToast(t('public_catalog.notice.duplicate'));
+          return;
+        }
+        if (result.status === 'retryable') {
+          const spec = resolvePublicCatalogErrorI18n(result.error);
+          pushToast(spec.params ? t(spec.key, spec.params) : t(spec.key));
+        }
+      })().catch((error: unknown) => {
+        const spec = resolvePublicCatalogErrorI18n(error);
+        pushToast(spec.params ? t(spec.key, spec.params) : t(spec.key));
+      });
+    },
+    [appDb, publicCatalogClient, pushToast, refreshTournamentList, t],
+  );
+
   const refreshSettingsSnapshot = React.useCallback(async () => {
     const songMeta = await appDb.getSongMasterMeta();
     const songReady = await appDb.hasSongMaster();
@@ -2358,19 +2395,44 @@ export function App({ webLockAcquired = false }: AppProps = {}): JSX.Element {
     setCreateSaveError(null);
     try {
       const input = buildCreateTournamentInput(createDraft, validation.selectedChartIds);
-      await appDb.createTournament(input);
+      const publishPayload = buildPublicTournamentPayload(input.tournamentUuid ?? crypto.randomUUID(), input);
+      const publishEnabled = publicCatalogClient.isAvailable();
+      const tournamentUuid = await appDb.createTournament({
+        ...input,
+        ...(publishEnabled
+          ? {
+              tournamentUuid: publishPayload.uuid,
+              publicStatus: 'publishing',
+              lastPublishAttemptAt: new Date().toISOString(),
+            }
+          : {}),
+      });
       pushToast(t('notify.saved'));
       await refreshTournamentList();
       clearStoredCreateDraft();
       setCreateDraftDirty(false);
       setCreateDraft(null);
       resetRoute({ name: 'home' });
+      if (publishEnabled) {
+        startBackgroundTournamentPublication(tournamentUuid, publishPayload);
+      }
     } catch (error) {
       setCreateSaveError(resolveErrorMessage(t, error, 'error.description.generic'));
     } finally {
       setCreateSaving(false);
     }
-  }, [appDb, createDraft, createSaving, pushToast, refreshTournamentList, resetRoute, t, todayDate]);
+  }, [
+    appDb,
+    createDraft,
+    createSaving,
+    publicCatalogClient,
+    pushToast,
+    refreshTournamentList,
+    resetRoute,
+    startBackgroundTournamentPublication,
+    t,
+    todayDate,
+  ]);
 
   const saveAutoDelete = React.useCallback(
     async (enabled: boolean, days: number) => {

--- a/packages/web-app/src/components/TournamentSummaryCard.tsx
+++ b/packages/web-app/src/components/TournamentSummaryCard.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { daysUntilStart } from '@iidx/shared';
+import type { TournamentPublicationStatus } from '@iidx/db';
 import { useTheme } from '@mui/material/styles';
 import { useTranslation } from 'react-i18next';
 
@@ -24,6 +25,8 @@ interface TournamentSummaryCardProps {
   shareAction?: React.ReactNode;
   prefersReducedMotion?: boolean;
   animateProgress?: boolean;
+  publicationStatus?: TournamentPublicationStatus;
+  showPublicationStatus?: boolean;
 }
 
 function joinClasses(...values: Array<string | undefined | null | false>): string {
@@ -48,6 +51,19 @@ function resolveRelativeTone(status: TournamentStatus): RelativeTone {
     return 'urgent';
   }
   return 'normal';
+}
+
+function resolvePublicationLabelKey(status: TournamentPublicationStatus): string {
+  if (status === 'publishing') {
+    return 'public_catalog.status.publishing';
+  }
+  if (status === 'published') {
+    return 'public_catalog.status.published';
+  }
+  if (status === 'retryable') {
+    return 'public_catalog.status.retryable';
+  }
+  return 'public_catalog.status.unpublished';
 }
 
 export function TournamentSummaryCard(props: TournamentSummaryCardProps): JSX.Element {
@@ -98,6 +114,8 @@ export function TournamentSummaryCard(props: TournamentSummaryCardProps): JSX.El
   const progressValueText = `${submittedCount}/${totalCount}`;
   const showDetailLink = props.variant === 'list';
   const showShareAction = props.variant === 'detail' && Boolean(props.shareAction);
+  const publicationStatus = props.publicationStatus ?? 'unpublished';
+  const showPublicationStatus = Boolean(props.showPublicationStatus);
   const [displayedProgress, setDisplayedProgress] = React.useState(() => ({
     shared: shouldAnimateProgress ? 0 : sharedPercent,
     unshared: shouldAnimateProgress ? 0 : unsharedPercent,
@@ -180,6 +198,20 @@ export function TournamentSummaryCard(props: TournamentSummaryCardProps): JSX.El
                 {t('home.progress.badge.send_waiting', { count: safeUnsharedCount })} {safeUnsharedCount}
               </span>
             ) : null}
+          </div>
+        ) : null}
+        {showPublicationStatus ? (
+          <div className="tournamentStatusLabelRow" data-testid={`tournament-summary-publication-row-${props.variant}`}>
+            <span
+              className={joinClasses(
+                'tournamentStatusLabel',
+                'tournamentStatusLabel-publication',
+                `tournamentStatusLabel-publication-${publicationStatus}`,
+              )}
+              data-testid={`tournament-summary-publication-${props.variant}`}
+            >
+              {t(resolvePublicationLabelKey(publicationStatus))}
+            </span>
           </div>
         ) : null}
         {showProgress ? (

--- a/packages/web-app/src/i18n/locales/en.json
+++ b/packages/web-app/src/i18n/locales/en.json
@@ -414,6 +414,33 @@
     "deleted": "Deleted.",
     "updated": "Updated."
   },
+  "public_catalog": {
+    "section": {
+      "title": "Publication"
+    },
+    "action": {
+      "retry": "Retry publish",
+      "retrying": "Retrying..."
+    },
+    "status": {
+      "unpublished": "Unpublished",
+      "publishing": "Publishing",
+      "published": "Published",
+      "retryable": "Unpublished (retry available)"
+    },
+    "summary": {
+      "last_attempt": "Last publish attempt: {{value}}"
+    },
+    "notice": {
+      "published": "Published to the public catalog.",
+      "duplicate": "Matched an existing public catalog entry."
+    },
+    "error": {
+      "unavailable": "Public catalog API is not configured.",
+      "rate_limited": "The public catalog API is rate limited. Please try again later.",
+      "publish_failed": "Publishing failed. Please try again later."
+    }
+  },
   "create_tournament": {
     "wizard": {
       "aria_label": "Score Attack definition wizard",

--- a/packages/web-app/src/i18n/locales/ja.json
+++ b/packages/web-app/src/i18n/locales/ja.json
@@ -414,6 +414,33 @@
     "deleted": "削除しました。",
     "updated": "更新しました。"
   },
+  "public_catalog": {
+    "section": {
+      "title": "公開状態"
+    },
+    "action": {
+      "retry": "公開を再試行",
+      "retrying": "再試行中..."
+    },
+    "status": {
+      "unpublished": "未公開",
+      "publishing": "公開中",
+      "published": "公開済み",
+      "retryable": "未公開（再試行可）"
+    },
+    "summary": {
+      "last_attempt": "最終公開試行: {{value}}"
+    },
+    "notice": {
+      "published": "公開登録しました。",
+      "duplicate": "既に公開済みとして反映しました。"
+    },
+    "error": {
+      "unavailable": "公開 API が未設定のため公開できません。",
+      "rate_limited": "公開 API の上限に達しました。時間を置いて再試行してください。",
+      "publish_failed": "公開に失敗しました。しばらくしてから再試行してください。"
+    }
+  },
   "create_tournament": {
     "wizard": {
       "aria_label": "スコアタ定義ウィザード",

--- a/packages/web-app/src/i18n/locales/ko.json
+++ b/packages/web-app/src/i18n/locales/ko.json
@@ -414,6 +414,33 @@
     "deleted": "삭제했습니다.",
     "updated": "업데이트했습니다."
   },
+  "public_catalog": {
+    "section": {
+      "title": "공개 상태"
+    },
+    "action": {
+      "retry": "공개 다시 시도",
+      "retrying": "재시도 중..."
+    },
+    "status": {
+      "unpublished": "미공개",
+      "publishing": "공개 중",
+      "published": "공개됨",
+      "retryable": "미공개(재시도 가능)"
+    },
+    "summary": {
+      "last_attempt": "마지막 공개 시도: {{value}}"
+    },
+    "notice": {
+      "published": "공개 카탈로그에 등록했습니다.",
+      "duplicate": "이미 공개된 항목으로 반영했습니다."
+    },
+    "error": {
+      "unavailable": "공개 API가 설정되지 않아 공개할 수 없습니다.",
+      "rate_limited": "공개 API 호출 한도에 도달했습니다. 잠시 후 다시 시도해 주세요.",
+      "publish_failed": "공개에 실패했습니다. 잠시 후 다시 시도해 주세요."
+    }
+  },
   "create_tournament": {
     "wizard": {
       "aria_label": "스코어 어택 정의 마법사",

--- a/packages/web-app/src/pages/HomePage.test.tsx
+++ b/packages/web-app/src/pages/HomePage.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { cleanup, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { HomePage } from './HomePage';
@@ -152,5 +152,64 @@ describe('HomePage', () => {
     expect(emptyResetButton).toBeTruthy();
     await userEvent.click(emptyResetButton as HTMLButtonElement);
     expect(onOpenFilterInEmpty).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows publication status for local tournaments and hides it for imported tournaments', () => {
+    cleanup();
+    const { container, rerender } = render(
+      <HomePage
+        todayDate="2026-02-10"
+        state="active"
+        prefersReducedMotion
+        items={[
+          {
+            tournamentUuid: 't1',
+            sourceTournamentUuid: null,
+            tournamentName: '公開大会',
+            owner: 'owner',
+            hashtag: 'tag',
+            startDate: '2026-02-01',
+            endDate: '2026-02-12',
+            isImported: false,
+            chartCount: 1,
+            submittedCount: 0,
+            sendWaitingCount: 0,
+            pendingCount: 1,
+            publicStatus: 'retryable',
+          },
+        ]}
+        onOpenDetail={() => undefined}
+      />,
+    );
+
+    expect(container.querySelector('[data-testid="tournament-summary-publication-list"]')?.textContent).toBe('未公開（再試行可）');
+
+    rerender(
+      <HomePage
+        todayDate="2026-02-10"
+        state="active"
+        prefersReducedMotion
+        items={[
+          {
+            tournamentUuid: 't2',
+            sourceTournamentUuid: 'public-1',
+            tournamentName: '取込大会',
+            owner: 'owner',
+            hashtag: 'tag',
+            startDate: '2026-02-01',
+            endDate: '2026-02-12',
+            isImported: true,
+            chartCount: 1,
+            submittedCount: 0,
+            sendWaitingCount: 0,
+            pendingCount: 1,
+            publicStatus: 'published',
+          },
+        ]}
+        onOpenDetail={() => undefined}
+      />,
+    );
+
+    expect(container.querySelector('[data-testid="tournament-summary-publication-list"]')).toBeNull();
   });
 });

--- a/packages/web-app/src/pages/HomePage.tsx
+++ b/packages/web-app/src/pages/HomePage.tsx
@@ -341,6 +341,8 @@ export function HomePage(props: HomePageProps): JSX.Element {
                       sharedCount={progress.sharedCount}
                       unsharedCount={progress.sendWaitingCount}
                       unregisteredCount={progress.unregisteredCount}
+                      showPublicationStatus={!entry.item.isImported}
+                      {...(entry.item.publicStatus ? { publicationStatus: entry.item.publicStatus } : {})}
                       prefersReducedMotion={prefersReducedMotion}
                       onOpenDetail={() => props.onOpenDetail(entry.item.tournamentUuid)}
                     />

--- a/packages/web-app/src/pages/TournamentDetailPage.test.tsx
+++ b/packages/web-app/src/pages/TournamentDetailPage.test.tsx
@@ -17,8 +17,15 @@ const serviceMocks = vi.hoisted(() => ({
   appDb: {
     getEvidenceRecord: vi.fn(),
     getEvidenceRelativePath: vi.fn(),
+    markTournamentPublishing: vi.fn(),
+    markTournamentPublished: vi.fn(),
+    markTournamentPublishRetryable: vi.fn(),
     markEvidenceSendCompleted: vi.fn(),
     markEvidenceSendPending: vi.fn(),
+  },
+  publicCatalogClient: {
+    isAvailable: vi.fn(),
+    registerTournament: vi.fn(),
   },
   opfs: {
     readFile: vi.fn(),
@@ -53,6 +60,9 @@ const detail: TournamentDetailItem = {
   submittedCount: 2,
   sendWaitingCount: 1,
   pendingCount: 1,
+  publicId: null,
+  publicStatus: 'unpublished',
+  lastPublishAttemptAt: null,
   lastSubmittedAt: '2026-02-10T12:00:00.000Z',
   charts: [
     {
@@ -108,6 +118,8 @@ function renderPage(
   options: {
     debugModeEnabled?: boolean;
     onOpenSubmit?: (chartId: number) => void;
+    onUpdated?: () => Promise<void> | void;
+    onReportDebugError?: (errorMessage: string | null) => void;
     returnSignal?: TournamentDetailReturnSignal | null;
     onConsumeReturnSignal?: (token: string) => void;
     prefersReducedMotion?: boolean;
@@ -118,11 +130,11 @@ function renderPage(
       detail={buildDetail(overrides)}
       todayDate={todayDate}
       onOpenSubmit={options.onOpenSubmit ?? (() => undefined)}
-      onUpdated={() => undefined}
+      onUpdated={options.onUpdated ?? (() => undefined)}
       onOpenSettings={() => undefined}
       debugModeEnabled={options.debugModeEnabled ?? false}
       debugLastError={null}
-      onReportDebugError={() => undefined}
+      onReportDebugError={options.onReportDebugError ?? (() => undefined)}
       returnSignal={options.returnSignal ?? null}
       {...(options.onConsumeReturnSignal ? { onConsumeReturnSignal: options.onConsumeReturnSignal } : {})}
       {...(options.prefersReducedMotion !== undefined ? { prefersReducedMotion: options.prefersReducedMotion } : {})}
@@ -271,8 +283,13 @@ describe('TournamentDetailPage', () => {
     vi.clearAllMocks();
     serviceMocks.appDb.getEvidenceRecord.mockResolvedValue({ fileDeleted: false });
     serviceMocks.appDb.getEvidenceRelativePath.mockResolvedValue('evidences/mock/1.jpg');
+    serviceMocks.appDb.markTournamentPublishing.mockResolvedValue(undefined);
+    serviceMocks.appDb.markTournamentPublished.mockResolvedValue(undefined);
+    serviceMocks.appDb.markTournamentPublishRetryable.mockResolvedValue(undefined);
     serviceMocks.appDb.markEvidenceSendCompleted.mockResolvedValue(undefined);
     serviceMocks.appDb.markEvidenceSendPending.mockResolvedValue(undefined);
+    serviceMocks.publicCatalogClient.isAvailable.mockReturnValue(false);
+    serviceMocks.publicCatalogClient.registerTournament.mockResolvedValue({ status: 'created', publicId: 'public-1' });
     serviceMocks.opfs.readFile.mockResolvedValue(new Uint8Array([1, 2, 3]));
     vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => undefined);
   });
@@ -553,6 +570,70 @@ describe('TournamentDetailPage', () => {
       expect(serviceMocks.appDb.markEvidenceSendCompleted).not.toHaveBeenCalled();
     });
     expect(screen.getByTestId('tournament-detail-submit-summary-text').getAttribute('data-send-pending-count')).toBe('1');
+  });
+
+  it('retries publication from detail when local tournament is retryable', async () => {
+    const onUpdated = vi.fn();
+    serviceMocks.publicCatalogClient.isAvailable.mockReturnValue(true);
+    serviceMocks.publicCatalogClient.registerTournament.mockResolvedValue({ status: 'created', publicId: 'public-99' });
+
+    renderPage(
+      {
+        publicStatus: 'retryable',
+        lastPublishAttemptAt: '2026-02-10T12:00:00.000Z',
+      },
+      '2026-02-10',
+      { onUpdated },
+    );
+
+    expect(screen.getByTestId('tournament-summary-publication-detail').textContent).toBe('未公開（再試行可）');
+    expect(screen.getByTestId('tournament-detail-publication-last-attempt').textContent).toContain('2026');
+
+    await userEvent.click(screen.getByTestId('tournament-detail-publication-retry-button'));
+
+    await waitFor(() => {
+      expect(serviceMocks.appDb.markTournamentPublishing).toHaveBeenCalledWith(detail.tournamentUuid);
+      expect(serviceMocks.publicCatalogClient.registerTournament).toHaveBeenCalledTimes(1);
+      expect(serviceMocks.appDb.markTournamentPublished).toHaveBeenCalledWith(detail.tournamentUuid, 'public-99');
+    });
+    expect(onUpdated).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('tournament-detail-publication-notice').textContent).toBe('公開登録しました。');
+  });
+
+  it('keeps retryable notice when publication retry fails', async () => {
+    const onReportDebugError = vi.fn();
+    serviceMocks.publicCatalogClient.isAvailable.mockReturnValue(true);
+    serviceMocks.publicCatalogClient.registerTournament.mockRejectedValue(new Error('network failed'));
+
+    renderPage(
+      {
+        publicStatus: 'retryable',
+      },
+      '2026-02-10',
+      { onReportDebugError },
+    );
+
+    await userEvent.click(screen.getByTestId('tournament-detail-publication-retry-button'));
+
+    await waitFor(() => {
+      expect(serviceMocks.appDb.markTournamentPublishRetryable).toHaveBeenCalledWith(detail.tournamentUuid);
+    });
+    expect(serviceMocks.appDb.markTournamentPublished).not.toHaveBeenCalled();
+    expect(screen.getByTestId('tournament-detail-publication-notice').textContent).toContain('network failed');
+    expect(onReportDebugError).toHaveBeenCalledWith(expect.stringContaining('network failed'));
+  });
+
+  it('hides publication panel for imported tournaments', () => {
+    serviceMocks.publicCatalogClient.isAvailable.mockReturnValue(true);
+
+    renderPage({
+      isImported: true,
+      publicStatus: 'published',
+      publicId: 'public-imported',
+    });
+
+    expect(screen.queryByTestId('tournament-detail-publication-panel')).toBeNull();
+    expect(screen.queryByTestId('tournament-summary-publication-detail')).toBeNull();
   });
 
   it('simplifies share dialog and keeps only required controls', async () => {

--- a/packages/web-app/src/pages/TournamentDetailPage.tsx
+++ b/packages/web-app/src/pages/TournamentDetailPage.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { PAYLOAD_VERSION, encodeTournamentPayload, formatHashtagForDisplay, normalizeHashtag } from '@iidx/shared';
-import type { TournamentDetailChart, TournamentDetailItem } from '@iidx/db';
+import type { TournamentDetailChart, TournamentDetailItem, TournamentPublicationStatus } from '@iidx/db';
 import QRCode from 'qrcode';
 import { useTranslation } from 'react-i18next';
 import CloseIcon from '@mui/icons-material/Close';
@@ -28,6 +28,8 @@ import {
 import useMediaQuery from '@mui/material/useMediaQuery';
 
 import { useAppServices } from '../services/context';
+import { resolvePublicCatalogErrorI18n } from '../services/public-catalog-client';
+import { buildPublicTournamentPayloadFromDetail, publishTournamentDefinition } from '../services/public-catalog-publish';
 import { ChartCard } from '../components/ChartCard';
 import { toSafeArrayBuffer } from '../utils/image';
 import { buildImportUrl } from '../utils/payload-url';
@@ -232,6 +234,30 @@ function resolveChartShareState(localSaved: boolean, submitted: boolean): ChartS
     return 'unregistered';
   }
   return submitted ? 'shared' : 'unshared';
+}
+
+function resolvePublicationStatusLabelKey(status: TournamentPublicationStatus): string {
+  if (status === 'publishing') {
+    return 'public_catalog.status.publishing';
+  }
+  if (status === 'published') {
+    return 'public_catalog.status.published';
+  }
+  if (status === 'retryable') {
+    return 'public_catalog.status.retryable';
+  }
+  return 'public_catalog.status.unpublished';
+}
+
+function formatPublicationAttempt(value: string | null | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return value;
+  }
+  return parsed.toLocaleString();
 }
 
 function resolveChartTaskStatus(
@@ -598,7 +624,7 @@ async function buildShareImage(detail: TournamentDetailItem, shareUrl: string, t
 }
 
 export function TournamentDetailPage(props: TournamentDetailPageProps): JSX.Element {
-  const { appDb, opfs } = useAppServices();
+  const { appDb, opfs, publicCatalogClient } = useAppServices();
   const { t } = useTranslation();
   const theme = useTheme();
   const prefersReducedMotion = props.prefersReducedMotion ?? useMediaQuery('(prefers-reduced-motion: reduce)');
@@ -618,6 +644,8 @@ export function TournamentDetailPage(props: TournamentDetailPageProps): JSX.Elem
   const [submitUndoBusy, setSubmitUndoBusy] = React.useState(false);
   const [submitToast, setSubmitToast] = React.useState<SubmitToast | null>(null);
   const [submitToastOpen, setSubmitToastOpen] = React.useState(false);
+  const [publicationBusy, setPublicationBusy] = React.useState(false);
+  const [publicationNotice, setPublicationNotice] = React.useState<ShareNotice | null>(null);
   const [needsSendOverrides, setNeedsSendOverrides] = React.useState<Record<number, boolean>>({});
   const [chartSubmitLocked, setChartSubmitLocked] = React.useState(false);
   const [footerSubmitLocked, setFooterSubmitLocked] = React.useState(false);
@@ -684,6 +712,17 @@ export function TournamentDetailPage(props: TournamentDetailPageProps): JSX.Elem
     () => props.detail.charts.some((chart) => chart.resolveIssue === 'CHART_NOT_FOUND'),
     [props.detail.charts],
   );
+  const publicationStatus = publicationBusy ? 'publishing' : props.detail.publicStatus ?? 'unpublished';
+  const formattedLastPublishAttempt = React.useMemo(
+    () => formatPublicationAttempt(props.detail.lastPublishAttemptAt),
+    [props.detail.lastPublishAttemptAt],
+  );
+  const showPublicationSection = !props.detail.isImported;
+  const canRetryPublication =
+    showPublicationSection &&
+    publicCatalogClient.isAvailable() &&
+    publicationStatus === 'retryable' &&
+    !publicationBusy;
   const showChartResolveAlert = hasMasterMissing || hasChartNotFound;
   const resolveNeedsSend = React.useCallback(
     (chart: TournamentDetailChart): boolean => {
@@ -1268,6 +1307,49 @@ export function TournamentDetailPage(props: TournamentDetailPageProps): JSX.Elem
     t,
   ]);
 
+  const retryPublication = React.useCallback(async () => {
+    if (!canRetryPublication) {
+      return;
+    }
+
+    setPublicationBusy(true);
+    setPublicationNotice(null);
+    try {
+      const result = await publishTournamentDefinition({
+        appDb,
+        publicCatalogClient,
+        tournamentUuid: props.detail.tournamentUuid,
+        payload: buildPublicTournamentPayloadFromDetail(props.detail),
+        setPublishing: true,
+      });
+      await Promise.resolve(props.onUpdated());
+
+      if (result.status === 'published') {
+        setPublicationNotice({ severity: 'success', text: t('public_catalog.notice.published') });
+        props.onReportDebugError(null);
+        return;
+      }
+      if (result.status === 'duplicate') {
+        setPublicationNotice({ severity: 'success', text: t('public_catalog.notice.duplicate') });
+        props.onReportDebugError(null);
+        return;
+      }
+      if (result.status === 'retryable') {
+        const spec = resolvePublicCatalogErrorI18n(result.error);
+        const message = spec.params ? t(spec.key, spec.params) : t(spec.key);
+        setPublicationNotice({ severity: 'warning', text: message });
+        props.onReportDebugError(message);
+      }
+    } catch (error: unknown) {
+      const spec = resolvePublicCatalogErrorI18n(error);
+      const message = spec.params ? t(spec.key, spec.params) : t(spec.key);
+      setPublicationNotice({ severity: 'warning', text: message });
+      props.onReportDebugError(message);
+    } finally {
+      setPublicationBusy(false);
+    }
+  }, [appDb, canRetryPublication, props, publicCatalogClient, t]);
+
   return (
     <div className="page detailPageWithSubmitBar">
       <TournamentSummaryCard
@@ -1280,6 +1362,8 @@ export function TournamentDetailPage(props: TournamentDetailPageProps): JSX.Elem
         sharedCount={chartStateCounts.shared}
         unsharedCount={chartStateCounts.unshared}
         unregisteredCount={chartStateCounts.unregistered}
+        publicationStatus={publicationStatus}
+        showPublicationStatus={showPublicationSection}
         prefersReducedMotion={prefersReducedMotion}
         animateProgress={summaryProgressAnimationEnabled}
         shareAction={
@@ -1293,6 +1377,43 @@ export function TournamentDetailPage(props: TournamentDetailPageProps): JSX.Elem
           ) : null
         }
       />
+      {showPublicationSection ? (
+        <section className="detailCard" data-testid="tournament-detail-publication-panel">
+          <Stack
+            direction={{ xs: 'column', sm: 'row' }}
+            spacing={1.5}
+            justifyContent="space-between"
+            alignItems={{ xs: 'flex-start', sm: 'center' }}
+          >
+            <Box>
+              <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 0.5 }}>
+                {t('public_catalog.section.title')}
+              </Typography>
+              <Typography variant="body2">{t(resolvePublicationStatusLabelKey(publicationStatus))}</Typography>
+              {formattedLastPublishAttempt ? (
+                <Typography variant="body2" color="text.secondary" data-testid="tournament-detail-publication-last-attempt">
+                  {t('public_catalog.summary.last_attempt', { value: formattedLastPublishAttempt })}
+                </Typography>
+              ) : null}
+            </Box>
+            {publicCatalogClient.isAvailable() && (publicationStatus === 'retryable' || publicationBusy) ? (
+              <Button
+                variant="outlined"
+                onClick={() => void retryPublication()}
+                disabled={!canRetryPublication}
+                data-testid="tournament-detail-publication-retry-button"
+              >
+                {publicationBusy ? t('public_catalog.action.retrying') : t('public_catalog.action.retry')}
+              </Button>
+            ) : null}
+          </Stack>
+          {publicationNotice ? (
+            <Alert severity={publicationNotice.severity} sx={{ mt: 1.5 }} data-testid="tournament-detail-publication-notice">
+              {publicationNotice.text}
+            </Alert>
+          ) : null}
+        </section>
+      ) : null}
 
       <section>
         <h2>{t('tournament_detail.chart.heading')}</h2>

--- a/packages/web-app/src/services/app-services.ts
+++ b/packages/web-app/src/services/app-services.ts
@@ -8,6 +8,8 @@ import {
 } from '@iidx/db';
 import type { CreateSqliteWorkerClientOptions, IdFactory } from '@iidx/db';
 
+import { FetchPublicCatalogClient, type PublicCatalogClient } from './public-catalog-client';
+import { resolvePublicCatalogRuntimeConfig } from './public-catalog-config';
 import { resolveSongMasterRuntimeConfig } from './song-master-config';
 
 export interface AppServices {
@@ -15,6 +17,7 @@ export interface AppServices {
   opfs: OpfsStorage;
   appDb: AppDatabase;
   songMasterService: SongMasterService;
+  publicCatalogClient: PublicCatalogClient;
 }
 
 export interface AppServiceOverrides {
@@ -22,6 +25,7 @@ export interface AppServiceOverrides {
   opfs?: OpfsStorage;
   appDb?: AppDatabase;
   songMasterService?: SongMasterService;
+  publicCatalogClient?: PublicCatalogClient;
   clock?: RuntimeClock;
   idFactory?: IdFactory;
   fetchImpl?: typeof fetch;
@@ -30,6 +34,7 @@ export interface AppServiceOverrides {
 export async function createAppServices(overrides: AppServiceOverrides = {}): Promise<AppServices> {
   const workerUrl = `${import.meta.env.BASE_URL}sqlite/sqlite3-worker1.mjs`;
   const songMasterConfig = resolveSongMasterRuntimeConfig(import.meta.env);
+  const publicCatalogConfig = resolvePublicCatalogRuntimeConfig(import.meta.env);
 
   const sqliteClient =
     overrides.sqliteClient ??
@@ -54,11 +59,15 @@ export async function createAppServices(overrides: AppServiceOverrides = {}): Pr
   const songMasterService =
     overrides.songMasterService ??
     new SongMasterService(appDb, sqliteClient, opfs, songMasterOptions);
+  const publicCatalogClient =
+    overrides.publicCatalogClient ??
+    new FetchPublicCatalogClient(publicCatalogConfig, overrides.fetchImpl);
 
   return {
     sqliteClient,
     opfs,
     appDb,
     songMasterService,
+    publicCatalogClient,
   };
 }

--- a/packages/web-app/src/services/public-catalog-client.ts
+++ b/packages/web-app/src/services/public-catalog-client.ts
@@ -1,0 +1,162 @@
+import type {
+  PublicCatalogApiErrorCode,
+  PublicCatalogApiErrorResponse,
+  PublicTournamentRegisterResponse,
+  TournamentPayload,
+} from '@iidx/shared';
+
+import type { PublicCatalogRuntimeConfig } from './public-catalog-config';
+
+const REGISTER_PUBLIC_TOURNAMENT_PATH = 'api/public-tournaments';
+
+export interface PublicCatalogErrorI18nSpec {
+  key: string;
+  params?: Record<string, unknown>;
+}
+
+export interface PublicCatalogClient {
+  isAvailable(): boolean;
+  registerTournament(payload: TournamentPayload): Promise<PublicTournamentRegisterResponse>;
+}
+
+export class PublicCatalogClientError extends Error {
+  constructor(
+    public readonly kind: 'api' | 'invalid_response' | 'network' | 'unavailable',
+    message: string,
+    public readonly code?: PublicCatalogApiErrorCode,
+    public readonly status?: number,
+  ) {
+    super(message);
+    this.name = 'PublicCatalogClientError';
+  }
+}
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function isRegisterResponse(value: unknown): value is PublicTournamentRegisterResponse {
+  if (!isObjectRecord(value)) {
+    return false;
+  }
+  const publicId = value.publicId;
+  const status = value.status;
+  return typeof publicId === 'string' && publicId.trim().length > 0 && (status === 'created' || status === 'duplicate');
+}
+
+function readApiErrorCode(value: unknown): PublicCatalogApiErrorCode | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  return value as PublicCatalogApiErrorCode;
+}
+
+function parseApiErrorResponse(value: unknown): PublicCatalogApiErrorResponse | null {
+  if (!isObjectRecord(value) || !isObjectRecord(value.error)) {
+    return null;
+  }
+  const code = readApiErrorCode(value.error.code);
+  const message = value.error.message;
+  if (!code || typeof message !== 'string' || message.trim().length === 0) {
+    return null;
+  }
+  return {
+    error: {
+      code,
+      message,
+      ...(isObjectRecord(value.error.details) ? { details: value.error.details } : {}),
+    },
+  };
+}
+
+async function readJsonResponse(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (text.trim().length === 0) {
+    return null;
+  }
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw new PublicCatalogClientError('invalid_response', 'public catalog response must be valid JSON.', undefined, response.status);
+  }
+}
+
+export class FetchPublicCatalogClient implements PublicCatalogClient {
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(
+    private readonly config: PublicCatalogRuntimeConfig,
+    fetchImpl?: typeof fetch,
+  ) {
+    this.fetchImpl = fetchImpl ?? fetch;
+  }
+
+  isAvailable(): boolean {
+    return Boolean(this.config.apiBaseUrl);
+  }
+
+  async registerTournament(payload: TournamentPayload): Promise<PublicTournamentRegisterResponse> {
+    if (!this.config.apiBaseUrl) {
+      throw new PublicCatalogClientError('unavailable', 'public catalog api is unavailable.');
+    }
+
+    let response: Response;
+    try {
+      response = await this.fetchImpl(new URL(REGISTER_PUBLIC_TOURNAMENT_PATH, this.config.apiBaseUrl), {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+      });
+    } catch (error) {
+      throw new PublicCatalogClientError(
+        'network',
+        error instanceof Error ? error.message : 'public catalog request failed.',
+      );
+    }
+
+    const body = await readJsonResponse(response);
+    if (!response.ok) {
+      const apiError = parseApiErrorResponse(body);
+      throw new PublicCatalogClientError(
+        'api',
+        apiError?.error.message ?? `public catalog request failed with status ${response.status}.`,
+        apiError?.error.code,
+        response.status,
+      );
+    }
+
+    if (!isRegisterResponse(body)) {
+      throw new PublicCatalogClientError(
+        'invalid_response',
+        'public catalog response is missing publication metadata.',
+        undefined,
+        response.status,
+      );
+    }
+
+    return body;
+  }
+}
+
+export function resolvePublicCatalogErrorI18n(error: unknown): PublicCatalogErrorI18nSpec {
+  if (error instanceof PublicCatalogClientError) {
+    if (error.kind === 'unavailable') {
+      return { key: 'public_catalog.error.unavailable' };
+    }
+    if (error.kind === 'api' && error.code === 'RATE_LIMITED') {
+      return { key: 'public_catalog.error.rate_limited' };
+    }
+    if (error.kind === 'network' && typeof navigator !== 'undefined' && navigator.onLine === false) {
+      return { key: 'error.network.offline' };
+    }
+  }
+  if (error instanceof Error && error.message.trim().length > 0) {
+    return {
+      key: 'error.description.with_detail',
+      params: { message: error.message },
+    };
+  }
+  return { key: 'public_catalog.error.publish_failed' };
+}

--- a/packages/web-app/src/services/public-catalog-config.test.ts
+++ b/packages/web-app/src/services/public-catalog-config.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolvePublicCatalogRuntimeConfig } from './public-catalog-config';
+
+describe('resolvePublicCatalogRuntimeConfig', () => {
+  it('disables local publish when no public catalog URL is configured', () => {
+    const config = resolvePublicCatalogRuntimeConfig({} as ImportMetaEnv);
+
+    expect(config).toEqual({
+      apiBaseUrl: null,
+      source: 'disabled',
+    });
+  });
+
+  it('normalizes configured public catalog URLs', () => {
+    const config = resolvePublicCatalogRuntimeConfig({
+      VITE_PUBLIC_CATALOG_API_BASE_URL: 'https://example.workers.dev',
+    } as ImportMetaEnv);
+
+    expect(config).toEqual({
+      apiBaseUrl: 'https://example.workers.dev/',
+      source: 'env',
+    });
+  });
+
+  it('rejects invalid public catalog URLs', () => {
+    expect(() =>
+      resolvePublicCatalogRuntimeConfig({
+        VITE_PUBLIC_CATALOG_API_BASE_URL: '/relative-path',
+      } as ImportMetaEnv),
+    ).toThrow('VITE_PUBLIC_CATALOG_API_BASE_URL');
+  });
+});

--- a/packages/web-app/src/services/public-catalog-config.ts
+++ b/packages/web-app/src/services/public-catalog-config.ts
@@ -1,0 +1,41 @@
+export type PublicCatalogConfigSource = 'env' | 'disabled';
+
+export interface PublicCatalogRuntimeConfig {
+  apiBaseUrl: string | null;
+  source: PublicCatalogConfigSource;
+}
+
+function ensureTrailingSlash(value: string): string {
+  return value.endsWith('/') ? value : `${value}/`;
+}
+
+function parsePublicCatalogApiBaseUrl(raw: string | undefined): string | null {
+  const normalized = raw?.trim() ?? '';
+  if (normalized.length === 0) {
+    return null;
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(normalized);
+  } catch {
+    throw new Error('VITE_PUBLIC_CATALOG_API_BASE_URL must be an absolute URL.');
+  }
+
+  return ensureTrailingSlash(parsed.toString());
+}
+
+export function resolvePublicCatalogRuntimeConfig(env: ImportMetaEnv): PublicCatalogRuntimeConfig {
+  const apiBaseUrl = parsePublicCatalogApiBaseUrl(env.VITE_PUBLIC_CATALOG_API_BASE_URL);
+  if (!apiBaseUrl) {
+    return {
+      apiBaseUrl: null,
+      source: 'disabled',
+    };
+  }
+
+  return {
+    apiBaseUrl,
+    source: 'env',
+  };
+}

--- a/packages/web-app/src/services/public-catalog-publish.test.ts
+++ b/packages/web-app/src/services/public-catalog-publish.test.ts
@@ -40,6 +40,41 @@ describe('public catalog publish helpers', () => {
     expect(appDb.markTournamentPublishRetryable).not.toHaveBeenCalled();
   });
 
+  it('treats duplicate register responses as published without retryable fallback', async () => {
+    const appDb = {
+      markTournamentPublishing: vi.fn(),
+      markTournamentPublished: vi.fn(),
+      markTournamentPublishRetryable: vi.fn(),
+    };
+    const publicCatalogClient = {
+      isAvailable: () => true,
+      registerTournament: vi.fn().mockResolvedValue({ status: 'duplicate', publicId: 'public-existing' }),
+    };
+
+    const result = await publishTournamentDefinition({
+      appDb,
+      publicCatalogClient,
+      tournamentUuid: '44444444-4444-4444-8444-444444444444',
+      payload: buildPublicTournamentPayload('44444444-4444-4444-8444-444444444444', {
+        tournamentName: '重複公開テスト',
+        owner: '',
+        hashtag: 'DUPLICATE',
+        startDate: '2026-04-20',
+        endDate: '2026-04-25',
+        chartIds: [30, 40],
+      }),
+      setPublishing: true,
+    });
+
+    expect(result).toEqual({
+      status: 'duplicate',
+      publicId: 'public-existing',
+    });
+    expect(appDb.markTournamentPublishing).toHaveBeenCalledWith('44444444-4444-4444-8444-444444444444');
+    expect(appDb.markTournamentPublished).toHaveBeenCalledWith('44444444-4444-4444-8444-444444444444', 'public-existing');
+    expect(appDb.markTournamentPublishRetryable).not.toHaveBeenCalled();
+  });
+
   it('keeps retryable state when publish registration fails', async () => {
     const error = new Error('network failed');
     const appDb = {

--- a/packages/web-app/src/services/public-catalog-publish.test.ts
+++ b/packages/web-app/src/services/public-catalog-publish.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  buildPublicTournamentPayload,
+  buildPublicTournamentPayloadFromDetail,
+  publishTournamentDefinition,
+} from './public-catalog-publish';
+
+describe('public catalog publish helpers', () => {
+  it('marks tournament as published after a successful register call', async () => {
+    const appDb = {
+      markTournamentPublishing: vi.fn(),
+      markTournamentPublished: vi.fn(),
+      markTournamentPublishRetryable: vi.fn(),
+    };
+    const publicCatalogClient = {
+      isAvailable: () => true,
+      registerTournament: vi.fn().mockResolvedValue({ status: 'created', publicId: 'public-123' }),
+    };
+
+    const result = await publishTournamentDefinition({
+      appDb,
+      publicCatalogClient,
+      tournamentUuid: '11111111-1111-4111-8111-111111111111',
+      payload: buildPublicTournamentPayload('11111111-1111-4111-8111-111111111111', {
+        tournamentName: '公開テスト',
+        owner: '',
+        hashtag: 'PUBLIC',
+        startDate: '2026-04-20',
+        endDate: '2026-04-25',
+        chartIds: [10, 20],
+      }),
+    });
+
+    expect(result).toEqual({
+      status: 'published',
+      publicId: 'public-123',
+    });
+    expect(appDb.markTournamentPublished).toHaveBeenCalledWith('11111111-1111-4111-8111-111111111111', 'public-123');
+    expect(appDb.markTournamentPublishRetryable).not.toHaveBeenCalled();
+  });
+
+  it('keeps retryable state when publish registration fails', async () => {
+    const error = new Error('network failed');
+    const appDb = {
+      markTournamentPublishing: vi.fn(),
+      markTournamentPublished: vi.fn(),
+      markTournamentPublishRetryable: vi.fn(),
+    };
+    const publicCatalogClient = {
+      isAvailable: () => true,
+      registerTournament: vi.fn().mockRejectedValue(error),
+    };
+
+    const result = await publishTournamentDefinition({
+      appDb,
+      publicCatalogClient,
+      tournamentUuid: '22222222-2222-4222-8222-222222222222',
+      payload: buildPublicTournamentPayloadFromDetail({
+        tournamentUuid: '22222222-2222-4222-8222-222222222222',
+        sourceTournamentUuid: null,
+        defHash: 'def',
+        tournamentName: '失敗テスト',
+        owner: '',
+        hashtag: 'RETRY',
+        startDate: '2026-04-20',
+        endDate: '2026-04-25',
+        isImported: false,
+        chartCount: 1,
+        submittedCount: 0,
+        sendWaitingCount: 0,
+        pendingCount: 1,
+        lastSubmittedAt: null,
+        charts: [
+          {
+            chartId: 999,
+            title: 'Song',
+            playStyle: 'SP',
+            difficulty: 'HYPER',
+            level: '10',
+            resolveIssue: null,
+            submitted: false,
+            updateSeq: 0,
+            needsSend: false,
+            fileDeleted: false,
+          },
+        ],
+      }),
+      setPublishing: true,
+    });
+
+    expect(result).toEqual({
+      status: 'retryable',
+      error,
+    });
+    expect(appDb.markTournamentPublishing).toHaveBeenCalledWith('22222222-2222-4222-8222-222222222222');
+    expect(appDb.markTournamentPublishRetryable).toHaveBeenCalledWith('22222222-2222-4222-8222-222222222222');
+    expect(appDb.markTournamentPublished).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web-app/src/services/public-catalog-publish.ts
+++ b/packages/web-app/src/services/public-catalog-publish.ts
@@ -1,0 +1,76 @@
+import type { AppDatabase, CreateTournamentInput, TournamentDetailItem } from '@iidx/db';
+import { PAYLOAD_VERSION, normalizeTournamentPayload, type TournamentPayload } from '@iidx/shared';
+
+import type { PublicCatalogClient } from './public-catalog-client';
+
+export interface PublishTournamentDefinitionResult {
+  status: 'disabled' | 'duplicate' | 'published' | 'retryable';
+  publicId?: string;
+  error?: unknown;
+}
+
+type PublishableTournamentFields = Pick<
+  CreateTournamentInput,
+  'chartIds' | 'endDate' | 'hashtag' | 'owner' | 'startDate' | 'tournamentName'
+>;
+
+export function buildPublicTournamentPayload(
+  tournamentUuid: string,
+  input: PublishableTournamentFields,
+): TournamentPayload {
+  return normalizeTournamentPayload({
+    v: PAYLOAD_VERSION,
+    uuid: tournamentUuid,
+    name: input.tournamentName,
+    owner: input.owner,
+    hashtag: input.hashtag,
+    start: input.startDate,
+    end: input.endDate,
+    charts: input.chartIds,
+  });
+}
+
+export function buildPublicTournamentPayloadFromDetail(detail: TournamentDetailItem): TournamentPayload {
+  return buildPublicTournamentPayload(detail.tournamentUuid, {
+    tournamentName: detail.tournamentName,
+    owner: detail.owner,
+    hashtag: detail.hashtag,
+    startDate: detail.startDate,
+    endDate: detail.endDate,
+    chartIds: detail.charts.map((chart) => chart.chartId),
+  });
+}
+
+export async function publishTournamentDefinition(
+  options: {
+    appDb: Pick<AppDatabase, 'markTournamentPublishing' | 'markTournamentPublished' | 'markTournamentPublishRetryable'>;
+    publicCatalogClient: PublicCatalogClient;
+    tournamentUuid: string;
+    payload: TournamentPayload;
+    setPublishing?: boolean;
+  },
+): Promise<PublishTournamentDefinitionResult> {
+  const { appDb, payload, publicCatalogClient, setPublishing, tournamentUuid } = options;
+  if (!publicCatalogClient.isAvailable()) {
+    return { status: 'disabled' };
+  }
+
+  if (setPublishing) {
+    await appDb.markTournamentPublishing(tournamentUuid);
+  }
+
+  try {
+    const response = await publicCatalogClient.registerTournament(payload);
+    await appDb.markTournamentPublished(tournamentUuid, response.publicId);
+    return {
+      status: response.status === 'duplicate' ? 'duplicate' : 'published',
+      publicId: response.publicId,
+    };
+  } catch (error) {
+    await appDb.markTournamentPublishRetryable(tournamentUuid);
+    return {
+      status: 'retryable',
+      error,
+    };
+  }
+}

--- a/packages/web-app/src/styles.css
+++ b/packages/web-app/src/styles.css
@@ -816,6 +816,30 @@ label {
   color: var(--status-unshared-text);
 }
 
+.tournamentStatusLabel-publication-unpublished {
+  background: var(--surface-muted);
+  border-color: var(--border);
+  color: var(--text-muted);
+}
+
+.tournamentStatusLabel-publication-publishing {
+  background: var(--status-upcoming-bg);
+  border-color: transparent;
+  color: var(--status-upcoming-text);
+}
+
+.tournamentStatusLabel-publication-published {
+  background: var(--status-shared-bg);
+  border-color: transparent;
+  color: var(--status-shared-text);
+}
+
+.tournamentStatusLabel-publication-retryable {
+  background: var(--status-warning-bg);
+  border-color: transparent;
+  color: var(--status-warning-text);
+}
+
 .tournamentSummaryProgress {
   margin-top: 2px;
 }

--- a/packages/web-app/src/vite-env.d.ts
+++ b/packages/web-app/src/vite-env.d.ts
@@ -2,6 +2,7 @@
 
 interface ImportMetaEnv {
   readonly VITE_SONG_MASTER_SCHEMA_VERSION?: string;
+  readonly VITE_PUBLIC_CATALOG_API_BASE_URL?: string;
 }
 
 declare const __APP_VERSION__: string;


### PR DESCRIPTION
## 目的
Issue #50 と関連タスクを正本として、ローカル大会の公開 API publish 状態をローカル DB に保持し、作成後 publish と再試行を UI から扱えるようにします。

## 変更点
- `packages/db` に公開状態 (`unpublished` / `publishing` / `published` / `retryable`)、`publicId`、最終試行時刻の永続化と read model を追加
- ローカル大会作成後に公開 API へバックグラウンド publish するフローを `packages/web-app` に追加
- Home / Detail で公開状態と最終試行時刻を表示し、retryable 状態から再試行できるように変更
- `duplicate` 応答を公開済み扱いにし、直接カバーする自動テストを追加
- i18n 文言、runtime config、client / publish helper を追加

## 非変更点
- Service Worker / COOP / COEP / startup / import routing / Web Locks の既存フローは変更していません
- 公開 catalog の read API / register API 契約自体は変更していません
- ブラウザ実機 E2E 基盤や単一タブ smoke は今回追加していません

## 影響範囲
- `packages/db`
- `packages/web-app`

## 根本原因
ローカル大会作成後の公開 API 連携結果をローカル側に保持していなかったため、成功・失敗・再試行・duplicate の状態を再読込後も一貫して扱えませんでした。

## テスト内容
- `pnpm --filter @iidx/db lint`
- `pnpm --filter @iidx/web-app lint`
- `pnpm --filter @iidx/db test`
- `pnpm --filter @iidx/web-app test`
- `pnpm --filter @iidx/web-app test -- src/services/public-catalog-publish.test.ts`

## 回帰確認項目
- 通常の大会作成を維持
- 既存 import の表示・導線を維持
- imported tournament では公開 UI を出さないことを確認
- `duplicate` 応答で重複行や retryable 化が起きないことを確認

## ロールバック方針
本 PR を revert すれば、公開状態の追加カラムと UI 変更をまとめて戻せます。ユーザーデータ互換性を壊す export/import 形式変更は含みません。

## 互換性影響
既存ローカル DB には migration で追加カラムを導入します。既存データは `unpublished` として扱われ、既存大会の読み込み互換性を維持します。

## 保存/PWA/起動導線への影響
高リスク領域の Service Worker / Web Locks / startup / import routing は非変更です。永続化は既存 `tournaments` テーブルへの追加列のみです。

## docs更新有無
実装タスクの正本は既存 Issue / tasks を利用し、追加の docs 更新はしていません.