### PR TITLE
[codex] Allow deleting owned public score attacks

### DIFF
--- a/packages/web-app/src/App.tsx
+++ b/packages/web-app/src/App.tsx
@@ -1259,6 +1259,19 @@ export function App({ webLockAcquired = false }: AppProps = {}): JSX.Element {
     () => runtimeLogs.find((entry) => entry.level === 'error') ?? null,
     [runtimeLogs],
   );
+  const publicCatalogDeleteTokensByPublicId = React.useMemo(() => {
+    const tokens = new Map<string, string>();
+    [
+      ...homeTournamentBuckets.active,
+      ...homeTournamentBuckets.upcoming,
+      ...homeTournamentBuckets.ended,
+    ].forEach((item) => {
+      if (item.publicId && item.publicDeleteToken) {
+        tokens.set(item.publicId, item.publicDeleteToken);
+      }
+    });
+    return tokens;
+  }, [homeTournamentBuckets]);
   const detailPayloadSizeBytes = React.useMemo(() => {
     if (!detail) {
       return 0;
@@ -3166,6 +3179,7 @@ export function App({ webLockAcquired = false }: AppProps = {}): JSX.Element {
           <PublicCatalogPage
             client={publicCatalogClient}
             songMasterReady={songMasterReady}
+            localDeleteTokensByPublicId={publicCatalogDeleteTokensByPublicId}
             onOpenImportConfirm={openImportConfirm}
           />
         )}

--- a/packages/web-app/src/i18n/locales/en.json
+++ b/packages/web-app/src/i18n/locales/en.json
@@ -436,7 +436,8 @@
       "retrying": "Retrying...",
       "explore": "Browse server catalog",
       "search": "Search",
-      "import": "Import"
+      "import": "Import",
+      "delete": "Delete"
     },
     "status": {
       "unpublished": "Unpublished",
@@ -456,7 +457,8 @@
     },
     "notice": {
       "published": "Published to the public catalog.",
-      "duplicate": "Matched an existing public catalog entry."
+      "duplicate": "Matched an existing public catalog entry.",
+      "deleted": "Deleted the public score attack."
     },
     "error": {
       "unavailable": "Public catalog API is not configured.",
@@ -464,7 +466,12 @@
       "publish_failed": "Publishing failed. Please try again later.",
       "list_failed": "Failed to load the public catalog.",
       "import_failed": "Failed to import the selected public score attack.",
+      "delete_failed": "Failed to delete the public score attack.",
       "not_found": "The selected public score attack could not be found."
+    },
+    "delete_dialog": {
+      "title": "Delete this public score attack?",
+      "description": "Delete \"{{name}}\" from the public catalog. The score attack stored on this device will not be deleted."
     }
   },
   "create_tournament": {

--- a/packages/web-app/src/i18n/locales/ja.json
+++ b/packages/web-app/src/i18n/locales/ja.json
@@ -436,7 +436,8 @@
       "retrying": "再試行中...",
       "explore": "サーバーから探す",
       "search": "検索",
-      "import": "Import"
+      "import": "Import",
+      "delete": "削除"
     },
     "status": {
       "unpublished": "未公開",
@@ -456,7 +457,8 @@
     },
     "notice": {
       "published": "公開登録しました。",
-      "duplicate": "既に公開済みとして反映しました。"
+      "duplicate": "既に公開済みとして反映しました。",
+      "deleted": "公開スコアタを削除しました。"
     },
     "error": {
       "unavailable": "公開スコアタ機能が未設定のため利用できません。",
@@ -464,7 +466,12 @@
       "publish_failed": "公開に失敗しました。しばらくしてから再試行してください。",
       "list_failed": "公開スコアタの取得に失敗しました。",
       "import_failed": "公開スコアタの取り込みに失敗しました。",
+      "delete_failed": "公開スコアタの削除に失敗しました。",
       "not_found": "対象の公開スコアタが見つかりませんでした。"
+    },
+    "delete_dialog": {
+      "title": "公開スコアタを削除しますか？",
+      "description": "「{{name}}」を公開カタログから削除します。この端末に保存されているスコアタは削除されません。"
     }
   },
   "create_tournament": {

--- a/packages/web-app/src/i18n/locales/ko.json
+++ b/packages/web-app/src/i18n/locales/ko.json
@@ -436,7 +436,8 @@
       "retrying": "재시도 중...",
       "explore": "서버에서 찾기",
       "search": "검색",
-      "import": "Import"
+      "import": "Import",
+      "delete": "삭제"
     },
     "status": {
       "unpublished": "미공개",
@@ -456,7 +457,8 @@
     },
     "notice": {
       "published": "공개 카탈로그에 등록했습니다.",
-      "duplicate": "이미 공개된 항목으로 반영했습니다."
+      "duplicate": "이미 공개된 항목으로 반영했습니다.",
+      "deleted": "공개 스코어 어택을 삭제했습니다."
     },
     "error": {
       "unavailable": "공개 카탈로그 API가 설정되지 않아 이용할 수 없습니다.",
@@ -464,7 +466,12 @@
       "publish_failed": "공개에 실패했습니다. 잠시 후 다시 시도해 주세요.",
       "list_failed": "공개 카탈로그를 불러오지 못했습니다.",
       "import_failed": "선택한 공개 스코어 어택을 가져오지 못했습니다.",
+      "delete_failed": "공개 스코어 어택을 삭제하지 못했습니다.",
       "not_found": "선택한 공개 스코어 어택을 찾을 수 없습니다."
+    },
+    "delete_dialog": {
+      "title": "공개 스코어 어택을 삭제할까요?",
+      "description": "\"{{name}}\"을 공개 카탈로그에서 삭제합니다. 이 기기에 저장된 스코어 어택은 삭제되지 않습니다."
     }
   },
   "create_tournament": {

--- a/packages/web-app/src/pages/PublicCatalogPage.test.tsx
+++ b/packages/web-app/src/pages/PublicCatalogPage.test.tsx
@@ -344,4 +344,139 @@ describe('PublicCatalogPage', () => {
       nextCursor: null,
     });
   });
+
+  it('shows delete action only for locally owned public score attacks', async () => {
+    const { client, listPublicTournaments } = createClientMock();
+
+    listPublicTournaments.mockResolvedValue({
+      items: [createListItem(1), createListItem(2)],
+      nextCursor: null,
+    });
+
+    render(
+      <PublicCatalogPage
+        client={client}
+        songMasterReady
+        localDeleteTokensByPublicId={new Map([['public-1', 'delete-token-1']])}
+        onOpenImportConfirm={() => undefined}
+      />,
+    );
+
+    expect(await screen.findByText('Cup 1')).toBeTruthy();
+    expect(await screen.findByText('Cup 2')).toBeTruthy();
+    expect(screen.getAllByRole('button', { name: '削除' })).toHaveLength(1);
+  });
+
+  it('deletes a locally owned public score attack and removes it from the list', async () => {
+    const user = userEvent.setup();
+    const { client, listPublicTournaments, deletePublicTournament } =
+      createClientMock();
+
+    listPublicTournaments.mockResolvedValue({
+      items: [createListItem(1)],
+      nextCursor: null,
+    });
+    deletePublicTournament.mockResolvedValue(undefined);
+
+    render(
+      <PublicCatalogPage
+        client={client}
+        songMasterReady
+        localDeleteTokensByPublicId={new Map([['public-1', 'delete-token-1']])}
+        onOpenImportConfirm={() => undefined}
+      />,
+    );
+
+    expect(await screen.findByText('Cup 1')).toBeTruthy();
+
+    await user.click(screen.getByRole('button', { name: '削除' }));
+    expect(
+      screen.getByText('公開スコアタを削除しますか？'),
+    ).toBeTruthy();
+
+    const deleteButtons = screen.getAllByRole('button', { name: '削除' });
+    await user.click(deleteButtons[deleteButtons.length - 1]!);
+
+    await waitFor(() => {
+      expect(deletePublicTournament).toHaveBeenCalledWith(
+        'public-1',
+        'delete-token-1',
+      );
+    });
+    expect(await screen.findByText('公開スコアタを削除しました。')).toBeTruthy();
+    expect(screen.queryByText('Cup 1')).toBeNull();
+  });
+
+  it('keeps the item and shows an error when delete fails', async () => {
+    const user = userEvent.setup();
+    const { client, listPublicTournaments, deletePublicTournament } =
+      createClientMock();
+
+    listPublicTournaments.mockResolvedValue({
+      items: [createListItem(1)],
+      nextCursor: null,
+    });
+    deletePublicTournament.mockRejectedValue(new Error('delete failed'));
+
+    render(
+      <PublicCatalogPage
+        client={client}
+        songMasterReady
+        localDeleteTokensByPublicId={new Map([['public-1', 'delete-token-1']])}
+        onOpenImportConfirm={() => undefined}
+      />,
+    );
+
+    expect(await screen.findByText('Cup 1')).toBeTruthy();
+
+    await user.click(screen.getByRole('button', { name: '削除' }));
+    const deleteButtons = screen.getAllByRole('button', { name: '削除' });
+    await user.click(deleteButtons[deleteButtons.length - 1]!);
+
+    expect(
+      await screen.findByText('公開スコアタの削除に失敗しました。'),
+    ).toBeTruthy();
+    expect(screen.getByText('Cup 1')).toBeTruthy();
+  });
+
+  it('disables import while delete is pending', async () => {
+    const user = userEvent.setup();
+    const deleteRequest = createDeferred<void>();
+    const { client, listPublicTournaments, deletePublicTournament } =
+      createClientMock();
+
+    listPublicTournaments.mockResolvedValue({
+      items: [createListItem(1)],
+      nextCursor: null,
+    });
+    deletePublicTournament.mockReturnValue(deleteRequest.promise);
+
+    render(
+      <PublicCatalogPage
+        client={client}
+        songMasterReady
+        localDeleteTokensByPublicId={new Map([['public-1', 'delete-token-1']])}
+        onOpenImportConfirm={() => undefined}
+      />,
+    );
+
+    expect(await screen.findByText('Cup 1')).toBeTruthy();
+
+    await user.click(screen.getByRole('button', { name: '削除' }));
+    const deleteButtons = screen.getAllByRole('button', { name: '削除' });
+    await user.click(deleteButtons[deleteButtons.length - 1]!);
+
+    expect(
+      screen
+        .getByTestId('public-catalog-delete-button-public-1')
+        .hasAttribute('disabled'),
+    ).toBe(true);
+    expect(
+      screen
+        .getByTestId('public-catalog-import-button-public-1')
+        .hasAttribute('disabled'),
+    ).toBe(true);
+
+    deleteRequest.resolve();
+  });
 });

--- a/packages/web-app/src/pages/PublicCatalogPage.tsx
+++ b/packages/web-app/src/pages/PublicCatalogPage.tsx
@@ -4,6 +4,10 @@ import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
 import CircularProgress from '@mui/material/CircularProgress';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
 import InputAdornment from '@mui/material/InputAdornment';
 import Paper from '@mui/material/Paper';
 import Skeleton from '@mui/material/Skeleton';
@@ -12,6 +16,7 @@ import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import CalendarTodayIcon from '@mui/icons-material/CalendarToday';
 import CloudDownloadIcon from '@mui/icons-material/CloudDownload';
+import DeleteIcon from '@mui/icons-material/Delete';
 import LibraryMusicIcon from '@mui/icons-material/LibraryMusic';
 import SearchIcon from '@mui/icons-material/Search';
 import SearchOffIcon from '@mui/icons-material/SearchOff';
@@ -25,11 +30,13 @@ import { PublicCatalogClientError } from '../services/public-catalog-client';
 interface PublicCatalogPageProps {
   client: PublicCatalogClient;
   songMasterReady: boolean;
+  localDeleteTokensByPublicId?: ReadonlyMap<string, string>;
   onOpenImportConfirm: (rawPayloadParam: string) => void;
 }
 
 interface BannerMessage {
   text: string;
+  severity: 'success' | 'warning' | 'error';
 }
 
 type LoadPhase = 'idle' | 'loading' | 'ready' | 'error';
@@ -189,6 +196,11 @@ export function PublicCatalogPage(props: PublicCatalogPageProps): JSX.Element {
   const [importingPublicId, setImportingPublicId] = React.useState<string | null>(
     null,
   );
+  const [deletingPublicId, setDeletingPublicId] = React.useState<string | null>(
+    null,
+  );
+  const [deleteDialogItem, setDeleteDialogItem] =
+    React.useState<PublicTournamentListItem | null>(null);
   const mountedRef = React.useRef(true);
   const requestTokenRef = React.useRef(0);
 
@@ -279,6 +291,7 @@ export function PublicCatalogPage(props: PublicCatalogPageProps): JSX.Element {
           error,
           'public_catalog.error.list_failed',
         ),
+        severity: 'warning',
       });
     } finally {
       if (mountedRef.current && requestToken === requestTokenRef.current) {
@@ -308,12 +321,14 @@ export function PublicCatalogPage(props: PublicCatalogPageProps): JSX.Element {
       if (!props.client.isAvailable()) {
         setBannerMessage({
           text: t('public_catalog.error.unavailable'),
+          severity: 'warning',
         });
         return;
       }
       if (!props.songMasterReady) {
         setBannerMessage({
           text: t('public_catalog.song_master_required'),
+          severity: 'warning',
         });
         return;
       }
@@ -337,6 +352,7 @@ export function PublicCatalogPage(props: PublicCatalogPageProps): JSX.Element {
             error,
             'public_catalog.error.import_failed',
           ),
+          severity: 'warning',
         });
       } finally {
         if (mountedRef.current) {
@@ -354,6 +370,69 @@ export function PublicCatalogPage(props: PublicCatalogPageProps): JSX.Element {
       t,
     ],
   );
+
+  const handleDeleteConfirm = React.useCallback(async () => {
+    if (!deleteDialogItem || deletingPublicId) {
+      return;
+    }
+
+    const deleteToken = props.localDeleteTokensByPublicId?.get(
+      deleteDialogItem.publicId,
+    );
+    if (!deleteToken) {
+      setBannerMessage({
+        text: t('public_catalog.error.delete_failed'),
+        severity: 'error',
+      });
+      setDeleteDialogItem(null);
+      return;
+    }
+
+    setBannerMessage(null);
+    setDeletingPublicId(deleteDialogItem.publicId);
+
+    try {
+      await props.client.deletePublicTournament(
+        deleteDialogItem.publicId,
+        deleteToken,
+      );
+      if (!mountedRef.current) {
+        return;
+      }
+      setItems((previous) =>
+        previous.filter((item) => item.publicId !== deleteDialogItem.publicId),
+      );
+      setBannerMessage({
+        text: t('public_catalog.notice.deleted'),
+        severity: 'success',
+      });
+      setDeleteDialogItem(null);
+    } catch (error) {
+      if (!mountedRef.current) {
+        return;
+      }
+      setBannerMessage({
+        text: resolveActionErrorMessage(
+          t,
+          error,
+          'public_catalog.error.delete_failed',
+        ),
+        severity: 'error',
+      });
+    } finally {
+      if (mountedRef.current) {
+        setDeletingPublicId((current) =>
+          current === deleteDialogItem.publicId ? null : current,
+        );
+      }
+    }
+  }, [
+    deleteDialogItem,
+    deletingPublicId,
+    props.client,
+    props.localDeleteTokensByPublicId,
+    t,
+  ]);
 
   const hasSearchQuery = searchText.length > 0 || currentQuery.length > 0;
   const initialLoading = clientAvailable && loadPhase === 'loading' && items.length === 0;
@@ -463,7 +542,7 @@ export function PublicCatalogPage(props: PublicCatalogPageProps): JSX.Element {
       ) : null}
 
       {bannerMessage ? (
-        <Alert severity="warning">{bannerMessage.text}</Alert>
+        <Alert severity={bannerMessage.severity}>{bannerMessage.text}</Alert>
       ) : null}
 
       {initialLoading ? (
@@ -531,6 +610,10 @@ export function PublicCatalogPage(props: PublicCatalogPageProps): JSX.Element {
           <Stack spacing={2}>
             {items.map((item) => {
               const isImporting = importingPublicId === item.publicId;
+              const isDeleting = deletingPublicId === item.publicId;
+              const deleteToken = props.localDeleteTokensByPublicId?.get(
+                item.publicId,
+              );
               const chartCountText =
                 typeof item.spChartCount === 'number' &&
                 typeof item.dpChartCount === 'number'
@@ -600,14 +683,43 @@ export function PublicCatalogPage(props: PublicCatalogPageProps): JSX.Element {
                       sx={{
                         display: 'flex',
                         justifyContent: 'flex-end',
+                        gap: 1,
+                        flexWrap: 'wrap',
                       }}
                     >
+                      {deleteToken ? (
+                        <Button
+                          type="button"
+                          variant="outlined"
+                          color="error"
+                          data-testid={`public-catalog-delete-button-${item.publicId}`}
+                          disabled={
+                            importingPublicId !== null ||
+                            deletingPublicId !== null
+                          }
+                          startIcon={
+                            isDeleting ? (
+                              <CircularProgress color="inherit" size={18} />
+                            ) : (
+                              <DeleteIcon />
+                            )
+                          }
+                          onClick={() => setDeleteDialogItem(item)}
+                        >
+                          {isDeleting
+                            ? t('common.loading')
+                            : t('public_catalog.action.delete')}
+                        </Button>
+                      ) : null}
                       <Button
                         type="button"
                         variant="contained"
                         disableElevation
+                        data-testid={`public-catalog-import-button-${item.publicId}`}
                         disabled={
-                          importingPublicId !== null || !props.songMasterReady
+                          importingPublicId !== null ||
+                          deletingPublicId !== null ||
+                          !props.songMasterReady
                         }
                         startIcon={
                           isImporting ? (
@@ -650,6 +762,47 @@ export function PublicCatalogPage(props: PublicCatalogPageProps): JSX.Element {
           ) : null}
         </>
       ) : null}
+
+      <Dialog
+        open={deleteDialogItem !== null}
+        onClose={() => {
+          if (!deletingPublicId) {
+            setDeleteDialogItem(null);
+          }
+        }}
+        fullWidth
+        maxWidth="xs"
+      >
+        <DialogTitle>{t('public_catalog.delete_dialog.title')}</DialogTitle>
+        <DialogContent>
+          <Typography variant="body2">
+            {t('public_catalog.delete_dialog.description', {
+              name: deleteDialogItem?.name ?? '',
+            })}
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button
+            onClick={() => setDeleteDialogItem(null)}
+            disabled={deletingPublicId !== null}
+          >
+            {t('common.cancel')}
+          </Button>
+          <Button
+            color="error"
+            variant="contained"
+            onClick={() => void handleDeleteConfirm()}
+            disabled={deletingPublicId !== null}
+            startIcon={
+              deletingPublicId ? (
+                <CircularProgress color="inherit" size={18} />
+              ) : undefined
+            }
+          >
+            {t('public_catalog.action.delete')}
+          </Button>
+        </DialogActions>
+      </Dialog>
     </Box>
   );
 }


### PR DESCRIPTION
## Summary
- Add a public catalog delete action only for entries with a locally stored `publicId` + `publicDeleteToken`.
- Confirm before deleting, call the existing `deletePublicTournament(publicId, deleteToken)` client method, and remove the item from the visible list on success.
- Add Japanese, English, and Korean copy plus regression coverage for visibility, success, failure, and busy-state behavior.

Refs #66

## Non-goals
- No account/auth ownership model changes.
- No public catalog API contract changes.
- No DB schema, migration, payload, PWA, Service Worker, or Web Locks changes.

## Validation
- `pnpm --filter @iidx/web-app exec vitest run src/pages/PublicCatalogPage.test.tsx src/App.test.ts`
- `pnpm --filter @iidx/web-app lint`
- `pnpm --filter @iidx/web-app build`
- Chrome browser check: verified owned-only delete action, confirmation dialog, busy disabled state, successful removal, success notice, and non-owned item retention.